### PR TITLE
Enforce design system: refined palette, missing tokens, hardcoded value fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,7 +24,7 @@
   filter: drop-shadow(0 0 2em var(--color-primary-500));
 }
 .logo.solid:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+  filter: drop-shadow(0 0 2em var(--color-primary-400));
 }
 
 .card {

--- a/src/App.vue
+++ b/src/App.vue
@@ -230,7 +230,7 @@ main {
   min-height: 100vh;
 }
 
-:global(hr) { margin: 1rem 0; }
+:global(hr) { margin: var(--spacing-4) 0; }
 
 .layout-left-column {
   grid-column: 1;
@@ -289,7 +289,7 @@ main {
   .layout-right-column { grid-row: 3; border-top: 1px solid var(--color-border); }
 }
 
-.dropdowns { display: flex; gap: 1rem; justify-content: center; }
+.dropdowns { display: flex; gap: var(--spacing-4); justify-content: center; }
 
 .keyboard-hint {
   text-align: right;
@@ -298,5 +298,5 @@ main {
   grid-column: 1 / -1;
   margin-top: var(--spacing-4);
 }
-.keyboard-hint button { padding: 0.5rem; border-radius: 0.25rem; }
+.keyboard-hint button { padding: var(--spacing-2); border-radius: var(--radius-sm); }
 </style>

--- a/src/components/CommandPalette.vue
+++ b/src/components/CommandPalette.vue
@@ -280,7 +280,7 @@ onUnmounted(() => window.removeEventListener("keydown", onGlobalKeydown));
   right: 0;
   bottom: 0;
   background: var(--color-overlay);
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(12px);
   z-index: calc(var(--z-index-modal) + 100);
   display: flex;
   align-items: flex-start;
@@ -361,7 +361,7 @@ onUnmounted(() => window.removeEventListener("keydown", onGlobalKeydown));
   color: var(--color-primary-600);
   font-weight: var(--font-weight-semibold);
   background: var(--color-primary-50);
-  padding: 0 2px;
+  padding: 0 var(--spacing-0-5);
   border-radius: var(--radius-xs);
 }
 
@@ -475,7 +475,7 @@ onUnmounted(() => window.removeEventListener("keydown", onGlobalKeydown));
   color: var(--color-primary-700);
   font-weight: var(--font-weight-semibold);
   border-radius: var(--radius-xs);
-  padding: 0 2px;
+  padding: 0 var(--spacing-0-5);
 }
 :root[data-theme="dark"] .command-item-title-highlight { background: var(--color-primary-900); color: var(--color-primary-300); }
 

--- a/src/components/FileInfo.vue
+++ b/src/components/FileInfo.vue
@@ -84,7 +84,7 @@ function handleBrowseAllTemplates() { openCommandPalette("browse-templates"); }
 <style scoped>
 .deck-name { font-size: var(--font-size-xl); font-weight: var(--font-weight-semibold); color: var(--color-text-primary); word-break: break-word; margin-bottom: var(--spacing-2); }
 .current-deck-section { margin-bottom: var(--spacing-4); }
-.current-deck-label { font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); color: var(--color-text-secondary); margin-bottom: var(--spacing-2); text-transform: uppercase; letter-spacing: 0.5px; }
+.current-deck-label { font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); color: var(--color-text-secondary); margin-bottom: var(--spacing-2); text-transform: uppercase; letter-spacing: var(--letter-spacing-wide); }
 .current-deck-display { padding: var(--spacing-3); background: var(--color-surface-elevated); border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: var(--spacing-2); }
 .current-deck-name { font-size: var(--font-size-base); font-weight: var(--font-weight-medium); color: var(--color-text-primary); margin-bottom: var(--spacing-1); word-break: break-word; }
 .current-deck-stats { font-size: var(--font-size-sm); color: var(--color-text-secondary); }
@@ -92,7 +92,7 @@ function handleBrowseAllTemplates() { openCommandPalette("browse-templates"); }
 .change-deck-button:hover { background: var(--color-surface-elevated); border-color: var(--color-border-hover); }
 .change-deck-button:active { transform: scale(0.98); }
 .change-deck-button:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; }
-.stats-section { margin-top: var(--spacing-4); padding-top: var(--spacing-4); border-top: 1px solid var(--color-border-primary); }
+.stats-section { margin-top: var(--spacing-4); padding-top: var(--spacing-4); border-top: 1px solid var(--color-border); }
 .stats-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--color-text-secondary); margin-bottom: var(--spacing-3); }
 .browse-item { margin-bottom: var(--spacing-2); }
 .browse-button { margin-bottom: var(--spacing-4); }

--- a/src/components/FilePicker.vue
+++ b/src/components/FilePicker.vue
@@ -35,5 +35,5 @@ function handleFileChange(event: Event) {
 
 <style scoped>
 .file-input { display: none; }
-.icon { width: 1.25rem; height: 1.25rem; }
+.icon { width: var(--spacing-5); height: var(--spacing-5); }
 </style>

--- a/src/components/FlashCard.vue
+++ b/src/components/FlashCard.vue
@@ -46,10 +46,10 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeyDown));
 
 <style scoped>
 .card {
-  border: 2px solid var(--color-border);
+  border: 1px solid var(--color-border);
   background: var(--color-surface);
-  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-base);
+  border-radius: var(--radius-xl);
   padding: 0;
   width: 500px;
   max-width: 100%;
@@ -57,25 +57,27 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeyDown));
   position: relative;
   overflow: hidden;
 }
-.card--front { border-top-color: var(--color-border); }
-.card--back { border-top-color: var(--color-border); }
 @media (max-width: 1200px) { .card { width: 800px; } }
 @media (max-width: 768px) { .card { width: 100%; min-height: 400px; } }
 .card-indicator {
   display: inline-block;
   padding: var(--spacing-1) var(--spacing-3);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
   border-radius: 0 0 var(--radius-md) 0;
   position: absolute;
   top: 0;
   left: 0;
-  opacity: 0.3;
+  opacity: 0.6;
 }
-.card-indicator--front { background: var(--color-primary); color: white; }
-.card-indicator--back { background: var(--color-success); color: white; }
+.card-indicator--front { background: var(--color-primary-100); color: var(--color-primary-700); }
+.card-indicator--back { background: var(--color-success-100); color: var(--color-success-700); }
+:root[data-theme="dark"] .card-indicator--front { background: var(--color-primary-950); color: var(--color-primary-300); }
+:root[data-theme="dark"] .card-indicator--back { background: var(--color-success-950); color: var(--color-success-300); }
 .card-content { padding: var(--spacing-8) var(--spacing-4) var(--spacing-4); }
 .card-content :deep(img) { height: 200px; margin: 0 auto; }
-.card-content :deep(hr) { margin: var(--spacing-4) 0; opacity: 0.25; }
+.card-content :deep(hr) { margin: var(--spacing-4) 0; border-color: var(--color-border); opacity: 0.5; }
 h1 { margin: 0; font-weight: var(--font-weight-normal); font-size: var(--font-size-2xl); }
 </style>

--- a/src/components/SRSVisualization.vue
+++ b/src/components/SRSVisualization.vue
@@ -164,7 +164,7 @@ function handleOpenSettings() { schedulerSettingsModalOpenSig.value = true; }
 
           <div class="info-item">
             <div class="info-label">Card ID</div>
-            <div class="info-value" style="font-size: 0.7rem; opacity: 0.5">
+            <div class="info-value info-value--muted">
               {{ currentCard?.cardId.split(":").slice(-2).join(":") }}
             </div>
           </div>
@@ -191,11 +191,11 @@ function handleOpenSettings() { schedulerSettingsModalOpenSig.value = true; }
 <style scoped>
 .srs-container { max-width: 100%; width: 100%; }
 @media (max-width: 1200px) { .srs-container { max-width: 800px; } }
-.status-badge { padding: var(--spacing-1) var(--spacing-3); border-radius: var(--radius-lg); font-size: var(--font-size-sm); font-weight: var(--font-weight-medium); cursor: pointer; border: none; transition: var(--transition-colors); }
-.status-badge:hover { opacity: 0.9; transform: translateY(-1px); }
+.status-badge { padding: var(--spacing-1) var(--spacing-3); border-radius: var(--radius-full); font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); cursor: pointer; border: none; transition: var(--transition-all); letter-spacing: var(--letter-spacing-wide); }
+.status-badge:hover { filter: brightness(1.1); transform: translateY(-1px); }
 .status-badge:active { transform: translateY(0); }
-.status-enabled { background: var(--color-success-500); color: white; }
-.status-disabled { background: var(--color-neutral-500); color: white; }
+.status-enabled { background: var(--color-success-500); color: var(--color-text-inverse); }
+.status-disabled { background: var(--color-neutral-400); color: var(--color-text-inverse); }
 .srs-section { display: flex; flex-direction: column; gap: var(--spacing-2); }
 .section-title { font-weight: var(--font-weight-semibold); font-size: var(--font-size-sm); color: var(--color-text-secondary); text-transform: uppercase; letter-spacing: var(--letter-spacing-wide); }
 .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: var(--spacing-3); }
@@ -213,6 +213,7 @@ function handleOpenSettings() { schedulerSettingsModalOpenSig.value = true; }
 .info-item { display: flex; justify-content: space-between; padding: var(--spacing-2); background: var(--color-surface-elevated); border: 1px solid var(--color-border); border-radius: var(--radius-sm); }
 .info-label { color: var(--color-text-secondary); font-size: var(--font-size-sm); }
 .info-value { font-weight: var(--font-weight-semibold); font-size: var(--font-size-sm); color: var(--color-text-primary); }
+.info-value--muted { font-size: var(--font-size-2xs); opacity: 0.5; }
 .no-cards-message { text-align: center; padding: var(--spacing-8); color: var(--color-text-tertiary); font-style: italic; }
 .scheduler-controls { display: flex; flex-direction: column; gap: var(--spacing-2); padding-top: var(--spacing-4); margin-top: var(--spacing-4); border-top: 1px solid var(--color-border); }
 .button-group { display: flex; gap: var(--spacing-2); flex-wrap: wrap; }

--- a/src/components/SchedulerSettings.vue
+++ b/src/components/SchedulerSettings.vue
@@ -137,6 +137,6 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
 .form-group { margin-bottom: var(--spacing-4); }
 .form-label { display: block; margin-bottom: var(--spacing-2); font-weight: var(--font-weight-medium); font-size: var(--font-size-sm); color: var(--color-text-primary); }
 .form-input, .form-select { width: 100%; padding: var(--spacing-2); border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: var(--color-surface-elevated); font-size: var(--font-size-sm); color: var(--color-text-primary); transition: var(--transition-colors); }
-.form-input:focus, .form-select:focus { outline: none; border-color: var(--color-border-focus); box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1); }
+.form-input:focus, .form-select:focus { outline: none; border-color: var(--color-border-focus); box-shadow: var(--shadow-focus-ring); }
 .help-text { font-size: var(--font-size-xs); color: var(--color-text-secondary); margin-top: var(--spacing-1); }
 </style>

--- a/src/design-system/components/primitives/Button.vue
+++ b/src/design-system/components/primitives/Button.vue
@@ -46,7 +46,7 @@ const classes = computed(() =>
   justify-content: center;
   gap: var(--spacing-2);
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   font-family: var(--font-family-sans);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
@@ -55,7 +55,7 @@ const classes = computed(() =>
   user-select: none;
 }
 
-.ds-button:focus-visible { outline: 2px solid var(--color-border-focus); outline-offset: 2px; }
+.ds-button:focus-visible { outline: 2px solid var(--color-border-focus); outline-offset: 2px; box-shadow: var(--shadow-focus-ring); }
 .ds-button:disabled { cursor: not-allowed; opacity: 0.5; }
 
 .ds-button--primary { background: var(--color-primary-500); color: var(--color-text-inverse); border-color: var(--color-primary-500); }

--- a/src/design-system/components/primitives/Input.vue
+++ b/src/design-system/components/primitives/Input.vue
@@ -75,10 +75,10 @@ function onInput(e: Event) {
 
 .ds-input::placeholder { color: var(--color-text-tertiary); }
 .ds-input:hover:not(:disabled) { border-color: var(--color-border-hover); }
-.ds-input:focus { outline: none; border-color: var(--color-border-focus); box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1); }
+.ds-input:focus { outline: none; border-color: var(--color-border-focus); box-shadow: var(--shadow-focus-ring); }
 .ds-input:disabled { opacity: 0.5; cursor: not-allowed; }
 .ds-input--error { border-color: var(--color-error-500); }
-.ds-input--error:focus { border-color: var(--color-error-500); box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1); }
+.ds-input--error:focus { border-color: var(--color-error-500); box-shadow: var(--shadow-focus-ring-error); }
 .ds-input-helper-text { font-size: var(--font-size-xs); color: var(--color-text-secondary); }
 .ds-input-error-message { font-size: var(--font-size-xs); color: var(--color-error-500); }
 </style>

--- a/src/design-system/components/primitives/Modal.vue
+++ b/src/design-system/components/primitives/Modal.vue
@@ -87,7 +87,7 @@ function handleContentClick(e: MouseEvent) {
   width: 100%;
   height: 100%;
   background-color: var(--color-overlay);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(12px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -100,7 +100,7 @@ function handleContentClick(e: MouseEvent) {
   max-height: 90vh;
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;

--- a/src/design-system/components/primitives/Select.vue
+++ b/src/design-system/components/primitives/Select.vue
@@ -77,10 +77,10 @@ function onChange(e: Event) {
 }
 
 .ds-select:hover:not(:disabled) { border-color: var(--color-border-hover); }
-.ds-select:focus { outline: none; border-color: var(--color-border-focus); box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1); }
+.ds-select:focus { outline: none; border-color: var(--color-border-focus); box-shadow: var(--shadow-focus-ring); }
 .ds-select:disabled { opacity: 0.5; cursor: not-allowed; }
 .ds-select--error { border-color: var(--color-error-500); }
-.ds-select--error:focus { border-color: var(--color-error-500); box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1); }
+.ds-select--error:focus { border-color: var(--color-error-500); box-shadow: var(--shadow-focus-ring-error); }
 .ds-select-helper-text { font-size: var(--font-size-xs); color: var(--color-text-secondary); }
 .ds-select-error-message { font-size: var(--font-size-xs); color: var(--color-error-500); }
 </style>

--- a/src/design-system/tokens/colors.css
+++ b/src/design-system/tokens/colors.css
@@ -1,59 +1,59 @@
-/* Color Tokens - Comprehensive palette for light and dark themes */
+/* Color Tokens - Refined palette with zinc neutrals, indigo primary */
 
 :root[data-theme="light"] {
-  /* Neutral Scale (50-950) */
+  /* Neutral Scale - Zinc (subtle cool undertone, modern feel) */
   --color-neutral-50: #fafafa;
-  --color-neutral-100: #f5f5f5;
-  --color-neutral-200: #e5e5e5;
-  --color-neutral-300: #d4d4d4;
-  --color-neutral-400: #a3a3a3;
-  --color-neutral-500: #737373;
-  --color-neutral-600: #525252;
-  --color-neutral-700: #404040;
-  --color-neutral-800: #262626;
-  --color-neutral-900: #171717;
-  --color-neutral-950: #0a0a0a;
+  --color-neutral-100: #f4f4f5;
+  --color-neutral-200: #e4e4e7;
+  --color-neutral-300: #d4d4d8;
+  --color-neutral-400: #a1a1aa;
+  --color-neutral-500: #71717a;
+  --color-neutral-600: #52525b;
+  --color-neutral-700: #3f3f46;
+  --color-neutral-800: #27272a;
+  --color-neutral-900: #18181b;
+  --color-neutral-950: #09090b;
 
-  /* Primary Scale (Blue) */
-  --color-primary-50: #eff6ff;
-  --color-primary-100: #dbeafe;
-  --color-primary-200: #bfdbfe;
-  --color-primary-300: #93c5fd;
-  --color-primary-400: #60a5fa;
-  --color-primary-500: #2563eb;
-  --color-primary-600: #1d4ed8;
-  --color-primary-700: #1e40af;
-  --color-primary-800: #1e3a8a;
-  --color-primary-900: #172554;
-  --color-primary-950: #0f172a;
+  /* Primary Scale - Indigo (refined, premium feel for productivity) */
+  --color-primary-50: #eef2ff;
+  --color-primary-100: #e0e7ff;
+  --color-primary-200: #c7d2fe;
+  --color-primary-300: #a5b4fc;
+  --color-primary-400: #818cf8;
+  --color-primary-500: #6366f1;
+  --color-primary-600: #4f46e5;
+  --color-primary-700: #4338ca;
+  --color-primary-800: #3730a3;
+  --color-primary-900: #312e81;
+  --color-primary-950: #1e1b4b;
 
-  /* Success Scale (Green) */
-  --color-success-50: #f0fdf4;
-  --color-success-100: #dcfce7;
-  --color-success-200: #bbf7d0;
-  --color-success-300: #86efac;
-  --color-success-400: #4ade80;
-  --color-success-500: #22c55e;
-  --color-success-600: #16a34a;
-  --color-success-700: #15803d;
-  --color-success-800: #166534;
-  --color-success-900: #14532d;
-  --color-success-950: #052e16;
+  /* Success Scale - Emerald (clear, confident green) */
+  --color-success-50: #ecfdf5;
+  --color-success-100: #d1fae5;
+  --color-success-200: #a7f3d0;
+  --color-success-300: #6ee7b7;
+  --color-success-400: #34d399;
+  --color-success-500: #10b981;
+  --color-success-600: #059669;
+  --color-success-700: #047857;
+  --color-success-800: #065f46;
+  --color-success-900: #064e3b;
+  --color-success-950: #022c22;
 
-  /* Error Scale (Red) */
-  --color-error-50: #fef2f2;
-  --color-error-100: #fee2e2;
-  --color-error-200: #fecaca;
-  --color-error-300: #fca5a5;
-  --color-error-400: #f87171;
-  --color-error-500: #ef4444;
-  --color-error-600: #dc2626;
-  --color-error-700: #b91c1c;
-  --color-error-800: #991b1b;
-  --color-error-900: #7f1d1d;
-  --color-error-950: #450a0a;
+  /* Error Scale - Rose (warm, attention-grabbing) */
+  --color-error-50: #fff1f2;
+  --color-error-100: #ffe4e6;
+  --color-error-200: #fecdd3;
+  --color-error-300: #fda4af;
+  --color-error-400: #fb7185;
+  --color-error-500: #f43f5e;
+  --color-error-600: #e11d48;
+  --color-error-700: #be123c;
+  --color-error-800: #9f1239;
+  --color-error-900: #881337;
+  --color-error-950: #4c0519;
 
-  /* Warning Scale (Amber/Orange) */
+  /* Warning Scale - Amber */
   --color-warning-50: #fffbeb;
   --color-warning-100: #fef3c7;
   --color-warning-200: #fde68a;
@@ -66,21 +66,31 @@
   --color-warning-900: #78350f;
   --color-warning-950: #451a03;
 
-  /* Semantic Colors (Light Theme) */
-  --color-background: #e9e9e9;
-  --color-surface: #f2f2f2;
-  --color-surface-elevated: #ffffff;
+  /* Semantic Aliases (shorthand for common usage) */
+  --color-primary: var(--color-primary-500);
+  --color-success: var(--color-success-500);
+  --color-error: var(--color-error-500);
+  --color-warning: var(--color-warning-500);
 
+  /* Semantic Surface Colors */
+  --color-background: var(--color-neutral-100);
+  --color-surface: #ffffff;
+  --color-surface-elevated: #ffffff;
+  --color-surface-hover: var(--color-neutral-50);
+
+  /* Semantic Text Colors */
   --color-text-primary: var(--color-neutral-900);
   --color-text-secondary: var(--color-neutral-600);
   --color-text-tertiary: var(--color-neutral-500);
   --color-text-inverse: #ffffff;
 
-  --color-border: #d5d5d5;
+  /* Semantic Border Colors */
+  --color-border: var(--color-neutral-200);
   --color-border-hover: var(--color-neutral-400);
   --color-border-focus: var(--color-primary-500);
 
-  --color-overlay: rgba(0, 0, 0, 0.5);
+  /* Overlay */
+  --color-overlay: rgba(0, 0, 0, 0.4);
 
   /* Deprecated - for backward compatibility */
   --background-color: var(--color-background);
@@ -92,59 +102,59 @@
 }
 
 :root[data-theme="dark"] {
-  /* Neutral Scale (inverted for dark mode) */
-  --color-neutral-50: #0a0a0a;
-  --color-neutral-100: #171717;
-  --color-neutral-200: #262626;
-  --color-neutral-300: #404040;
-  --color-neutral-400: #525252;
-  --color-neutral-500: #737373;
-  --color-neutral-600: #a3a3a3;
-  --color-neutral-700: #d4d4d4;
-  --color-neutral-800: #e5e5e5;
-  --color-neutral-900: #f5f5f5;
+  /* Neutral Scale - Zinc (inverted for dark mode) */
+  --color-neutral-50: #09090b;
+  --color-neutral-100: #18181b;
+  --color-neutral-200: #27272a;
+  --color-neutral-300: #3f3f46;
+  --color-neutral-400: #52525b;
+  --color-neutral-500: #71717a;
+  --color-neutral-600: #a1a1aa;
+  --color-neutral-700: #d4d4d8;
+  --color-neutral-800: #e4e4e7;
+  --color-neutral-900: #f4f4f5;
   --color-neutral-950: #fafafa;
 
-  /* Primary Scale (same as light mode) */
-  --color-primary-50: #eff6ff;
-  --color-primary-100: #dbeafe;
-  --color-primary-200: #bfdbfe;
-  --color-primary-300: #93c5fd;
-  --color-primary-400: #60a5fa;
-  --color-primary-500: #2563eb;
-  --color-primary-600: #1d4ed8;
-  --color-primary-700: #1e40af;
-  --color-primary-800: #1e3a8a;
-  --color-primary-900: #172554;
-  --color-primary-950: #0f172a;
+  /* Primary Scale - Indigo (same hues, used via semantic aliases) */
+  --color-primary-50: #eef2ff;
+  --color-primary-100: #e0e7ff;
+  --color-primary-200: #c7d2fe;
+  --color-primary-300: #a5b4fc;
+  --color-primary-400: #818cf8;
+  --color-primary-500: #6366f1;
+  --color-primary-600: #4f46e5;
+  --color-primary-700: #4338ca;
+  --color-primary-800: #3730a3;
+  --color-primary-900: #312e81;
+  --color-primary-950: #1e1b4b;
 
-  /* Success Scale (same as light mode) */
-  --color-success-50: #f0fdf4;
-  --color-success-100: #dcfce7;
-  --color-success-200: #bbf7d0;
-  --color-success-300: #86efac;
-  --color-success-400: #4ade80;
-  --color-success-500: #22c55e;
-  --color-success-600: #16a34a;
-  --color-success-700: #15803d;
-  --color-success-800: #166534;
-  --color-success-900: #14532d;
-  --color-success-950: #052e16;
+  /* Success Scale - Emerald */
+  --color-success-50: #ecfdf5;
+  --color-success-100: #d1fae5;
+  --color-success-200: #a7f3d0;
+  --color-success-300: #6ee7b7;
+  --color-success-400: #34d399;
+  --color-success-500: #10b981;
+  --color-success-600: #059669;
+  --color-success-700: #047857;
+  --color-success-800: #065f46;
+  --color-success-900: #064e3b;
+  --color-success-950: #022c22;
 
-  /* Error Scale (same as light mode) */
-  --color-error-50: #fef2f2;
-  --color-error-100: #fee2e2;
-  --color-error-200: #fecaca;
-  --color-error-300: #fca5a5;
-  --color-error-400: #f87171;
-  --color-error-500: #ef4444;
-  --color-error-600: #dc2626;
-  --color-error-700: #b91c1c;
-  --color-error-800: #991b1b;
-  --color-error-900: #7f1d1d;
-  --color-error-950: #450a0a;
+  /* Error Scale - Rose */
+  --color-error-50: #fff1f2;
+  --color-error-100: #ffe4e6;
+  --color-error-200: #fecdd3;
+  --color-error-300: #fda4af;
+  --color-error-400: #fb7185;
+  --color-error-500: #f43f5e;
+  --color-error-600: #e11d48;
+  --color-error-700: #be123c;
+  --color-error-800: #9f1239;
+  --color-error-900: #881337;
+  --color-error-950: #4c0519;
 
-  /* Warning Scale (same as light mode) */
+  /* Warning Scale - Amber */
   --color-warning-50: #fffbeb;
   --color-warning-100: #fef3c7;
   --color-warning-200: #fde68a;
@@ -157,21 +167,31 @@
   --color-warning-900: #78350f;
   --color-warning-950: #451a03;
 
-  /* Semantic Colors (Dark Theme) */
-  --color-background: #1a1a1a;
-  --color-surface: #242424;
-  --color-surface-elevated: #2d2d2d;
+  /* Semantic Aliases (lighter in dark mode for contrast) */
+  --color-primary: var(--color-primary-400);
+  --color-success: var(--color-success-400);
+  --color-error: var(--color-error-400);
+  --color-warning: var(--color-warning-400);
 
+  /* Semantic Surface Colors (more contrast between levels) */
+  --color-background: #0c0c0e;
+  --color-surface: var(--color-neutral-100);
+  --color-surface-elevated: var(--color-neutral-200);
+  --color-surface-hover: var(--color-neutral-300);
+
+  /* Semantic Text Colors */
   --color-text-primary: var(--color-neutral-950);
   --color-text-secondary: var(--color-neutral-700);
   --color-text-tertiary: var(--color-neutral-600);
   --color-text-inverse: var(--color-neutral-100);
 
-  --color-border: #404040;
+  /* Semantic Border Colors */
+  --color-border: var(--color-neutral-300);
   --color-border-hover: var(--color-neutral-400);
   --color-border-focus: var(--color-primary-400);
 
-  --color-overlay: rgba(0, 0, 0, 0.7);
+  /* Overlay */
+  --color-overlay: rgba(0, 0, 0, 0.6);
 
   /* Deprecated - for backward compatibility */
   --background-color: var(--color-background);

--- a/src/design-system/tokens/radius.css
+++ b/src/design-system/tokens/radius.css
@@ -2,6 +2,7 @@
 
 :root {
   --radius-none: 0;
+  --radius-xs: 0.125rem; /* 2px */
   --radius-sm: 0.25rem; /* 4px */
   --radius-base: 0.375rem; /* 6px */
   --radius-md: 0.5rem; /* 8px */

--- a/src/design-system/tokens/shadows.css
+++ b/src/design-system/tokens/shadows.css
@@ -2,24 +2,32 @@
 
 :root[data-theme="light"] {
   --shadow-xs: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
-  --shadow-base: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-  --shadow-md: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
-  --shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
-  --shadow-xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.08), 0 1px 2px -1px rgba(0, 0, 0, 0.08);
+  --shadow-base: 0 4px 6px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -2px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -4px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.08), 0 8px 10px -6px rgba(0, 0, 0, 0.06);
+  --shadow-xl: 0 25px 50px -12px rgba(0, 0, 0, 0.2);
+
+  /* Focus ring for interactive elements */
+  --shadow-focus-ring: 0 0 0 3px rgba(99, 102, 241, 0.15);
+  --shadow-focus-ring-error: 0 0 0 3px rgba(244, 63, 94, 0.15);
 
   /* Deprecated - for backward compatibility */
-  --box-shadow: -2px 2px 1px #cecece;
+  --box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.08);
 }
 
 :root[data-theme="dark"] {
-  --shadow-xs: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
-  --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.4), 0 1px 2px -1px rgba(0, 0, 0, 0.4);
-  --shadow-base: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -2px rgba(0, 0, 0, 0.4);
-  --shadow-md: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -4px rgba(0, 0, 0, 0.4);
-  --shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.5);
-  --shadow-xl: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+  --shadow-xs: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
+  --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.5), 0 1px 2px -1px rgba(0, 0, 0, 0.5);
+  --shadow-base: 0 4px 6px -1px rgba(0, 0, 0, 0.5), 0 2px 4px -2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -4px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.6), 0 8px 10px -6px rgba(0, 0, 0, 0.5);
+  --shadow-xl: 0 25px 50px -12px rgba(0, 0, 0, 0.7);
+
+  /* Focus ring for interactive elements */
+  --shadow-focus-ring: 0 0 0 3px rgba(129, 140, 248, 0.2);
+  --shadow-focus-ring-error: 0 0 0 3px rgba(251, 113, 133, 0.2);
 
   /* Deprecated - for backward compatibility */
-  --box-shadow: -1px 2px 5px #171717;
+  --box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4);
 }

--- a/src/design-system/tokens/typography.css
+++ b/src/design-system/tokens/typography.css
@@ -8,6 +8,7 @@
     ui-monospace, "SF Mono", "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
 
   /* Font Sizes */
+  --font-size-2xs: 0.625rem; /* 10px */
   --font-size-xs: 0.75rem; /* 12px */
   --font-size-sm: 0.875rem; /* 14px */
   --font-size-base: 1rem; /* 16px */

--- a/src/index.css
+++ b/src/index.css
@@ -24,21 +24,21 @@ h1 {
 button {
   border-radius: var(--radius-md);
   border: 1px solid transparent;
-  padding: 0.6em 1.2em;
+  padding: var(--spacing-2) var(--spacing-4);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-medium);
   font-family: inherit;
   background-color: var(--color-surface-elevated);
   color: var(--color-text-secondary);
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--shadow-xs);
   cursor: pointer;
   transition: var(--transition-colors);
 }
 button:hover {
-  border-color: var(--color-primary-500);
+  border-color: var(--color-border-hover);
 }
-button:focus,
 button:focus-visible {
   outline: 2px solid var(--color-border-focus);
   outline-offset: 2px;
+  box-shadow: var(--shadow-focus-ring);
 }


### PR DESCRIPTION
## Summary

- **Color palette overhaul**: Pure gray neutrals → zinc (cool undertone), stock blue → indigo primary, green → emerald, red → rose. Better surface layering in both themes.
- **New tokens**: `--font-size-2xs`, `--radius-xs`, `--shadow-focus-ring` / `--shadow-focus-ring-error`, `--color-surface-hover`, semantic color aliases.
- **Hardcoded values replaced**: Focus ring rgba() shadows, padding, letter-spacing, border-radius, and `color: white` across 13 files now use design tokens.
- **Bug fix**: `--color-border-primary` (nonexistent) → `--color-border` in FileInfo.