### PR TITLE
add zod validation to all JSON.parse call sites

### DIFF
--- a/cli/extractMedia.ts
+++ b/cli/extractMedia.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { BlobReader, ZipReader, BlobWriter } from '@zip-js/zip-js';
 import { decompressZstd } from './utils/zstdNode.js';
 import { parseMediaProto } from '../src/ankiParser/parseMediaProto.js';
+import { mediaMappingSchema } from '../src/ankiParser/anki2/jsonParsers.js';
 
 async function extractAnkiMedia(filePath: string, outputDir: string) {
   const fileName = path.basename(filePath);
@@ -75,7 +76,7 @@ async function extractAnkiMedia(filePath: string, outputDir: string) {
   let mediaMapping: Record<string, string>;
   try {
     // Try parsing as JSON first (older format)
-    mediaMapping = JSON.parse(mediaContent);
+    mediaMapping = mediaMappingSchema.parse(JSON.parse(mediaContent));
   } catch (_jsonError) {
     // If JSON parsing fails, try parsing as Protocol Buffer (newer .anki21b format)
     try {

--- a/cli/inspectCards.ts
+++ b/cli/inspectCards.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import initSqlJs from 'sql.js';
 import { BlobReader, ZipReader, BlobWriter } from '@zip-js/zip-js';
+import { modelSchema, deckSchema } from '../src/ankiParser/anki2/jsonParsers.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -99,8 +100,8 @@ async function inspectAnkiFile(filePath: string) {
     tags: string;
   }>(db, "SELECT * from col");
 
-  const models = JSON.parse(colData.models);
-  const decks = JSON.parse(colData.decks);
+  const models = modelSchema.parse(JSON.parse(colData.models));
+  const decks = deckSchema.parse(JSON.parse(colData.decks));
 
   // Get notes
   const notes = executeQueryAll<{ id: number; modelId: string; tags: string; fields: string }>(

--- a/cli/inspectMedia.ts
+++ b/cli/inspectMedia.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { BlobReader, ZipReader, BlobWriter } from '@zip-js/zip-js';
 import { decompressZstd } from './utils/zstdNode.js';
 import { parseMediaProto } from '../src/ankiParser/parseMediaProto.js';
+import { mediaMappingSchema } from '../src/ankiParser/anki2/jsonParsers.js';
 
 async function inspectAnkiMedia(filePath: string) {
   const fileName = path.basename(filePath);
@@ -68,7 +69,7 @@ async function inspectAnkiMedia(filePath: string) {
   let mediaMapping: Record<string, string>;
   try {
     // Try parsing as JSON first (older format)
-    mediaMapping = JSON.parse(mediaContent);
+    mediaMapping = mediaMappingSchema.parse(JSON.parse(mediaContent));
   } catch (_jsonError) {
     // If JSON parsing fails, try parsing as Protocol Buffer (newer .anki21b format)
     try {

--- a/src/ankiParser/anki2/index.ts
+++ b/src/ankiParser/anki2/index.ts
@@ -1,6 +1,6 @@
 import { Database } from "sql.js";
 import { executeQuery, executeQueryAll } from "~/utils/sql";
-import { modelSchema } from "./jsonParsers";
+import { modelSchema, deckSchema, fsrsJsonSchema } from "./jsonParsers";
 import { z } from "zod";
 import { assertTruthy } from "~/utils/assert";
 
@@ -96,10 +96,7 @@ export function getDataFromAnki2(db: Database): AnkiDB2Data {
     let deckName = "Unknown";
     let decks: Record<string, { id: number; name: string }> = {};
     try {
-      const parsedDecks = JSON.parse(colData.decks) as Record<
-        string,
-        { id: number; name?: string }
-      >;
+      const parsedDecks = deckSchema.parse(JSON.parse(colData.decks));
 
       // Convert to our format, filtering out entries without names
       decks = Object.fromEntries(
@@ -272,16 +269,14 @@ export function parseFsrsData(
   // If it's a string, try JSON first
   if (typeof data === "string") {
     try {
-      const parsed = JSON.parse(data);
-      if (parsed && typeof parsed.s === "number") {
-        return {
-          stability: parsed.s,
-          difficulty: parsed.d,
-          desiredRetention: parsed.dr ?? 0.9,
-        };
-      }
+      const parsed = fsrsJsonSchema.parse(JSON.parse(data));
+      return {
+        stability: parsed.s,
+        difficulty: parsed.d,
+        desiredRetention: parsed.dr ?? 0.9,
+      };
     } catch {
-      // Not JSON — try interpreting as binary if it contains non-printable chars
+      // Not JSON or wrong shape — try interpreting as binary if it contains non-printable chars
     }
   }
 

--- a/src/ankiParser/anki2/jsonParsers.ts
+++ b/src/ankiParser/anki2/jsonParsers.ts
@@ -29,3 +29,26 @@ export const modelSchema = z.record(
     ),
   }),
 );
+
+export const deckSchema = z.record(
+  z.object({
+    id: z.number(),
+    name: z.string().optional(),
+  }),
+);
+
+export const fsrsJsonSchema = z.object({
+  s: z.number(),
+  d: z.number(),
+  dr: z.number().optional(),
+});
+
+export const mediaMappingSchema = z.record(z.string());
+
+export const cachedFileEntrySchema = z.array(
+  z.object({
+    name: z.string(),
+    size: z.number(),
+    addedAt: z.number(),
+  }),
+);

--- a/src/ankiParser/unzipAnki.ts
+++ b/src/ankiParser/unzipAnki.ts
@@ -6,6 +6,7 @@ import { assertTruthy } from "../utils/assert";
 import mime from "mime";
 import { decompressZstd } from "../utils/zstd";
 import { parseMediaProto } from "./parseMediaProto";
+import { mediaMappingSchema } from "./anki2/jsonParsers";
 
 /**
  * Type guard to check if an Entry is a FileEntry (has getData method)
@@ -60,7 +61,7 @@ async function getFilesFromEntries(entries: Entry[]): Promise<Map<string, string
   const mediaFile = (() => {
     try {
       // Try parsing as JSON first (older format)
-      return JSON.parse(mediaFileText) as Record<number, string>;
+      return mediaMappingSchema.parse(JSON.parse(mediaFileText));
       // eslint-disable-next-line no-unused-vars
     } catch (_jsonError) {
       // If JSON parsing fails, try parsing as Protocol Buffer (newer .anki21b format)

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -4,6 +4,7 @@ import { ReviewQueue, type ReviewCard } from "./scheduler/queue";
 import { DEFAULT_SCHEDULER_SETTINGS, type SchedulerSettings } from "./scheduler/types";
 import { reviewDB } from "./scheduler/db";
 import type { DeckInfo } from "./types";
+import { cachedFileEntrySchema } from "./ankiParser/anki2/jsonParsers";
 
 // View state
 export type AppView = "files" | "review" | "create";
@@ -29,7 +30,7 @@ export const activeFileNameSig = ref<string | null>(null);
 const storedFiles = localStorage.getItem("anki-cached-files");
 if (storedFiles) {
   try {
-    cachedFilesSig.value = JSON.parse(storedFiles);
+    cachedFilesSig.value = cachedFileEntrySchema.parse(JSON.parse(storedFiles));
   } catch {
     // ignore corrupt data
   }


### PR DESCRIPTION
Replace `as` type assertions and manual `typeof` checks on `JSON.parse` results with Zod schema validation.

- Add `deckSchema`, `fsrsJsonSchema`, `mediaMappingSchema`, and `cachedFileEntrySchema` to `jsonParsers.ts`
- Update 6 call sites across src and cli to use `schema.parse()`