### PR TITLE
Remove WebGL background and make panels stick to screen edges

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,17 +1,7 @@
 @import "tailwindcss";
 
 #root {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: var(--spacing-8);
-  text-align: center;
-}
-
-@media (max-width: 1200px) {
-  #root {
-    max-width: 800px;
-    padding: var(--spacing-4);
-  }
+  width: 100%;
 }
 
 /*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,30 +33,15 @@ import { SchedulerSettingsModal } from "./components/SchedulerSettings";
 import { CommandPalette } from "./components/CommandPalette";
 import { FileInfo } from "./components/FileInfo";
 import { useCommands } from "./useCommands";
-import { BackgroundWebGL } from "./components/BackgroundWebGL";
-import { backgroundFxEnabledSig } from "./stores";
-import { triggerPositiveBurst } from "./utils/fxBus";
 import { isTruthy } from "./utils/assert";
 
 function App() {
   // eslint-disable-next-line no-unused-expressions
   css`
     main {
-      position: relative;
-      z-index: 1;
       display: grid;
       grid-template-columns: 300px 1fr 400px;
-      gap: var(--spacing-4);
-      align-items: start;
-      max-width: 1400px;
-      margin: 0 auto;
-    }
-
-    @media (max-width: 1200px) {
-      main {
-        grid-template-columns: 1fr;
-        max-width: 800px;
-      }
+      min-height: 100vh;
     }
 
     :global(hr) {
@@ -66,6 +51,14 @@ function App() {
     .layout-left-column {
       grid-column: 1;
       grid-row: 1;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      overflow-y: auto;
+      background: var(--color-surface);
+      border-right: 1px solid var(--color-border);
+      padding: var(--spacing-4);
+      text-align: left;
     }
 
     .layout-center-column {
@@ -75,28 +68,49 @@ function App() {
       flex-direction: column;
       align-items: center;
       gap: var(--spacing-4);
+      padding: var(--spacing-8) var(--spacing-4);
     }
 
     .layout-right-column {
       grid-column: 3;
       grid-row: 1;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      overflow-y: auto;
+      background: var(--color-surface);
+      border-left: 1px solid var(--color-border);
+      padding: var(--spacing-4);
+      text-align: left;
     }
 
     @media (max-width: 1200px) {
+      main {
+        grid-template-columns: 1fr;
+        min-height: auto;
+      }
+
       .layout-left-column,
       .layout-center-column,
       .layout-right-column {
         grid-column: 1;
+        position: static;
+        height: auto;
+        overflow: visible;
+        border: none;
       }
 
       .layout-left-column {
         grid-row: 1;
+        border-bottom: 1px solid var(--color-border);
       }
       .layout-center-column {
         grid-row: 2;
+        background: transparent;
       }
       .layout-right-column {
         grid-row: 3;
+        border-top: 1px solid var(--color-border);
       }
     }
 
@@ -250,7 +264,6 @@ function App() {
 
   return (
     <>
-      {backgroundFxEnabledSig() && <BackgroundWebGL />}
       <main>
         {/* LEFT COLUMN: File Info */}
         <div class="layout-left-column">{deckInfoSig() && <FileInfo />}</div>
@@ -284,9 +297,6 @@ function App() {
                     setReviewStartTime(Date.now());
                   }}
                   onChooseAnswer={async (answer: Answer) => {
-                    if (answer === "good" || answer === "easy") {
-                      triggerPositiveBurst(answer);
-                    }
                     if (schedulerEnabledSig()) {
                       // Scheduler mode: process review
                       const reviewCard = currentReviewCardSig();
@@ -314,9 +324,6 @@ function App() {
                     setReviewStartTime(Date.now());
                   }}
                   onChooseAnswer={async (answer: Answer) => {
-                    if (answer === "good" || answer === "easy") {
-                      triggerPositiveBurst(answer);
-                    }
                     if (schedulerEnabledSig()) {
                       // Scheduler mode: process review
                       const reviewCard = currentReviewCardSig();

--- a/src/design-system/components/layout/SidePanel.tsx
+++ b/src/design-system/components/layout/SidePanel.tsx
@@ -12,15 +12,9 @@ export interface SidePanelProps extends JSX.HTMLAttributes<HTMLDivElement> {
 export function SidePanel(props: SidePanelProps) {
   const [local, others] = splitProps(props, ["title", "headerAction", "maxWidth", "children", "class"]);
 
-  const maxWidth = () => local.maxWidth ?? "300px";
-
   // eslint-disable-next-line no-unused-expressions
   css`
     .ds-side-panel {
-      border: 1px solid var(--color-border);
-      background: var(--color-surface);
-      border-radius: var(--radius-sm);
-      padding: var(--spacing-4);
       display: flex;
       flex-direction: column;
       gap: var(--spacing-4);
@@ -49,7 +43,7 @@ export function SidePanel(props: SidePanelProps) {
   const classes = () => ["ds-side-panel", local.class].filter(Boolean).join(" ");
 
   return (
-    <div class={classes()} style={{ "max-width": maxWidth() }} {...others}>
+    <div class={classes()} {...others}>
       <div class="ds-side-panel-header">
         <div class="ds-side-panel-title">{local.title}</div>
         {local.headerAction}

--- a/src/index.css
+++ b/src/index.css
@@ -12,8 +12,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
- Remove the WebGL particle grid background and its wave burst effects
- Make side panels sticky and full-height, hugging the left/right edges of the viewport
- Strip floating box styling (border, border-radius, background) from SidePanel component
- Make root layout full-width with responsive single-column fallback