### PR TITLE
align design system with tagebook: violet primary, Inter fonts, deeper dark surfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
     <title>Anki Notes</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1842,7 +1842,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2119,7 +2118,6 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -3837,7 +3835,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3897,7 +3894,6 @@
       "integrity": "sha512-5hI5NCJwKBGtzWtdKB3c2fOEpI77Iaa0z4mSzZPU1cJ/OqrGbFafm90edVCd7T9Snz+Sh09TMAv4EQqyVLzuEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.101.0",
         "fdir": "^6.5.0",
@@ -4036,7 +4032,6 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",
@@ -4114,7 +4109,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",

--- a/src/design-system/tokens/colors.css
+++ b/src/design-system/tokens/colors.css
@@ -1,4 +1,4 @@
-/* Color Tokens - Refined palette with zinc neutrals, indigo primary */
+/* Color Tokens - Refined palette with zinc neutrals, violet primary (tagebook-inspired) */
 
 :root[data-theme="light"] {
   /* Neutral Scale - Zinc (subtle cool undertone, modern feel) */
@@ -14,18 +14,18 @@
   --color-neutral-900: #18181b;
   --color-neutral-950: #09090b;
 
-  /* Primary Scale - Indigo (refined, premium feel for productivity) */
-  --color-primary-50: #eef2ff;
-  --color-primary-100: #e0e7ff;
-  --color-primary-200: #c7d2fe;
-  --color-primary-300: #a5b4fc;
-  --color-primary-400: #818cf8;
-  --color-primary-500: #6366f1;
-  --color-primary-600: #4f46e5;
-  --color-primary-700: #4338ca;
-  --color-primary-800: #3730a3;
-  --color-primary-900: #312e81;
-  --color-primary-950: #1e1b4b;
+  /* Primary Scale - Violet (vibrant purple, matching tagebook accent) */
+  --color-primary-50: #f5f3ff;
+  --color-primary-100: #ede9fe;
+  --color-primary-200: #ddd6fe;
+  --color-primary-300: #c4b5fd;
+  --color-primary-400: #a78bfa;
+  --color-primary-500: #8b5cf6;
+  --color-primary-600: #7c3aed;
+  --color-primary-700: #6d28d9;
+  --color-primary-800: #5b21b6;
+  --color-primary-900: #4c1d95;
+  --color-primary-950: #2e1065;
 
   /* Success Scale - Emerald (clear, confident green) */
   --color-success-50: #ecfdf5;
@@ -115,18 +115,18 @@
   --color-neutral-900: #f4f4f5;
   --color-neutral-950: #fafafa;
 
-  /* Primary Scale - Indigo (same hues, used via semantic aliases) */
-  --color-primary-50: #eef2ff;
-  --color-primary-100: #e0e7ff;
-  --color-primary-200: #c7d2fe;
-  --color-primary-300: #a5b4fc;
-  --color-primary-400: #818cf8;
-  --color-primary-500: #6366f1;
-  --color-primary-600: #4f46e5;
-  --color-primary-700: #4338ca;
-  --color-primary-800: #3730a3;
-  --color-primary-900: #312e81;
-  --color-primary-950: #1e1b4b;
+  /* Primary Scale - Violet (same hues, used via semantic aliases) */
+  --color-primary-50: #f5f3ff;
+  --color-primary-100: #ede9fe;
+  --color-primary-200: #ddd6fe;
+  --color-primary-300: #c4b5fd;
+  --color-primary-400: #a78bfa;
+  --color-primary-500: #8b5cf6;
+  --color-primary-600: #7c3aed;
+  --color-primary-700: #6d28d9;
+  --color-primary-800: #5b21b6;
+  --color-primary-900: #4c1d95;
+  --color-primary-950: #2e1065;
 
   /* Success Scale - Emerald */
   --color-success-50: #ecfdf5;
@@ -173,21 +173,21 @@
   --color-error: var(--color-error-400);
   --color-warning: var(--color-warning-400);
 
-  /* Semantic Surface Colors (more contrast between levels) */
-  --color-background: #0c0c0e;
-  --color-surface: var(--color-neutral-100);
-  --color-surface-elevated: var(--color-neutral-200);
-  --color-surface-hover: var(--color-neutral-300);
+  /* Semantic Surface Colors - deeper blacks matching tagebook */
+  --color-background: #0a0a0c;
+  --color-surface: #111114;
+  --color-surface-elevated: #18181c;
+  --color-surface-hover: #222226;
 
   /* Semantic Text Colors */
-  --color-text-primary: var(--color-neutral-950);
-  --color-text-secondary: var(--color-neutral-700);
-  --color-text-tertiary: var(--color-neutral-600);
+  --color-text-primary: #e4e4e7;
+  --color-text-secondary: #a1a1aa;
+  --color-text-tertiary: #71717a;
   --color-text-inverse: var(--color-neutral-100);
 
-  /* Semantic Border Colors */
-  --color-border: var(--color-neutral-300);
-  --color-border-hover: var(--color-neutral-400);
+  /* Semantic Border Colors - low-opacity white matching tagebook */
+  --color-border: rgba(255, 255, 255, 0.07);
+  --color-border-hover: rgba(255, 255, 255, 0.13);
   --color-border-focus: var(--color-primary-400);
 
   /* Overlay */

--- a/src/design-system/tokens/shadows.css
+++ b/src/design-system/tokens/shadows.css
@@ -8,8 +8,8 @@
   --shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.08), 0 8px 10px -6px rgba(0, 0, 0, 0.06);
   --shadow-xl: 0 25px 50px -12px rgba(0, 0, 0, 0.2);
 
-  /* Focus ring for interactive elements */
-  --shadow-focus-ring: 0 0 0 3px rgba(99, 102, 241, 0.15);
+  /* Focus ring for interactive elements - violet */
+  --shadow-focus-ring: 0 0 0 3px rgba(139, 92, 246, 0.15);
   --shadow-focus-ring-error: 0 0 0 3px rgba(244, 63, 94, 0.15);
 
   /* Deprecated - for backward compatibility */
@@ -20,12 +20,12 @@
   --shadow-xs: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
   --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.5), 0 1px 2px -1px rgba(0, 0, 0, 0.5);
   --shadow-base: 0 4px 6px -1px rgba(0, 0, 0, 0.5), 0 2px 4px -2px rgba(0, 0, 0, 0.4);
-  --shadow-md: 0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -4px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.6), 0 8px 10px -6px rgba(0, 0, 0, 0.5);
   --shadow-xl: 0 25px 50px -12px rgba(0, 0, 0, 0.7);
 
-  /* Focus ring for interactive elements */
-  --shadow-focus-ring: 0 0 0 3px rgba(129, 140, 248, 0.2);
+  /* Focus ring for interactive elements - violet */
+  --shadow-focus-ring: 0 0 0 3px rgba(167, 139, 250, 0.2);
   --shadow-focus-ring-error: 0 0 0 3px rgba(251, 113, 133, 0.2);
 
   /* Deprecated - for backward compatibility */

--- a/src/design-system/tokens/typography.css
+++ b/src/design-system/tokens/typography.css
@@ -1,11 +1,11 @@
 /* Typography Tokens */
 
 :root {
-  /* Font Families */
+  /* Font Families - Inter + JetBrains Mono (matching tagebook) */
   --font-family-sans:
-    system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-family-mono:
-    ui-monospace, "SF Mono", "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
+    "JetBrains Mono", "Fira Code", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
   /* Font Sizes */
   --font-size-2xs: 0.625rem; /* 10px */


### PR DESCRIPTION
Switch primary color scale from Indigo to Violet to match tagebook's purple accent (#a78bfa). Update dark mode surfaces to deeper blacks (#0a0a0c, #111114, #18181c) and use low-opacity white borders. Switch fonts to Inter + JetBrains Mono. Update focus rings and shadows to use violet hues.