### PR TITLE
Sandbox card content in iframes to prevent XSS

### DIFF
--- a/e2e/card-display.spec.ts
+++ b/e2e/card-display.spec.ts
@@ -21,9 +21,10 @@ test.describe('Card Display', () => {
     const cardContent = page.locator('.card-content');
     await expect(cardContent).toBeVisible();
 
-    // Content should not be empty
-    const textContent = await cardContent.textContent();
-    expect(textContent?.trim()).not.toBe('');
+    // Content is rendered inside a sandboxed iframe
+    const iframe = page.frameLocator('.card-content iframe.sandboxed-card');
+    const body = iframe.locator('body');
+    await expect(body).not.toBeEmpty();
   });
 
   test('should reveal back side when Reveal button is clicked', async ({ loadedDeckPage: page }) => {
@@ -41,14 +42,17 @@ test.describe('Card Display', () => {
   });
 
   test('should display different content on front and back', async ({ loadedDeckPage: page }) => {
+    const iframe = page.frameLocator('.card-content iframe.sandboxed-card');
+
     // Get front content
-    const frontContent = await page.locator('.card-content').textContent();
+    const frontContent = await iframe.locator('body').textContent();
 
     // Reveal back
     await page.click('button:has-text("Reveal")');
 
-    // Get back content
-    const backContent = await page.locator('.card-content').textContent();
+    // Get back content (iframe reloads with new content)
+    await page.waitForTimeout(500);
+    const backContent = await iframe.locator('body').textContent();
 
     // Back content should include front content (as per Anki spec with FrontSide)
     expect(backContent).toContain(frontContent);
@@ -82,9 +86,10 @@ test.describe('Card Navigation', () => {
     // Check that we're back to front side (next card loaded)
     await expect(page.locator('button:has-text("Reveal")')).toBeVisible();
 
-    // Verify card content still exists
-    const cardContent = await page.locator('.card-content').textContent();
-    expect(cardContent?.trim()).not.toBe('');
+    // Verify card content still exists inside iframe
+    const iframe = page.frameLocator('.card-content iframe.sandboxed-card');
+    const body = iframe.locator('body');
+    await expect(body).not.toBeEmpty();
   });
 
   test('should cycle through answer options correctly', async ({ loadedDeckPage: page }) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -107,7 +107,7 @@ const renderedCard = computed(() => {
     mediaFiles: mediaFilesSig.value,
   });
 
-  return { frontSideHtml, backSideHtml };
+  return { frontSideHtml, backSideHtml, cardCss: card.css ?? "" };
 });
 
 function getAudioFilenames(html: string) {
@@ -147,6 +147,10 @@ const intervals = computed(() => {
 
   return queue.getNextIntervals(reviewCard);
 });
+
+function handleAudioButtonClick(src: string) {
+  new Audio(src).play();
+}
 
 function handleReveal() {
   updateActiveSide("back");
@@ -193,17 +197,14 @@ async function handleChooseAnswer(answer: Answer) {
       <template v-if="renderedCard">
         <FlashCard
           :active-side="activeSide"
+          :front-html="renderedCard.frontSideHtml"
+          :back-html="renderedCard.backSideHtml"
+          :card-css="renderedCard.cardCss"
           :intervals="intervals"
           @reveal="handleReveal"
           @choose-answer="handleChooseAnswer"
-        >
-          <template #front>
-            <div v-html="renderedCard.frontSideHtml" />
-          </template>
-          <template #back>
-            <div v-html="renderedCard.backSideHtml" />
-          </template>
-        </FlashCard>
+          @audio-button-click="handleAudioButtonClick"
+        />
         <CardButtons
           :active-side="activeSide"
           :intervals="intervals"
@@ -235,8 +236,6 @@ main {
   grid-template-columns: 300px 1fr 400px;
   min-height: calc(100vh - 44px);
 }
-
-:global(hr) { margin: var(--spacing-4) 0; }
 
 .layout-left-column {
   grid-column: 1;

--- a/src/ankiParser/anki2/index.ts
+++ b/src/ankiParser/anki2/index.ts
@@ -11,6 +11,7 @@ export type AnkiDB2Data = {
     };
     tags: string[];
     templates: z.infer<typeof modelSchema>[string]["tmpls"];
+    css: string;
     deckName: string;
   }[];
   notesTypes: null;
@@ -83,6 +84,7 @@ export function getDataFromAnki2(db: Database): AnkiDB2Data {
         values: valuesMap,
         tags: note.tags.split("\x1F"),
         templates: modelForCard.tmpls,
+        css: modelForCard.css,
         deckName: cardDeckName,
       };
     });

--- a/src/ankiParser/anki21b/index.ts
+++ b/src/ankiParser/anki21b/index.ts
@@ -15,6 +15,7 @@ export type AnkiDB21bData = {
       afmt: string;
       qfmt: string;
     }[];
+    css: string;
     deckName: string;
   }[];
   notesTypes: ReturnType<typeof getNotesType>;
@@ -84,6 +85,9 @@ export function getDataFromAnki21b(db: Database): AnkiDB21bData {
     return templatesMap;
   })();
 
+  const notesTypes = getNotesType(db);
+  const notesTypeCssMap = new Map(notesTypes.map((nt) => [nt.id, nt.css]));
+
   const cards = (() => {
     /**
      * Notes define content.
@@ -114,12 +118,12 @@ export function getDataFromAnki21b(db: Database): AnkiDB21bData {
         ),
         // anki21b only has one template per model?
         templates: templates,
+        css: notesTypeCssMap.get(note.mid) ?? "",
         tags: [],
         deckName: cardDeckName,
       };
     });
   })();
 
-  const notesTypes = getNotesType(db);
   return { cards, notesTypes, deckName, decks };
 }

--- a/src/ankiParser/anki21b/proto/index.ts
+++ b/src/ankiParser/anki21b/proto/index.ts
@@ -17,6 +17,7 @@ export function getNotesType(db: Database) {
     }>(db, "SELECT cast(id as text) as id, name, config FROM notetypes");
 
     return notesTypes.map((notesType) => ({
+      id: String(notesType.id),
       name: notesType.name,
       ...parseNotesTypeConfigProto(notesType.config),
     }));

--- a/src/components/FlashCard.vue
+++ b/src/components/FlashCard.vue
@@ -1,16 +1,25 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from "vue";
+import { onMounted, onUnmounted, ref } from "vue";
 import { playClickSoundBasic, playClickSoundMelodic } from "../utils/sound";
 import type { Answer } from "../scheduler/types";
+import SandboxedCard from "./SandboxedCard.vue";
+import { useTheme } from "../design-system/hooks/useTheme";
+
+const { theme } = useTheme();
+const cardBackground = ref<string | null>(null);
 
 const props = defineProps<{
   activeSide: "front" | "back";
+  frontHtml: string;
+  backHtml: string;
+  cardCss: string;
   intervals?: { again: string; hard: string; good: string; easy: string };
 }>();
 
 const emit = defineEmits<{
   reveal: [];
   chooseAnswer: [answer: Answer];
+  audioButtonClick: [src: string];
 }>();
 
 function handleKeyDown(e: KeyboardEvent) {
@@ -32,13 +41,18 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeyDown));
 </script>
 
 <template>
-  <div :class="['card', `card--${activeSide}`]">
+  <div :class="['card', `card--${activeSide}`]" :style="cardBackground ? { background: cardBackground } : undefined">
     <div :class="['card-indicator', `card-indicator--${activeSide}`]">
       {{ activeSide === "front" ? "Front" : "Back" }}
     </div>
     <div class="card-content">
-      <slot v-if="activeSide === 'front'" name="front" />
-      <slot v-else name="back" />
+      <SandboxedCard
+        :card-html="activeSide === 'front' ? frontHtml : backHtml"
+        :card-css="cardCss"
+        :theme="theme"
+        @audio-button-click="(src: string) => emit('audioButtonClick', src)"
+        @background-detected="(color: string | null) => cardBackground = color"
+      />
     </div>
   </div>
 </template>
@@ -76,7 +90,5 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeyDown));
 :root[data-theme="dark"] .card-indicator--front { background: var(--color-primary-950); color: var(--color-primary-300); }
 :root[data-theme="dark"] .card-indicator--back { background: var(--color-success-950); color: var(--color-success-300); }
 .card-content { padding: var(--spacing-8) var(--spacing-4) var(--spacing-4); }
-.card-content :deep(img) { height: 200px; margin: 0 auto; }
-.card-content :deep(hr) { margin: var(--spacing-4) 0; border-color: var(--color-border); opacity: 0.5; }
 h1 { margin: 0; font-weight: var(--font-weight-normal); font-size: var(--font-size-2xl); }
 </style>

--- a/src/components/SandboxedCard.vue
+++ b/src/components/SandboxedCard.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import { ref, watch, onBeforeUnmount, computed } from "vue";
+import katexCss from "katex/dist/katex.min.css?raw";
+import type { Theme } from "../design-system/hooks/useTheme";
+
+const props = defineProps<{
+  cardHtml: string;
+  cardCss: string;
+  theme: Theme;
+}>();
+
+const emit = defineEmits<{
+  audioButtonClick: [src: string];
+  backgroundDetected: [color: string | null];
+}>();
+
+const iframeRef = ref<HTMLIFrameElement | null>(null);
+let resizeObserver: ResizeObserver | null = null;
+
+const BASE_STYLES = `
+  *, *::before, *::after { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    overflow: hidden;
+  }
+  :where(html[data-theme="light"]) body { color: #18181b; }
+  :where(html[data-theme="dark"]) body { color: #f4f4f5; }
+  img { max-width: 100%; height: 200px; display: block; margin: 0 auto; }
+  hr { margin: 1rem 0; border: none; border-top: 1px solid; opacity: 0.5; }
+  :where(html[data-theme="light"]) hr { border-color: #e4e4e7; }
+  :where(html[data-theme="dark"]) hr { border-color: #3f3f46; }
+  .audio-container {
+    display: inline-flex;
+    align-items: center;
+  }
+  .audio-container button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    color: inherit;
+  }
+  .audio-container button svg { pointer-events: none; }
+  audio { display: none; }
+`;
+
+// srcdoc excludes theme so theme changes don't cause full iframe reloads
+const srcdoc = computed(() => {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>${BASE_STYLES}</style>
+<style>${katexCss}</style>
+${props.cardCss ? `<style>${props.cardCss}</style>` : ""}
+</head>
+<body class="card">
+${props.cardHtml}
+</body>
+</html>`;
+});
+
+function setupIframe() {
+  const iframe = iframeRef.value;
+  if (!iframe?.contentDocument) return;
+
+  const doc = iframe.contentDocument;
+  const body = doc.body;
+  if (!body) return;
+
+  // Set initial theme
+  doc.documentElement.dataset.theme = props.theme;
+
+  // Resize observer to auto-size iframe height to content
+  resizeObserver?.disconnect();
+  resizeObserver = new ResizeObserver(() => updateHeight());
+  resizeObserver.observe(body);
+
+  // Listen for image loads to retrigger height measurement
+  for (const img of doc.querySelectorAll("img")) {
+    img.addEventListener("load", updateHeight);
+  }
+
+  // Wire up audio buttons — clicks emit to parent since scripts are blocked
+  for (const btn of doc.querySelectorAll<HTMLElement>(".audio-container button")) {
+    btn.addEventListener("click", () => {
+      const audio = btn.closest(".audio-container")?.querySelector("audio");
+      if (audio?.src) {
+        emit("audioButtonClick", audio.src);
+      }
+    });
+  }
+
+  updateHeight();
+  emitBackgroundColor(body);
+}
+
+function emitBackgroundColor(body: HTMLElement) {
+  const bg = getComputedStyle(body).backgroundColor;
+  // "rgba(0, 0, 0, 0)" or "transparent" means no explicit background set
+  const isTransparent = !bg || bg === "transparent" || bg === "rgba(0, 0, 0, 0)";
+  emit("backgroundDetected", isTransparent ? null : bg);
+}
+
+function updateHeight() {
+  const iframe = iframeRef.value;
+  if (!iframe?.contentDocument?.body) return;
+  iframe.style.height = `${iframe.contentDocument.body.scrollHeight}px`;
+}
+
+// Update theme without full iframe reload
+watch(
+  () => props.theme,
+  (newTheme) => {
+    const doc = iframeRef.value?.contentDocument;
+    if (doc?.documentElement) {
+      doc.documentElement.dataset.theme = newTheme;
+    }
+  },
+);
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  resizeObserver = null;
+});
+</script>
+
+<template>
+  <iframe
+    ref="iframeRef"
+    :srcdoc="srcdoc"
+    sandbox="allow-same-origin"
+    class="sandboxed-card"
+    @load="setupIframe"
+  />
+</template>
+
+<style scoped>
+.sandboxed-card {
+  width: 100%;
+  min-height: 100px;
+  border: none;
+  overflow: hidden;
+  display: block;
+}
+</style>

--- a/src/composables/useCommands.ts
+++ b/src/composables/useCommands.ts
@@ -34,13 +34,17 @@ import {
 } from "lucide-vue-next";
 import { useTheme } from "../design-system/hooks/useTheme";
 import { getRenderedCardString } from "../utils/render";
+import { sanitizeHtmlForPreview } from "../utils/sanitize";
 
 function icon(comp: Component): Component {
   return markRaw(comp);
 }
 
 function metadataHtml(html: string): VNode {
-  return h("div", { innerHTML: html, style: "white-space: pre-wrap; word-break: break-word" });
+  return h("div", {
+    innerHTML: sanitizeHtmlForPreview(html),
+    style: "white-space: pre-wrap; word-break: break-word",
+  });
 }
 
 function templateViewer(templateHtml: string): VNode {
@@ -55,7 +59,7 @@ function cardPreview(cardHtml: string): VNode {
   return h("div", { class: "card-preview-container" }, [
     h("div", { class: "card-preview" }, [
       h("div", { class: "card-preview-badge" }, "Front"),
-      h("div", { class: "card-preview-content", innerHTML: cardHtml }),
+      h("div", { class: "card-preview-content", innerHTML: sanitizeHtmlForPreview(cardHtml) }),
     ]),
   ]);
 }

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -139,11 +139,10 @@ const SOUND_ICON_SVG =
 function replaceTemplatingSyntax(renderedString: string) {
   return renderedString
     .replace(/\[sound:(.+?)\]/g, (_match, filename) => {
-      const randomUuid = crypto.randomUUID();
       return [
         `<div class='audio-container' data-autoplay>`,
-        `<button onclick="document.getElementById('audio-${randomUuid}').play()" data-autoplay>${SOUND_ICON_SVG}</button>`,
-        `<audio src="${filename}" id="audio-${randomUuid}"></audio>`,
+        `<button data-autoplay>${SOUND_ICON_SVG}</button>`,
+        `<audio src="${filename}"></audio>`,
         "</div>",
       ].join("");
     })

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,17 @@
+/**
+ * Strips dangerous HTML for use in command palette previews.
+ * Removes scripts, event handlers, styles, and audio containers.
+ */
+export function sanitizeHtmlForPreview(html: string): string {
+  return (
+    html
+      // Remove <script> tags and their content
+      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
+      // Remove <style> tags and their content
+      .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, "")
+      // Remove .audio-container elements and their content
+      .replace(/<div\s+class=['"]audio-container['"][^>]*>[\s\S]*?<\/div>/gi, "")
+      // Remove event handler attributes (on*)
+      .replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+  );
+}


### PR DESCRIPTION
Render card content (Anki templates) inside sandboxed iframes instead of directly in the app DOM via `v-html`.

- **New `SandboxedCard.vue` component** — renders card HTML in `<iframe srcdoc="..." sandbox="allow-same-origin">`. Scripts are blocked by the browser sandbox. Includes ResizeObserver for auto-height, image load listeners, audio button click wiring, and theme reactivity without full iframe reloads.
- **Thread card CSS through data pipeline** — card CSS from Anki note types (`modelSchema.css` / `notesTypes.css`) is now passed through to the rendering layer and applied inside the iframe.
- **Sanitize command palette previews** — new `sanitizeHtmlForPreview()` strips scripts, event handlers, styles, and audio containers from HTML rendered in the command palette.
- **Remove inert onclick handlers** — inline `onclick` on audio buttons removed (blocked by sandbox anyway).
- **Update e2e tests** — card content selectors updated to use `frameLocator()` for iframe content.