### PR TITLE
add status bar with file library and deck creator views

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,9 +6,8 @@ import CardButtons from "./components/CardButtons.vue";
 import type { Answer } from "./scheduler/types";
 import { getRenderedCardString } from "./utils/render";
 import { computeDeckInfo } from "./utils/deckInfo";
-import FilePicker from "./components/FilePicker.vue";
 import {
-  ankiCachePromise,
+  activeViewSig,
   ankiDataSig,
   cardsSig,
   currentReviewCardSig,
@@ -22,9 +21,11 @@ import {
   selectedCardSig,
   selectedDeckIdSig,
   selectedTemplateSig,
-  blobSig,
   templatesSig,
 } from "./stores";
+import StatusBar from "./components/StatusBar.vue";
+import FileLibrary from "./components/FileLibrary.vue";
+import DeckCreator from "./components/DeckCreator.vue";
 import SRSVisualization from "./components/SRSVisualization.vue";
 import SchedulerSettings from "./components/SchedulerSettings.vue";
 import CommandPalette from "./components/CommandPalette.vue";
@@ -147,12 +148,6 @@ const intervals = computed(() => {
   return queue.getNextIntervals(reviewCard);
 });
 
-async function handleFileChange(file: File) {
-  const cache = await ankiCachePromise;
-  await cache.put("anki-deck", new Response(file));
-  blobSig.value = file;
-}
-
 function handleReveal() {
   updateActiveSide("back");
   reviewStartTime.value = Date.now();
@@ -178,7 +173,16 @@ async function handleChooseAnswer(answer: Answer) {
 </script>
 
 <template>
-  <main>
+  <StatusBar />
+
+  <!-- FILES VIEW -->
+  <FileLibrary v-if="activeViewSig === 'files'" />
+
+  <!-- CREATE DECK VIEW -->
+  <DeckCreator v-else-if="activeViewSig === 'create'" />
+
+  <!-- REVIEW VIEW -->
+  <main v-else>
     <!-- LEFT COLUMN: File Info -->
     <div class="layout-left-column">
       <FileInfo v-if="deckInfoSig" />
@@ -207,7 +211,9 @@ async function handleChooseAnswer(answer: Answer) {
           @choose-answer="handleChooseAnswer"
         />
       </template>
-      <FilePicker v-else-if="cardsSig.length === 0" @file-change="handleFileChange" />
+      <p v-else-if="cardsSig.length === 0" class="no-deck-message">
+        No deck loaded. Switch to the <button class="link-btn" @click="activeViewSig = 'files'">Files</button> tab to open one.
+      </p>
     </div>
 
     <!-- RIGHT COLUMN: SRS Visualization -->
@@ -227,7 +233,7 @@ async function handleChooseAnswer(answer: Answer) {
 main {
   display: grid;
   grid-template-columns: 300px 1fr 400px;
-  min-height: 100vh;
+  min-height: calc(100vh - 44px);
 }
 
 :global(hr) { margin: var(--spacing-4) 0; }
@@ -236,8 +242,8 @@ main {
   grid-column: 1;
   grid-row: 1;
   position: sticky;
-  top: 0;
-  height: 100vh;
+  top: 44px;
+  height: calc(100vh - 44px);
   overflow-y: auto;
   background: var(--color-surface);
   border-right: 1px solid var(--color-border);
@@ -259,13 +265,30 @@ main {
   grid-column: 3;
   grid-row: 1;
   position: sticky;
-  top: 0;
-  height: 100vh;
+  top: 44px;
+  height: calc(100vh - 44px);
   overflow-y: auto;
   background: var(--color-surface);
   border-left: 1px solid var(--color-border);
   padding: var(--spacing-4);
   text-align: left;
+}
+
+.no-deck-message {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-base);
+}
+
+.link-btn {
+  display: inline;
+  padding: 0;
+  font: inherit;
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  box-shadow: none;
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 @media (max-width: 1200px) {

--- a/src/components/DeckCreator.vue
+++ b/src/components/DeckCreator.vue
@@ -1,0 +1,210 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { Button } from "../design-system";
+
+const rawInput = ref("");
+const delimiter = ref<"tab" | "comma">("tab");
+
+const parsedRows = computed(() => {
+  const sep = delimiter.value === "tab" ? "\t" : ",";
+  return rawInput.value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const parts = line.split(sep);
+      return { front: (parts[0] ?? "").trim(), back: (parts[1] ?? "").trim() };
+    })
+    .filter((row) => row.front.length > 0);
+});
+
+function exportDeck() {
+  if (parsedRows.value.length === 0) return;
+
+  const tsv = parsedRows.value.map((r) => `${r.front}\t${r.back}`).join("\n");
+  const blob = new Blob([tsv], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "deck.txt";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+</script>
+
+<template>
+  <div class="deck-creator">
+    <h2 class="title">Create Deck</h2>
+    <p class="description">
+      Paste a table with two columns. Column 1 becomes the front of each card,
+      column 2 becomes the back. Export as a text file you can import into Anki.
+    </p>
+
+    <div class="controls">
+      <label class="delimiter-label">
+        Delimiter:
+        <select v-model="delimiter" class="delimiter-select">
+          <option value="tab">Tab</option>
+          <option value="comma">Comma</option>
+        </select>
+      </label>
+    </div>
+
+    <textarea
+      v-model="rawInput"
+      class="input-area"
+      placeholder="Paste your table here&#10;front1&#9;back1&#10;front2&#9;back2"
+      rows="10"
+    />
+
+    <div v-if="parsedRows.length > 0" class="preview-section">
+      <div class="preview-header">
+        <h3 class="preview-title">Preview ({{ parsedRows.length }} cards)</h3>
+        <Button variant="primary" size="sm" @click="exportDeck">
+          Export .txt
+        </Button>
+      </div>
+      <div class="table-wrapper">
+        <table class="preview-table">
+          <thead>
+            <tr>
+              <th class="col-num">#</th>
+              <th>Front</th>
+              <th>Back</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(row, i) in parsedRows" :key="i">
+              <td class="col-num">{{ i + 1 }}</td>
+              <td>{{ row.front }}</td>
+              <td>{{ row.back }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.deck-creator {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: var(--spacing-8) var(--spacing-4);
+}
+
+.title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-2) 0;
+}
+
+.description {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  margin: 0 0 var(--spacing-4) 0;
+}
+
+.controls {
+  margin-bottom: var(--spacing-3);
+}
+
+.delimiter-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.delimiter-select {
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.input-area {
+  width: 100%;
+  min-height: 200px;
+  padding: var(--spacing-3);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  resize: vertical;
+  box-sizing: border-box;
+  transition: var(--transition-colors);
+}
+
+.input-area::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+.input-area:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+  box-shadow: var(--shadow-focus-ring);
+}
+
+.preview-section {
+  margin-top: var(--spacing-6);
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-3);
+}
+
+.preview-title {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.preview-table th,
+.preview-table td {
+  padding: var(--spacing-2) var(--spacing-3);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.preview-table th {
+  background: var(--color-surface-elevated);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+}
+
+.preview-table td {
+  color: var(--color-text-primary);
+}
+
+.preview-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.col-num {
+  width: 40px;
+  color: var(--color-text-tertiary);
+}
+</style>

--- a/src/components/FileLibrary.vue
+++ b/src/components/FileLibrary.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { Button } from "../design-system";
+import {
+  cachedFilesSig,
+  activeFileNameSig,
+  addCachedFile,
+  loadCachedFile,
+  deleteCachedFile,
+} from "../stores";
+
+const fileInput = ref<HTMLInputElement>();
+
+const sortedFiles = computed(() =>
+  [...cachedFilesSig.value].sort((a, b) => b.addedAt - a.addedAt),
+);
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function handleFileInput(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (file) addCachedFile(file);
+}
+</script>
+
+<template>
+  <div class="file-library">
+    <div class="header">
+      <h2 class="title">Your Decks</h2>
+      <input ref="fileInput" type="file" accept=".apkg" class="hidden-input" @change="handleFileInput" />
+      <Button variant="primary" size="sm" @click="fileInput?.click()">
+        Add File
+      </Button>
+    </div>
+
+    <div v-if="sortedFiles.length === 0" class="empty-state">
+      <p class="empty-text">No decks yet. Add an .apkg file to get started.</p>
+      <Button variant="secondary" @click="fileInput?.click()">
+        Choose a Deck File
+      </Button>
+    </div>
+
+    <div v-else class="file-grid">
+      <div
+        v-for="file in sortedFiles"
+        :key="file.name"
+        :class="['file-card', { 'file-card--active': activeFileNameSig === file.name }]"
+        @click="loadCachedFile(file.name)"
+      >
+        <div class="file-info">
+          <span class="file-name">{{ file.name }}</span>
+          <span class="file-meta">{{ formatSize(file.size) }} &middot; {{ formatDate(file.addedAt) }}</span>
+        </div>
+        <button
+          class="delete-btn"
+          title="Remove from library"
+          @click.stop="deleteCachedFile(file.name)"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.file-library {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: var(--spacing-8) var(--spacing-4);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-6);
+}
+
+.title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.hidden-input {
+  display: none;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-4);
+  padding: var(--spacing-12) var(--spacing-4);
+  text-align: center;
+}
+
+.empty-text {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-base);
+}
+
+.file-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.file-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: var(--transition-colors);
+}
+
+.file-card:hover {
+  background: var(--color-surface-hover);
+  border-color: var(--color-border-hover);
+}
+
+.file-card--active {
+  border-color: var(--color-primary);
+  background: var(--color-surface-elevated);
+}
+
+.file-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-0-5);
+  min-width: 0;
+}
+
+.file-name {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-meta {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+}
+
+.delete-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  font-size: var(--font-size-lg);
+  color: var(--color-text-tertiary);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition-colors);
+  box-shadow: none;
+}
+
+.delete-btn:hover {
+  color: var(--color-error);
+  background: var(--color-surface-hover);
+}
+</style>

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { type AppView, activeViewSig } from "../stores";
+
+const tabs: { id: AppView; label: string }[] = [
+  { id: "files", label: "Files" },
+  { id: "review", label: "Review" },
+  { id: "create", label: "Create Deck" },
+];
+</script>
+
+<template>
+  <nav class="status-bar">
+    <div class="tabs">
+      <button
+        v-for="tab in tabs"
+        :key="tab.id"
+        :class="['tab', { 'tab--active': activeViewSig === tab.id }]"
+        @click="activeViewSig = tab.id"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+  </nav>
+</template>
+
+<style scoped>
+.status-bar {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-index-sticky);
+  display: flex;
+  align-items: center;
+  height: 44px;
+  padding: 0 var(--spacing-4);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tabs {
+  display: flex;
+  gap: var(--spacing-1);
+}
+
+.tab {
+  padding: var(--spacing-1-5) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: var(--transition-colors);
+  box-shadow: none;
+}
+
+.tab:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover);
+}
+
+.tab--active {
+  color: var(--color-primary);
+  background: var(--color-surface-elevated);
+}
+</style>

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -5,21 +5,120 @@ import { DEFAULT_SCHEDULER_SETTINGS, type SchedulerSettings } from "./scheduler/
 import { reviewDB } from "./scheduler/db";
 import type { DeckInfo } from "./types";
 
+// View state
+export type AppView = "files" | "review" | "create";
+export const activeViewSig = ref<AppView>("files");
+
 export const deckInfoSig = shallowRef<DeckInfo | null>(null);
 
 export const selectedDeckIdSig = ref<string | null>(null);
 
+// Multi-file cache management
+export interface CachedFileEntry {
+  name: string;
+  size: number;
+  addedAt: number;
+}
+
 export const ankiCachePromise = caches.open("anki-cache");
 export const blobSig = shallowRef<Blob | null>(null);
+export const cachedFilesSig = ref<CachedFileEntry[]>([]);
+export const activeFileNameSig = ref<string | null>(null);
 
+// Load cached files manifest from localStorage
+const storedFiles = localStorage.getItem("anki-cached-files");
+if (storedFiles) {
+  try {
+    cachedFilesSig.value = JSON.parse(storedFiles);
+  } catch {
+    // ignore corrupt data
+  }
+}
+
+// Restore last active file from localStorage
+const storedActiveFile = localStorage.getItem("anki-active-file");
+if (storedActiveFile && cachedFilesSig.value.some((f) => f.name === storedActiveFile)) {
+  activeFileNameSig.value = storedActiveFile;
+}
+
+// Initialize: migrate old single-file cache and load active file
 ankiCachePromise.then(async (cache) => {
-  const response = await cache.match("anki-deck");
-  if (!response) {
-    return;
+  // Migrate old "anki-deck" entry to new format
+  const oldResponse = await cache.match("anki-deck");
+  if (oldResponse) {
+    const blob = await oldResponse.blob();
+    const name = "imported-deck.apkg";
+    await cache.put(`/files/${name}`, new Response(blob));
+    await cache.delete("anki-deck");
+    if (!cachedFilesSig.value.some((f) => f.name === name)) {
+      cachedFilesSig.value = [
+        ...cachedFilesSig.value,
+        { name, size: blob.size, addedAt: Date.now() },
+      ];
+      localStorage.setItem("anki-cached-files", JSON.stringify(cachedFilesSig.value));
+    }
+    if (!activeFileNameSig.value) {
+      activeFileNameSig.value = name;
+      localStorage.setItem("anki-active-file", name);
+    }
   }
 
-  blobSig.value = await response.blob();
+  // Load the active file
+  if (activeFileNameSig.value) {
+    const response = await cache.match(`/files/${activeFileNameSig.value}`);
+    if (response) {
+      blobSig.value = await response.blob();
+      activeViewSig.value = "review";
+    }
+  }
 });
+
+export async function addCachedFile(file: File) {
+  const cache = await ankiCachePromise;
+  await cache.put(`/files/${file.name}`, new Response(file));
+
+  if (!cachedFilesSig.value.some((f) => f.name === file.name)) {
+    cachedFilesSig.value = [
+      ...cachedFilesSig.value,
+      { name: file.name, size: file.size, addedAt: Date.now() },
+    ];
+  }
+  localStorage.setItem("anki-cached-files", JSON.stringify(cachedFilesSig.value));
+
+  activeFileNameSig.value = file.name;
+  localStorage.setItem("anki-active-file", file.name);
+  blobSig.value = file;
+  activeViewSig.value = "review";
+}
+
+export async function loadCachedFile(name: string) {
+  const cache = await ankiCachePromise;
+  const response = await cache.match(`/files/${name}`);
+  if (response) {
+    activeFileNameSig.value = name;
+    localStorage.setItem("anki-active-file", name);
+    blobSig.value = await response.blob();
+    activeViewSig.value = "review";
+  }
+}
+
+export async function deleteCachedFile(name: string) {
+  const cache = await ankiCachePromise;
+  await cache.delete(`/files/${name}`);
+  cachedFilesSig.value = cachedFilesSig.value.filter((f) => f.name !== name);
+  localStorage.setItem("anki-cached-files", JSON.stringify(cachedFilesSig.value));
+
+  if (activeFileNameSig.value === name) {
+    if (cachedFilesSig.value.length > 0) {
+      await loadCachedFile(cachedFilesSig.value[0]!.name);
+    } else {
+      activeFileNameSig.value = null;
+      localStorage.removeItem("anki-active-file");
+      blobSig.value = null;
+      ankiDataSig.value = null;
+    }
+  }
+}
 
 // Resource replacement: watch blobSig and fetch data
 type AnkiData = Awaited<ReturnType<typeof getAnkiDataFromBlob>>;


### PR DESCRIPTION
Adds a sticky status bar at the top with three tabs:

- **Files** – file library view for managing cached .apkg decks via the Web Cache API (add, switch, delete)
- **Review** – existing card review experience
- **Create Deck** – paste a two-column table to generate an Anki-importable .txt file

Also migrates the cache from single-file to multi-file storage with localStorage manifest.