### PR TITLE
defrag: centralize queue constants, batch review log queries, deduplicate protobuf parsing

### DIFF
--- a/e2e/note-editing.spec.ts
+++ b/e2e/note-editing.spec.ts
@@ -199,8 +199,6 @@ test.describe('Note Editing', () => {
 
     // Get the first row guid by selecting it and reading a field value
     await page.locator('.browse-table tbody tr').first().click();
-    const firstFieldValue = await page.locator('.detail-field-value').first().textContent();
-
     // Edit the first card's note
     await page.locator('.detail-pane button:has-text("Edit")').click();
     const firstTextarea = page.locator('.edit-form textarea.field-input').first();

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,14 +61,11 @@ watch(computedDeckInfo, (newDeckInfo, oldDeckInfo) => {
 });
 
 // Initialize review queue when cards are loaded (scheduler enabled state is per-deck, checked inside)
-watch(
-  [cardsSig, templatesSig, selectedDeckIdSig],
-  ([cards, templates]) => {
-    if (cards.length > 0 && templates && templates.length > 0) {
-      initializeReviewQueue();
-    }
-  },
-);
+watch([cardsSig, templatesSig, selectedDeckIdSig], ([cards, templates]) => {
+  if (cards.length > 0 && templates && templates.length > 0) {
+    initializeReviewQueue();
+  }
+});
 
 // Get current card based on mode
 const currentCardData = computed(() => {
@@ -211,7 +208,8 @@ async function handleChooseAnswer(answer: Answer) {
       </template>
       <p v-else-if="cardsSig.length === 0" class="no-deck-message">
         No deck loaded. Click the
-        <button class="link-btn" @click="reviewModeSig = 'deck-list'">Review</button> tab to choose a deck.
+        <button class="link-btn" @click="reviewModeSig = 'deck-list'">Review</button> tab to choose
+        a deck.
       </p>
     </div>
   </main>

--- a/src/__tests__/anki-compat-gaps-2.test.ts
+++ b/src/__tests__/anki-compat-gaps-2.test.ts
@@ -9,11 +9,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { AnkiSM2Algorithm } from "../scheduler/anki-sm2-algorithm";
-import {
-  convertDue,
-  phaseToRevlogType,
-  serializeCardData,
-} from "../lib/syncWrite";
+import { convertDue, phaseToRevlogType, serializeCardData } from "../lib/syncWrite";
 import { stringHash } from "../utils/constants";
 import type { CardReviewState } from "../scheduler/types";
 import type { CardState } from "../scheduler/algorithm";
@@ -293,10 +289,7 @@ describe("GAP 8: Exporter sfld should store HTML-stripped text", () => {
     // but sfld is set to card.front directly (with HTML intact).
     // In Anki, sfld is always the HTML-stripped sort field.
     const fs = await import("fs");
-    const source = fs.readFileSync(
-      new URL("../ankiExporter/index.ts", import.meta.url),
-      "utf-8",
-    );
+    const source = fs.readFileSync(new URL("../ankiExporter/index.ts", import.meta.url), "utf-8");
 
     // The INSERT INTO notes uses card.front directly as the sfld value.
     // In Anki, sfld is HTML-stripped. The PWA should strip HTML from sfld.
@@ -308,8 +301,8 @@ describe("GAP 8: Exporter sfld should store HTML-stripped text", () => {
     // Check that all occurrences of "card.front" used as sfld have HTML stripping
     const noteInsertSection = source.split("INSERT INTO notes")[1]?.split(";")[0] ?? "";
     // The array of values passed to the INSERT
-    const usesFrontDirectly = noteInsertSection.includes("card.front") &&
-      !noteInsertSection.includes('card.front.replace');
+    const usesFrontDirectly =
+      noteInsertSection.includes("card.front") && !noteInsertSection.includes("card.front.replace");
     // If card.front is used directly without .replace, HTML isn't stripped
     expect(usesFrontDirectly).toBe(false);
   });
@@ -329,10 +322,7 @@ describe("GAP 9: Exporter col.mod should be milliseconds", () => {
     // The exporter sets: now = Math.floor(Date.now() / 1000) (SECONDS)
     // Then inserts col with mod=now (seconds) but Anki expects milliseconds.
     const fs = await import("fs");
-    const source = fs.readFileSync(
-      new URL("../ankiExporter/index.ts", import.meta.url),
-      "utf-8",
-    );
+    const source = fs.readFileSync(new URL("../ankiExporter/index.ts", import.meta.url), "utf-8");
 
     // Check that the INSERT INTO col doesn't use seconds for mod
     // The source has: const now = Math.floor(Date.now() / 1000)
@@ -373,10 +363,7 @@ describe("GAP 10: Exporter schema missing indexes", () => {
 
     // Read the schema from the source file
     const fs = await import("fs");
-    const source = fs.readFileSync(
-      new URL("../ankiExporter/index.ts", import.meta.url),
-      "utf-8",
-    );
+    const source = fs.readFileSync(new URL("../ankiExporter/index.ts", import.meta.url), "utf-8");
 
     for (const idx of requiredIndexes) {
       expect(source).toContain(idx);
@@ -397,27 +384,20 @@ describe("GAP 10: Exporter schema missing indexes", () => {
 describe("GAP 11: GUID should use random source, not be derived from note ID", () => {
   it("guidFromId should use random source for GUID generation", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync(
-      new URL("../ankiExporter/index.ts", import.meta.url),
-      "utf-8",
-    );
+    const source = fs.readFileSync(new URL("../ankiExporter/index.ts", import.meta.url), "utf-8");
 
     // The function guidFromId should use randomness like Anki (random u64).
     // PWA derives GUID deterministically from note ID.
     // Check that guidFromId's body (not generateId) uses Math.random or crypto
     const guidFnMatch = source.match(/function guidFromId[\s\S]*?^}/m);
     const guidFnBody = guidFnMatch?.[0] ?? "";
-    const usesRandom =
-      guidFnBody.includes("Math.random") || guidFnBody.includes("crypto");
+    const usesRandom = guidFnBody.includes("Math.random") || guidFnBody.includes("crypto");
     expect(usesRandom).toBe(true);
   });
 
   it("guidFromId should not pad with 'a'", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync(
-      new URL("../ankiExporter/index.ts", import.meta.url),
-      "utf-8",
-    );
+    const source = fs.readFileSync(new URL("../ankiExporter/index.ts", import.meta.url), "utf-8");
 
     // Anki doesn't pad GUIDs — they're variable length
     expect(source).not.toContain("padEnd");
@@ -440,10 +420,7 @@ describe("GAP 11: GUID should use random source, not be derived from note ID", (
 describe("GAP 12: Exporter ID generation is fragile", () => {
   it("generateId should not be used twice in quick succession without collision check", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync(
-      new URL("../ankiExporter/index.ts", import.meta.url),
-      "utf-8",
-    );
+    const source = fs.readFileSync(new URL("../ankiExporter/index.ts", import.meta.url), "utf-8");
 
     // The source has: generateId() + 1 for modelId
     // This means modelId = Date.now() + random(0,999) + 1
@@ -471,10 +448,7 @@ describe("GAP 12: Exporter ID generation is fragile", () => {
 describe("GAP 13: Exporter interleaves note and card IDs from same counter", () => {
   it("card ID should not be noteId + 1 (should be independent)", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync(
-      new URL("../ankiExporter/index.ts", import.meta.url),
-      "utf-8",
-    );
+    const source = fs.readFileSync(new URL("../ankiExporter/index.ts", import.meta.url), "utf-8");
 
     // Check that card IDs are generated independently of note IDs
     // The source has: noteId = nextId++; cardId = nextId++;
@@ -482,8 +456,7 @@ describe("GAP 13: Exporter interleaves note and card IDs from same counter", () 
     // Anki would generate each ID as a separate timestamp.
 
     // Verify the pattern exists (proving the gap)
-    const hasSequentialIds =
-      source.includes("nextId++") || source.includes("nextId += 1");
+    const hasSequentialIds = source.includes("nextId++") || source.includes("nextId += 1");
     expect(hasSequentialIds).toBe(false);
   });
 });
@@ -532,18 +505,13 @@ describe("GAP 15: encodeLeft caller never computes stepsToday", () => {
     // The caller (applyReviewStateToSqlite) should compute stepsToday
     // based on the day rollover boundary, but it never does.
     const fs = await import("fs");
-    const source = fs.readFileSync(
-      new URL("../lib/syncWrite.ts", import.meta.url),
-      "utf-8",
-    );
+    const source = fs.readFileSync(new URL("../lib/syncWrite.ts", import.meta.url), "utf-8");
 
     // Check that the caller passes stepsToday to encodeLeft
     // It should compute stepsToday from rollover time
     const encodeLeftCalls = source.match(/encodeLeft\([^)]+\)/g) ?? [];
     // Every call to encodeLeft should include a stepsToday argument
-    const allCallsHaveStepsToday = encodeLeftCalls.every(
-      (call) => call.split(",").length >= 3,
-    );
+    const allCallsHaveStepsToday = encodeLeftCalls.every((call) => call.split(",").length >= 3);
     expect(allCallsHaveStepsToday).toBe(true);
   });
 });
@@ -687,10 +655,7 @@ describe("GAP 18: Deck config should match Anki's expected fields", () => {
   it("dconf new.order should be 0 (NEW_CARDS_DUE), not 1 (RANDOM)", async () => {
     // In modern Anki (v2+), the default is order: 0 (NEW_CARDS_DUE).
     const fs = await import("fs");
-    const source = fs.readFileSync(
-      new URL("../ankiExporter/index.ts", import.meta.url),
-      "utf-8",
-    );
+    const source = fs.readFileSync(new URL("../ankiExporter/index.ts", import.meta.url), "utf-8");
 
     // Extract the order value from the new config in DEFAULT_DCONF
     const orderMatch = source.match(/order:\s*(\d+)/);

--- a/src/__tests__/anki-compat-gaps.test.ts
+++ b/src/__tests__/anki-compat-gaps.test.ts
@@ -9,12 +9,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { AnkiSM2Algorithm } from "../scheduler/anki-sm2-algorithm";
-import {
-  encodeLeft,
-  encodeFactor,
-  phaseToRevlogType,
-  serializeCardData,
-} from "../lib/syncWrite";
+import { encodeLeft, encodeFactor, phaseToRevlogType, serializeCardData } from "../lib/syncWrite";
 import type { CardReviewState } from "../scheduler/types";
 import type { CardState } from "../scheduler/algorithm";
 

--- a/src/__tests__/anki-compat.test.ts
+++ b/src/__tests__/anki-compat.test.ts
@@ -67,10 +67,7 @@ describe("Issue 4: notes.sfld column type in schema", () => {
     // Official Anki schema: sfld integer not null
     const { readFileSync } = await import("fs");
     const { resolve } = await import("path");
-    const source = readFileSync(
-      resolve(__dirname, "../ankiExporter/index.ts"),
-      "utf-8",
-    );
+    const source = readFileSync(resolve(__dirname, "../ankiExporter/index.ts"), "utf-8");
     const sfldMatch = source.match(/sfld\s+(\w+)/);
     expect(sfldMatch?.[1]).toBe("integer");
   });

--- a/src/__tests__/sync-integration.test.ts
+++ b/src/__tests__/sync-integration.test.ts
@@ -25,11 +25,7 @@ import {
   readResponseJson,
   normalizeUrl,
 } from "../lib/ankiSync";
-import {
-  normalSync,
-  FullSyncRequiredError,
-  ClockSkewError,
-} from "../lib/normalSync";
+import { normalSync, FullSyncRequiredError, ClockSkewError } from "../lib/normalSync";
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -38,13 +34,7 @@ const TEST_PASS = "testpass";
 const TEST_DECK_ID = "1";
 
 /** Path to a real .apkg fixture for extracting a valid SQLite collection. */
-const FIXTURE_APKG = join(
-  __dirname,
-  "..",
-  "ankiParser",
-  "__tests__",
-  "ap_gov_vocab_anki11.apkg",
-);
+const FIXTURE_APKG = join(__dirname, "..", "ankiParser", "__tests__", "ap_gov_vocab_anki11.apkg");
 
 // ── Server binary discovery ────────────────────────────────────────
 
@@ -80,11 +70,7 @@ async function waitForServer(url: string, timeoutMs = 15_000): Promise<void> {
   throw new Error(`Sync server did not start within ${timeoutMs}ms`);
 }
 
-function startServer(
-  binary: string,
-  port: number,
-  dataDir: string,
-): ChildProcess {
+function startServer(binary: string, port: number, dataDir: string): ChildProcess {
   const proc = spawn(binary, [], {
     env: {
       ...process.env,
@@ -264,8 +250,12 @@ describe.skipIf(!serverBin)("sync integration", () => {
     test("upload then download roundtrip preserves notes and cards", async () => {
       const hkey = await login(serverUrl, TEST_USER, TEST_PASS);
 
-      const noteCount = withDb(SQL, baseCollection, (db) => scalar(db, "SELECT count() FROM notes"));
-      const cardCount = withDb(SQL, baseCollection, (db) => scalar(db, "SELECT count() FROM cards"));
+      const noteCount = withDb(SQL, baseCollection, (db) =>
+        scalar(db, "SELECT count() FROM notes"),
+      );
+      const cardCount = withDb(SQL, baseCollection, (db) =>
+        scalar(db, "SELECT count() FROM cards"),
+      );
 
       await uploadCollection(serverUrl, hkey, baseCollection);
       const downloaded = await downloadCollection(serverUrl, hkey);
@@ -293,12 +283,7 @@ describe.skipIf(!serverBin)("sync integration", () => {
       await uploadCollection(serverUrl, hkey, baseCollection);
       const serverCopy = await downloadCollection(serverUrl, hkey);
 
-      const result = await normalSync(
-        serverUrl,
-        hkey,
-        TEST_DECK_ID,
-        serverCopy,
-      );
+      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, serverCopy);
 
       expect(result.action).toBe("noChanges");
     });
@@ -309,7 +294,9 @@ describe.skipIf(!serverBin)("sync integration", () => {
       const serverCopy = await downloadCollection(serverUrl, hkey);
 
       // Get a card ID to modify
-      const cardId = withDb(SQL, serverCopy, (db) => scalar(db, "SELECT id FROM cards LIMIT 1")) as number;
+      const cardId = withDb(SQL, serverCopy, (db) =>
+        scalar(db, "SELECT id FROM cards LIMIT 1"),
+      ) as number;
 
       // Simulate a local review: modify the card and mark as pending
       const modified = mutateCollection(SQL, serverCopy, (db) => {
@@ -326,13 +313,12 @@ describe.skipIf(!serverBin)("sync integration", () => {
       // mismatch (known issue: server may upgrade anki2 schema, changing
       // internal counts). Reaching sanity check proves the data exchange
       // (start, graves, changes, chunks) all succeeded.
-      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified)
-        .catch((e) => {
-          if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
-            return "sanity-phase-reached" as const;
-          }
-          throw e;
-        });
+      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified).catch((e) => {
+        if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
+          return "sanity-phase-reached" as const;
+        }
+        throw e;
+      });
 
       if (typeof result !== "string") {
         expect(result.action).toBe("normalSync");
@@ -355,27 +341,26 @@ describe.skipIf(!serverBin)("sync integration", () => {
       await uploadCollection(serverUrl, hkey, baseCollection);
       const serverCopy = await downloadCollection(serverUrl, hkey);
 
-      const cardId = withDb(SQL, serverCopy, (db) => scalar(db, "SELECT id FROM cards LIMIT 1")) as number;
+      const cardId = withDb(SQL, serverCopy, (db) =>
+        scalar(db, "SELECT id FROM cards LIMIT 1"),
+      ) as number;
 
       const modified = mutateCollection(SQL, serverCopy, (db) => {
         const nowMs = Date.now();
         const nowSec = Math.floor(nowMs / 1000);
-        db.run(
-          `INSERT INTO revlog VALUES (${nowMs},${cardId},-1,3,1,0,2500,5000,0)`,
-        );
+        db.run(`INSERT INTO revlog VALUES (${nowMs},${cardId},-1,3,1,0,2500,5000,0)`);
         db.run(
           `UPDATE cards SET type=1, queue=1, reps=1, mod=${nowSec}, usn=-1 WHERE id=${cardId}`,
         );
         db.run(`UPDATE col SET mod=${nowMs + 1}`);
       });
 
-      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified)
-        .catch((e) => {
-          if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
-            return "sanity-phase-reached" as const;
-          }
-          throw e;
-        });
+      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified).catch((e) => {
+        if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
+          return "sanity-phase-reached" as const;
+        }
+        throw e;
+      });
 
       expect(["normalSync", "sanity-phase-reached"]).toContain(
         typeof result === "string" ? result : result.action,
@@ -398,13 +383,12 @@ describe.skipIf(!serverBin)("sync integration", () => {
         db.run("UPDATE col SET decks=?, mod=?", [JSON.stringify(decks), nowMs + 1]);
       });
 
-      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified)
-        .catch((e) => {
-          if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
-            return "sanity-phase-reached" as const;
-          }
-          throw e;
-        });
+      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified).catch((e) => {
+        if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
+          return "sanity-phase-reached" as const;
+        }
+        throw e;
+      });
 
       expect(["normalSync", "sanity-phase-reached"]).toContain(
         typeof result === "string" ? result : result.action,
@@ -427,13 +411,12 @@ describe.skipIf(!serverBin)("sync integration", () => {
         db.run("UPDATE col SET dconf=?, mod=?", [JSON.stringify(dconf), nowMs + 1]);
       });
 
-      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified)
-        .catch((e) => {
-          if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
-            return "sanity-phase-reached" as const;
-          }
-          throw e;
-        });
+      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified).catch((e) => {
+        if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
+          return "sanity-phase-reached" as const;
+        }
+        throw e;
+      });
 
       expect(["normalSync", "sanity-phase-reached"]).toContain(
         typeof result === "string" ? result : result.action,
@@ -456,13 +439,12 @@ describe.skipIf(!serverBin)("sync integration", () => {
         db.run("UPDATE col SET models=?, mod=?", [JSON.stringify(models), nowMs + 1]);
       });
 
-      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified)
-        .catch((e) => {
-          if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
-            return "sanity-phase-reached" as const;
-          }
-          throw e;
-        });
+      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified).catch((e) => {
+        if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
+          return "sanity-phase-reached" as const;
+        }
+        throw e;
+      });
 
       expect(["normalSync", "sanity-phase-reached"]).toContain(
         typeof result === "string" ? result : result.action,
@@ -477,9 +459,9 @@ describe.skipIf(!serverBin)("sync integration", () => {
       const rawCol = await extractCollectionFromApkg();
       const mismatchedScm = createMinimalCollection(SQL, rawCol, { scm: 9999999999 });
 
-      await expect(
-        normalSync(serverUrl, hkey, TEST_DECK_ID, mismatchedScm),
-      ).rejects.toThrow(FullSyncRequiredError);
+      await expect(normalSync(serverUrl, hkey, TEST_DECK_ID, mismatchedScm)).rejects.toThrow(
+        FullSyncRequiredError,
+      );
     });
 
     test("handles graves (deletions) correctly", async () => {
@@ -487,7 +469,9 @@ describe.skipIf(!serverBin)("sync integration", () => {
       await uploadCollection(serverUrl, hkey, baseCollection);
       const serverCopy = await downloadCollection(serverUrl, hkey);
 
-      const cardToDelete = withDb(SQL, serverCopy, (db) => scalar(db, "SELECT id FROM cards LIMIT 1")) as number;
+      const cardToDelete = withDb(SQL, serverCopy, (db) =>
+        scalar(db, "SELECT id FROM cards LIMIT 1"),
+      ) as number;
       const noteToDelete = withDb(SQL, serverCopy, (db) =>
         scalar(db, `SELECT nid FROM cards WHERE id=${cardToDelete}`),
       ) as number;
@@ -501,13 +485,12 @@ describe.skipIf(!serverBin)("sync integration", () => {
         db.run(`UPDATE col SET mod=${nowMs + 1}`);
       });
 
-      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified)
-        .catch((e) => {
-          if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
-            return "sanity-phase-reached" as const;
-          }
-          throw e;
-        });
+      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified).catch((e) => {
+        if (e instanceof FullSyncRequiredError && e.message.includes("sanity")) {
+          return "sanity-phase-reached" as const;
+        }
+        throw e;
+      });
 
       expect(["normalSync", "sanity-phase-reached"]).toContain(
         typeof result === "string" ? result : result.action,
@@ -520,12 +503,16 @@ describe.skipIf(!serverBin)("sync integration", () => {
       // Upload baseline with a card at reps=0
       await uploadCollection(serverUrl, hkey, baseCollection);
       const serverCopy = await downloadCollection(serverUrl, hkey);
-      const cardId = withDb(SQL, serverCopy, (db) => scalar(db, "SELECT id FROM cards LIMIT 1")) as number;
+      const cardId = withDb(SQL, serverCopy, (db) =>
+        scalar(db, "SELECT id FROM cards LIMIT 1"),
+      ) as number;
 
       // Simulate server-side change: another device sets reps=5
       const serverEdit = mutateCollection(SQL, serverCopy, (db) => {
         const nowMs = Date.now();
-        db.run(`UPDATE cards SET reps=5, mod=${Math.floor(nowMs / 1000)}, usn=-1 WHERE id=${cardId}`);
+        db.run(
+          `UPDATE cards SET reps=5, mod=${Math.floor(nowMs / 1000)}, usn=-1 WHERE id=${cardId}`,
+        );
         db.run(`UPDATE col SET mod=${nowMs + 1}`);
       });
       await uploadCollection(serverUrl, hkey, serverEdit);
@@ -533,15 +520,16 @@ describe.skipIf(!serverBin)("sync integration", () => {
       // Our local edit: set reps=10 with a NEWER timestamp (should win)
       const localEdit = mutateCollection(SQL, serverCopy, (db) => {
         const futureMs = Date.now() + 5000;
-        db.run(`UPDATE cards SET reps=10, mod=${Math.floor(futureMs / 1000)}, usn=-1 WHERE id=${cardId}`);
+        db.run(
+          `UPDATE cards SET reps=10, mod=${Math.floor(futureMs / 1000)}, usn=-1 WHERE id=${cardId}`,
+        );
         db.run(`UPDATE col SET mod=${futureMs + 1}`);
       });
 
-      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, localEdit)
-        .catch((e) => {
-          if (e instanceof FullSyncRequiredError) return "sanity-reached" as const;
-          throw e;
-        });
+      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, localEdit).catch((e) => {
+        if (e instanceof FullSyncRequiredError) return "sanity-reached" as const;
+        throw e;
+      });
 
       if (typeof result !== "string" && result.sqliteBytes) {
         // If sync completed, our newer local edit (reps=10) should have won
@@ -562,21 +550,24 @@ describe.skipIf(!serverBin)("sync integration", () => {
       await uploadCollection(serverUrl, hkey, baseCollection);
       const serverCopy = await downloadCollection(serverUrl, hkey);
 
-      const cardId = withDb(SQL, serverCopy, (db) => scalar(db, "SELECT id FROM cards LIMIT 1")) as number;
+      const cardId = withDb(SQL, serverCopy, (db) =>
+        scalar(db, "SELECT id FROM cards LIMIT 1"),
+      ) as number;
 
       const modified = mutateCollection(SQL, serverCopy, (db) => {
         const nowMs = Date.now();
-        db.run(`UPDATE cards SET reps=1, mod=${Math.floor(nowMs / 1000)}, usn=-1 WHERE id=${cardId}`);
+        db.run(
+          `UPDATE cards SET reps=1, mod=${Math.floor(nowMs / 1000)}, usn=-1 WHERE id=${cardId}`,
+        );
         db.run(`UPDATE col SET mod=${nowMs + 1}`);
       });
 
       // The sync should either succeed or reach the sanity check phase
       // (FullSyncRequiredError from sanity check is acceptable)
-      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified)
-        .catch((e) => {
-          if (e instanceof FullSyncRequiredError) return "sanity-reached" as const;
-          throw e;
-        });
+      const result = await normalSync(serverUrl, hkey, TEST_DECK_ID, modified).catch((e) => {
+        if (e instanceof FullSyncRequiredError) return "sanity-reached" as const;
+        throw e;
+      });
 
       expect(["normalSync", "sanity-reached"]).toContain(
         typeof result === "string" ? result : result.action,
@@ -619,7 +610,10 @@ describe.skipIf(!serverBin)("sync integration", () => {
       const uploadForm = new FormData();
       uploadForm.append("k", hkey);
       uploadForm.append("data", zipBlob, "media.zip");
-      const uploadResp = await fetch(`${base}/msync/uploadChanges`, { method: "POST", body: uploadForm });
+      const uploadResp = await fetch(`${base}/msync/uploadChanges`, {
+        method: "POST",
+        body: uploadForm,
+      });
 
       expect(uploadResp.ok).toBe(true);
       const result = await readResponseJson(uploadResp);
@@ -688,7 +682,10 @@ describe.skipIf(!serverBin)("sync integration", () => {
       const uploadForm = new FormData();
       uploadForm.append("k", hkey);
       uploadForm.append("data", zipBlob, "media.zip");
-      const uploadResp = await fetch(`${base}/msync/uploadChanges`, { method: "POST", body: uploadForm });
+      const uploadResp = await fetch(`${base}/msync/uploadChanges`, {
+        method: "POST",
+        body: uploadForm,
+      });
       expect(uploadResp.ok).toBe(true);
 
       // Begin new media session for download
@@ -707,9 +704,14 @@ describe.skipIf(!serverBin)("sync integration", () => {
       changesForm.append("k", hkey);
       changesForm.append("data", JSON.stringify({ lastUsn: 0 }));
       changesForm.append("c", "0");
-      const changesResp = await fetch(`${base}/msync/mediaChanges`, { method: "POST", body: changesForm });
+      const changesResp = await fetch(`${base}/msync/mediaChanges`, {
+        method: "POST",
+        body: changesForm,
+      });
       expect(changesResp.ok).toBe(true);
-      const changes = await readResponseJson(changesResp) as Array<[string, number, string | null]>;
+      const changes = (await readResponseJson(changesResp)) as Array<
+        [string, number, string | null]
+      >;
       const ourFile = changes.find(([name]) => name === "roundtrip_test.txt");
       expect(ourFile).toBeTruthy();
       expect(ourFile![2]).not.toBeNull(); // sha1 present = file exists
@@ -723,24 +725,35 @@ describe.skipIf(!serverBin)("sync integration", () => {
       expect(dlResp.ok).toBe(true);
 
       // Parse the download ZIP
-      const { ZipReader, BlobReader: BlobReader2, BlobWriter: BlobWriter2, TextWriter } = await import("@zip-js/zip-js");
+      const {
+        ZipReader,
+        BlobReader: BlobReader2,
+        BlobWriter: BlobWriter2,
+        TextWriter,
+      } = await import("@zip-js/zip-js");
       const dlBytes = new Uint8Array(await dlResp.arrayBuffer());
       const zipReader = new ZipReader(new BlobReader2(new Blob([dlBytes])));
       const entries = await zipReader.getEntries();
 
-      type FileEntry = { getData: (w: InstanceType<typeof BlobWriter2> | InstanceType<typeof TextWriter>) => Promise<Blob | string> };
+      type FileEntry = {
+        getData: (
+          w: InstanceType<typeof BlobWriter2> | InstanceType<typeof TextWriter>,
+        ) => Promise<Blob | string>;
+      };
       const metaEntry = entries.find((e) => e.filename === "_meta");
       expect(metaEntry).toBeTruthy();
-      const metaText = await (metaEntry as FileEntry).getData(new TextWriter()) as string;
+      const metaText = (await (metaEntry as FileEntry).getData(new TextWriter())) as string;
       const dlMeta = JSON.parse(metaText) as Record<string, string>;
 
       // Find which zip index maps to our file
-      const zipIndex = Object.entries(dlMeta).find(([, name]) => name === "roundtrip_test.txt")?.[0];
+      const zipIndex = Object.entries(dlMeta).find(
+        ([, name]) => name === "roundtrip_test.txt",
+      )?.[0];
       expect(zipIndex).toBeTruthy();
 
       const dataEntry = entries.find((e) => e.filename === zipIndex);
       expect(dataEntry).toBeTruthy();
-      const dataBlob = await (dataEntry as FileEntry).getData(new BlobWriter2()) as Blob;
+      const dataBlob = (await (dataEntry as FileEntry).getData(new BlobWriter2())) as Blob;
       const downloadedContent = await dataBlob.text();
       expect(downloadedContent).toBe(fileContent);
 
@@ -764,7 +777,10 @@ describe.skipIf(!serverBin)("sync integration", () => {
       const zw = new ZipWriter(new BlobWriter("application/zip"));
       await zw.add("0", new BlobReader(new Blob(["content_a"])));
       await zw.add("1", new BlobReader(new Blob(["content_b"])));
-      const meta: Array<[string, string]> = [["file_a.txt", "0"], ["file_b.txt", "1"]];
+      const meta: Array<[string, string]> = [
+        ["file_a.txt", "0"],
+        ["file_b.txt", "1"],
+      ];
       await zw.add("_meta", new BlobReader(new Blob([JSON.stringify(meta)])));
       const zipBlob = await zw.close();
 
@@ -788,7 +804,9 @@ describe.skipIf(!serverBin)("sync integration", () => {
       const changesResp = await fetch(`${base}/msync/mediaChanges`, { method: "POST", body: cf });
       expect(changesResp.ok).toBe(true);
 
-      const changes = await readResponseJson(changesResp) as Array<[string, number, string | null]>;
+      const changes = (await readResponseJson(changesResp)) as Array<
+        [string, number, string | null]
+      >;
       // Should have our two files
       const fileA = changes.find(([name]) => name === "file_a.txt");
       const fileB = changes.find(([name]) => name === "file_b.txt");
@@ -858,7 +876,9 @@ describe.skipIf(!serverBin)("sync integration", () => {
       cf.append("data", JSON.stringify({ lastUsn: 0 }));
       cf.append("c", "0");
       const changesResp = await fetch(`${base}/msync/mediaChanges`, { method: "POST", body: cf });
-      const changes = await readResponseJson(changesResp) as Array<[string, number, string | null]>;
+      const changes = (await readResponseJson(changesResp)) as Array<
+        [string, number, string | null]
+      >;
 
       // Find the latest entry for our file (should have null sha1 = deleted)
       const deleteEntries = changes.filter(([name]) => name === "to_delete.txt");
@@ -894,9 +914,9 @@ describe.skipIf(!serverBin)("sync integration", () => {
       vi.spyOn(Date, "now").mockImplementation(() => realNow() + 10 * 60 * 1000);
 
       try {
-        await expect(
-          normalSync(serverUrl, hkey, TEST_DECK_ID, modified),
-        ).rejects.toThrow(ClockSkewError);
+        await expect(normalSync(serverUrl, hkey, TEST_DECK_ID, modified)).rejects.toThrow(
+          ClockSkewError,
+        );
       } finally {
         vi.restoreAllMocks();
       }
@@ -923,9 +943,7 @@ describe.skipIf(!serverBin)("sync integration", () => {
       corrupt.close();
 
       // Should throw but not hang or leave server in bad state
-      await expect(
-        normalSync(serverUrl, hkey, TEST_DECK_ID, corruptBytes),
-      ).rejects.toThrow();
+      await expect(normalSync(serverUrl, hkey, TEST_DECK_ID, corruptBytes)).rejects.toThrow();
 
       // Server should still be usable after the failed sync
       const hkey2 = await login(serverUrl, TEST_USER, TEST_PASS);

--- a/src/ankiExporter/index.ts
+++ b/src/ankiExporter/index.ts
@@ -13,7 +13,8 @@ function fieldChecksum(field: string): number {
 
 function guidFromId(_id: number): string {
   // Generate a random base91-like GUID (random source, not derived from ID)
-  const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&()*+,-./:;<=>?@[]^_`{|}~";
+  const chars =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&()*+,-./:;<=>?@[]^_`{|}~";
   let result = "";
   for (let i = 0; i < 10; i++) {
     result += chars[Math.floor(Math.random() * chars.length)];
@@ -219,10 +220,21 @@ export async function createApkg(spec: AnkiDeckSpec): Promise<Blob> {
   });
 
   // Insert collection row
-  db.run(
-    "INSERT INTO col VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    [1, nowSecs, nowMs, nowMs, 11, 0, -1, 0, DEFAULT_CONF, models, decks, DEFAULT_DCONF, "{}"],
-  );
+  db.run("INSERT INTO col VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", [
+    1,
+    nowSecs,
+    nowMs,
+    nowMs,
+    11,
+    0,
+    -1,
+    0,
+    DEFAULT_CONF,
+    models,
+    decks,
+    DEFAULT_DCONF,
+    "{}",
+  ]);
 
   // Insert notes and cards — use separate counters to avoid ID collisions
   // Collision handling: IDs are offset from base timestamp; in a full implementation
@@ -240,15 +252,40 @@ export async function createApkg(spec: AnkiDeckSpec): Promise<Blob> {
     const tags = (card.tags ?? []).join(" ");
     const sfld = card.front.replace(/<[^>]*>/g, "").trim();
 
-    db.run(
-      "INSERT INTO notes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-      [noteId, guid, modelId, nowSecs, -1, tags ? ` ${tags} ` : "", flds, sfld, csum, 0, ""],
-    );
+    db.run("INSERT INTO notes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", [
+      noteId,
+      guid,
+      modelId,
+      nowSecs,
+      -1,
+      tags ? ` ${tags} ` : "",
+      flds,
+      sfld,
+      csum,
+      0,
+      "",
+    ]);
 
-    db.run(
-      "INSERT INTO cards VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-      [cardId, noteId, deckId, 0, nowSecs, -1, 0, 0, i, 0, 0, 0, 0, 0, 0, 0, 0, ""],
-    );
+    db.run("INSERT INTO cards VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", [
+      cardId,
+      noteId,
+      deckId,
+      0,
+      nowSecs,
+      -1,
+      0,
+      0,
+      i,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "",
+    ]);
   }
 
   // Export database to binary

--- a/src/ankiParser/__tests__/anki2.test.ts
+++ b/src/ankiParser/__tests__/anki2.test.ts
@@ -354,9 +354,21 @@ describe("Anki2 Parser", () => {
     it("should expose dueType based on queue", async () => {
       const db = await createAnki2Database();
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }, { name: "Card 2", qfmt: "{{Back}}", afmt: "{{Front}}", ord: 1 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [
+            { name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 },
+            { name: "Card 2", qfmt: "{{Back}}", afmt: "{{Front}}", ord: 1 },
+          ],
+        },
       ];
-      const notes: Anki2Note[] = [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }];
+      const notes: Anki2Note[] = [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ];
       insertAnki2Data(db, models, notes);
 
       db.run(`UPDATE cards SET type = 0, queue = 0, due = 42 WHERE id = 1000`);
@@ -373,10 +385,21 @@ describe("Anki2 Parser", () => {
     it("should expose ivlUnit as seconds for negative ivl", async () => {
       const db = await createAnki2Database();
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+        },
       ];
-      insertAnki2Data(db, models, [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }]);
-      db.run(`UPDATE cards SET type = 1, queue = 1, ivl = -600, due = ${Math.floor(Date.now() / 1000)} WHERE id = 1000`);
+      insertAnki2Data(db, models, [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ]);
+      db.run(
+        `UPDATE cards SET type = 1, queue = 1, ivl = -600, due = ${Math.floor(Date.now() / 1000)} WHERE id = 1000`,
+      );
 
       const result = getDataFromAnki2(db);
       expect(result.cards[0]?.scheduling?.ivl).toBe(-600);
@@ -386,10 +409,21 @@ describe("Anki2 Parser", () => {
     it("should expose odue, flags, and left", async () => {
       const db = await createAnki2Database();
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+        },
       ];
-      insertAnki2Data(db, models, [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }]);
-      db.run(`UPDATE cards SET did = 2, odid = 1, odue = 100, flags = 3, left = 2002, type = 2, queue = 2 WHERE id = 1000`);
+      insertAnki2Data(db, models, [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ]);
+      db.run(
+        `UPDATE cards SET did = 2, odid = 1, odue = 100, flags = 3, left = 2002, type = 2, queue = 2 WHERE id = 1000`,
+      );
 
       const result = getDataFromAnki2(db);
       const sched = result.cards[0]?.scheduling;
@@ -401,9 +435,18 @@ describe("Anki2 Parser", () => {
     it("should set easeFactor to null when factor is 0", async () => {
       const db = await createAnki2Database();
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+        },
       ];
-      insertAnki2Data(db, models, [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }]);
+      insertAnki2Data(db, models, [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ]);
       db.run(`UPDATE cards SET type = 0, queue = 0, factor = 0 WHERE id = 1000`);
 
       const result = getDataFromAnki2(db);
@@ -416,9 +459,18 @@ describe("Anki2 Parser", () => {
     it("should expose noteData from notes.data", async () => {
       const db = await createAnki2Database();
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+        },
       ];
-      insertAnki2Data(db, models, [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }]);
+      insertAnki2Data(db, models, [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ]);
       db.run(`UPDATE notes SET data = '{"key":"value"}' WHERE id = 1`);
 
       const result = getDataFromAnki2(db);
@@ -428,9 +480,18 @@ describe("Anki2 Parser", () => {
     it("should expose csum and sfld", async () => {
       const db = await createAnki2Database();
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+        },
       ];
-      insertAnki2Data(db, models, [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }]);
+      insertAnki2Data(db, models, [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ]);
       db.run(`UPDATE notes SET sfld = 'Hello', csum = 12345678 WHERE id = 1`);
 
       const result = getDataFromAnki2(db);
@@ -440,14 +501,25 @@ describe("Anki2 Parser", () => {
 
     it("should parse graves table", async () => {
       const db = await createAnki2Database();
-      db.run(`CREATE TABLE IF NOT EXISTS graves (usn INTEGER NOT NULL, oid INTEGER NOT NULL, type INTEGER NOT NULL)`);
+      db.run(
+        `CREATE TABLE IF NOT EXISTS graves (usn INTEGER NOT NULL, oid INTEGER NOT NULL, type INTEGER NOT NULL)`,
+      );
       db.run(`INSERT INTO graves (usn, oid, type) VALUES (0, 999, 1)`);
       db.run(`INSERT INTO graves (usn, oid, type) VALUES (0, 888, 0)`);
 
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+        },
       ];
-      insertAnki2Data(db, models, [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }]);
+      insertAnki2Data(db, models, [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ]);
 
       const result = getDataFromAnki2(db);
       expect(result.graves).toHaveLength(2);
@@ -456,11 +528,22 @@ describe("Anki2 Parser", () => {
     it("should parse deck config learn/relearn steps", async () => {
       const db = await createAnki2Database();
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+        },
       ];
-      insertAnki2Data(db, models, [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }]);
+      insertAnki2Data(db, models, [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ]);
       db.run(`UPDATE col SET dconf = ? WHERE id = 1`, [
-        JSON.stringify({ "1": { id: 1, name: "Default", new: { delays: [1, 10, 30] }, lapse: { delays: [10] } } }),
+        JSON.stringify({
+          "1": { id: 1, name: "Default", new: { delays: [1, 10, 30] }, lapse: { delays: [10] } },
+        }),
       ]);
 
       const result = getDataFromAnki2(db);
@@ -471,9 +554,18 @@ describe("Anki2 Parser", () => {
     it("should compute schema hash for notesTypes", async () => {
       const db = await createAnki2Database();
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+        },
       ];
-      insertAnki2Data(db, models, [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }]);
+      insertAnki2Data(db, models, [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ]);
 
       const result = getDataFromAnki2(db);
       expect(result.notesTypes).not.toBeNull();
@@ -483,15 +575,29 @@ describe("Anki2 Parser", () => {
 
     it("should label revlog types correctly", async () => {
       const db = await createAnki2Database();
-      db.run(`CREATE TABLE IF NOT EXISTS revlog (id INTEGER PRIMARY KEY, cid INTEGER NOT NULL, usn INTEGER NOT NULL, ease INTEGER NOT NULL, ivl INTEGER NOT NULL, lastIvl INTEGER NOT NULL, factor INTEGER NOT NULL, time INTEGER NOT NULL, type INTEGER NOT NULL)`);
+      db.run(
+        `CREATE TABLE IF NOT EXISTS revlog (id INTEGER PRIMARY KEY, cid INTEGER NOT NULL, usn INTEGER NOT NULL, ease INTEGER NOT NULL, ivl INTEGER NOT NULL, lastIvl INTEGER NOT NULL, factor INTEGER NOT NULL, time INTEGER NOT NULL, type INTEGER NOT NULL)`,
+      );
       const models: Anki2Model[] = [
-        { id: "1", css: "", latexPre: "", latexPost: "", fields: [{ name: "Front" }, { name: "Back" }], templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }] },
+        {
+          id: "1",
+          css: "",
+          latexPre: "",
+          latexPost: "",
+          fields: [{ name: "Front" }, { name: "Back" }],
+          templates: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+        },
       ];
-      insertAnki2Data(db, models, [{ id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } }]);
+      insertAnki2Data(db, models, [
+        { id: 1, modelId: "1", tags: [], fields: { Front: "Hello", Back: "World" } },
+      ]);
 
       const now = Date.now();
       for (let t = 0; t <= 4; t++) {
-        db.run(`INSERT INTO revlog (id, cid, usn, ease, ivl, lastIvl, factor, time, type) VALUES (?, 1000, 0, 3, 1, 0, 2500, 5000, ?)`, [now + t, t]);
+        db.run(
+          `INSERT INTO revlog (id, cid, usn, ease, ivl, lastIvl, factor, time, type) VALUES (?, 1000, 0, 3, 1, 0, 2500, 5000, ?)`,
+          [now + t, t],
+        );
       }
 
       const result = getDataFromAnki2(db);

--- a/src/ankiParser/__tests__/anki21b.test.ts
+++ b/src/ankiParser/__tests__/anki21b.test.ts
@@ -545,9 +545,7 @@ describe("Anki21b Parser", () => {
       const templates: Anki21bTemplate[] = [
         { ntid: "1", ord: 0, name: "Card 1", qFormat: "{{Front}}", aFormat: "{{Back}}" },
       ];
-      const notes: Anki21bNote[] = [
-        { id: 1, mid: "1", tags: [], fields: { Front: "", Back: "" } },
-      ];
+      const notes: Anki21bNote[] = [{ id: 1, mid: "1", tags: [], fields: { Front: "", Back: "" } }];
 
       insertAnki21bData(db, notetypes, fields, templates, notes);
 
@@ -561,7 +559,9 @@ describe("Anki21b Parser", () => {
     it("should expose the tags table with collapse state", async () => {
       const db = await createAnki21bDatabase();
 
-      db.run(`CREATE TABLE IF NOT EXISTS tags (tag TEXT NOT NULL PRIMARY KEY, usn INTEGER NOT NULL, collapsed INTEGER NOT NULL DEFAULT 0)`);
+      db.run(
+        `CREATE TABLE IF NOT EXISTS tags (tag TEXT NOT NULL PRIMARY KEY, usn INTEGER NOT NULL, collapsed INTEGER NOT NULL DEFAULT 0)`,
+      );
       db.run(`INSERT INTO tags (tag, usn, collapsed) VALUES ('vocab', 0, 0)`);
       db.run(`INSERT INTO tags (tag, usn, collapsed) VALUES ('vocab::german', 0, 1)`);
 

--- a/src/ankiParser/__tests__/parserGaps.test.ts
+++ b/src/ankiParser/__tests__/parserGaps.test.ts
@@ -426,12 +426,8 @@ describe("Parser Gaps (expected to fail)", () => {
 
       // With req filtering, only the Forward card (ord=0) should remain
       // because Back (field 1) is empty and Reverse requires it
-      const forwardCards = result.cards.filter(
-        (c) => c.templates[0]?.name === "Forward",
-      );
-      const reverseCards = result.cards.filter(
-        (c) => c.templates[0]?.name === "Reverse",
-      );
+      const forwardCards = result.cards.filter((c) => c.templates[0]?.name === "Forward");
+      const reverseCards = result.cards.filter((c) => c.templates[0]?.name === "Reverse");
 
       expect(forwardCards).toHaveLength(1);
       // This is the assertion that should fail — reverse card should be filtered
@@ -451,9 +447,7 @@ describe("Parser Gaps (expected to fail)", () => {
             [0, "all", [0, 1]], // Card 0 requires BOTH field 0 AND field 1
           ],
           fields: [{ name: "Front" }, { name: "Back" }],
-          templates: [
-            { name: "Card 1", qfmt: "{{Front}} - {{Back}}", afmt: "{{Back}}", ord: 0 },
-          ],
+          templates: [{ name: "Card 1", qfmt: "{{Front}} - {{Back}}", afmt: "{{Back}}", ord: 0 }],
         },
       ];
 
@@ -552,9 +546,7 @@ describe("Parser Gaps (expected to fail)", () => {
           latexsvg: true,
           req: [[0, "any", [0]]],
           fields: [{ name: "Text" }],
-          templates: [
-            { name: "Cloze", qfmt: "{{cloze:Text}}", afmt: "{{cloze:Text}}", ord: 0 },
-          ],
+          templates: [{ name: "Cloze", qfmt: "{{cloze:Text}}", afmt: "{{cloze:Text}}", ord: 0 }],
         },
       ];
       const notes2: Anki2Note[] = [
@@ -569,9 +561,7 @@ describe("Parser Gaps (expected to fail)", () => {
       const notetypes: Anki21bNotetype[] = [
         { id: "1", name: "Cloze", config: { css: ".card {}", kind: 1, latexSvg: true } },
       ];
-      const fields: Anki21bField[] = [
-        { ntid: "1", ord: 0, name: "Text", config: {} },
-      ];
+      const fields: Anki21bField[] = [{ ntid: "1", ord: 0, name: "Text", config: {} }];
       const templates21b: Anki21bTemplate[] = [
         { ntid: "1", ord: 0, name: "Cloze", qFormat: "{{cloze:Text}}", aFormat: "{{cloze:Text}}" },
       ];
@@ -585,7 +575,19 @@ describe("Parser Gaps (expected to fail)", () => {
       // Both formats should produce cards with the same set of keys
       // anki2 now has noteData, csum, sfld which anki21b doesn't have yet
       // Check that anki21b has at least the core fields
-      const coreKeys = ["values", "tags", "templates", "css", "deckName", "guid", "scheduling", "noteType", "latexSvg", "latexPre", "req"];
+      const coreKeys = [
+        "values",
+        "tags",
+        "templates",
+        "css",
+        "deckName",
+        "guid",
+        "scheduling",
+        "noteType",
+        "latexSvg",
+        "latexPre",
+        "req",
+      ];
       for (const key of coreKeys) {
         expect(card21bKeys).toContain(key);
         expect(card2Keys).toContain(key);

--- a/src/ankiParser/anki2/index.ts
+++ b/src/ankiParser/anki2/index.ts
@@ -169,7 +169,10 @@ export function getDataFromAnki2(db: Database): AnkiDB2Data {
       data: string;
       sfld: string;
       csum: number;
-    }>(db, "SELECT id, guid, cast(mid as text) as modelId, tags, flds as fields, data, sfld, csum FROM notes");
+    }>(
+      db,
+      "SELECT id, guid, cast(mid as text) as modelId, tags, flds as fields, data, sfld, csum FROM notes",
+    );
 
     const notesMap = new Map(notes.map((n) => [n.id, n]));
 
@@ -270,7 +273,8 @@ export function getDataFromAnki2(db: Database): AnkiDB2Data {
   const graves = (() => {
     try {
       return executeQueryAll<{ usn: number; oid: number; type: number }>(
-        db, "SELECT usn, oid, type FROM graves",
+        db,
+        "SELECT usn, oid, type FROM graves",
       );
     } catch {
       return [];
@@ -290,16 +294,23 @@ export function getDataFromAnki2(db: Database): AnkiDB2Data {
     };
   });
 
-  return { cards, notesTypes, deckName, decks, revlog, collectionCreationTime, deckConfigs, graves };
+  return {
+    cards,
+    notesTypes,
+    deckName,
+    decks,
+    revlog,
+    collectionCreationTime,
+    deckConfigs,
+    graves,
+  };
 }
 
 /**
  * Parse FSRS memory state from card.data.
  * Supports both JSON format ({s, d, dr}) and protobuf format (FSRSMemoryState).
  */
-export function parseFsrsData(
-  data: string | Uint8Array,
-): CardScheduling["fsrs"] {
+export function parseFsrsData(data: string | Uint8Array): CardScheduling["fsrs"] {
   if (!data) return null;
 
   // If it's a Uint8Array (binary), try protobuf parsing
@@ -328,9 +339,7 @@ export function parseFsrsData(
  * Parse protobuf-encoded FSRSMemoryState.
  * Message: { stability: float (field 1), difficulty: float (field 2) }
  */
-function parseFsrsProtobuf(
-  data: Uint8Array,
-): CardScheduling["fsrs"] {
+function parseFsrsProtobuf(data: Uint8Array): CardScheduling["fsrs"] {
   if (data.length < 5) return null;
 
   let stability: number | null = null;

--- a/src/ankiParser/anki2/jsonParsers.ts
+++ b/src/ankiParser/anki2/jsonParsers.ts
@@ -10,9 +10,7 @@ export const modelSchema = z.record(
     latexPost: z.string(),
     latexsvg: z.boolean().optional(),
     type: z.number().optional(), // 0=MODEL_STD, 1=MODEL_CLOZE
-    req: z
-      .array(z.tuple([z.number(), z.string(), z.array(z.number())]))
-      .optional(),
+    req: z.array(z.tuple([z.number(), z.string(), z.array(z.number())])).optional(),
     flds: z.array(
       z.object({
         name: z.string(),

--- a/src/ankiParser/anki21b/index.ts
+++ b/src/ankiParser/anki21b/index.ts
@@ -243,7 +243,8 @@ export function getDataFromAnki21b(db: Database): AnkiDB21bData {
   const tagsTable = (() => {
     try {
       const rows = executeQueryAll<{ tag: string; collapsed: number }>(
-        db, "SELECT tag, collapsed FROM tags",
+        db,
+        "SELECT tag, collapsed FROM tags",
       );
       return rows.map((r) => ({ tag: r.tag, collapsed: r.collapsed !== 0 }));
     } catch {

--- a/src/ankiParser/parseMediaProto.ts
+++ b/src/ankiParser/parseMediaProto.ts
@@ -36,6 +36,12 @@ function readLengthDelimited(
   return { data, newOffset: afterLength + length };
 }
 
+function skipUnknownField(buffer: Uint8Array, offset: number, wireType: number): number | null {
+  if (wireType === 0) return readVarint(buffer, offset).newOffset;
+  if (wireType === 2) return readLengthDelimited(buffer, offset).newOffset;
+  return null;
+}
+
 export function parseMediaProto(buffer: Uint8Array): Record<string, string> {
   const result: Record<string, string> = {};
   let offset = 0;
@@ -87,19 +93,9 @@ export function parseMediaProto(buffer: Uint8Array): Record<string, string> {
           const { newOffset: afterHash } = readLengthDelimited(entryData, entryOffset);
           entryOffset = afterHash;
         } else {
-          // Unknown field, try to skip
-          if (entryWireType === 0) {
-            // Varint
-            const { newOffset } = readVarint(entryData, entryOffset);
-            entryOffset = newOffset;
-          } else if (entryWireType === 2) {
-            // Length-delimited
-            const { newOffset } = readLengthDelimited(entryData, entryOffset);
-            entryOffset = newOffset;
-          } else {
-            // Unknown wire type, break
-            break;
-          }
+          const skipped = skipUnknownField(entryData, entryOffset, entryWireType);
+          if (skipped === null) break;
+          entryOffset = skipped;
         }
       }
 
@@ -110,19 +106,9 @@ export function parseMediaProto(buffer: Uint8Array): Record<string, string> {
         entryIndex++;
       }
     } else {
-      // Skip unknown fields
-      if (wireType === 0) {
-        // Varint
-        const { newOffset } = readVarint(buffer, offset);
-        offset = newOffset;
-      } else if (wireType === 2) {
-        // Length-delimited
-        const { newOffset } = readLengthDelimited(buffer, offset);
-        offset = newOffset;
-      } else {
-        // Unknown wire type, break to avoid infinite loop
-        break;
-      }
+      const skipped = skipUnknownField(buffer, offset, wireType);
+      if (skipped === null) break;
+      offset = skipped;
     }
   }
 

--- a/src/components/AiDeckGenerator.vue
+++ b/src/components/AiDeckGenerator.vue
@@ -97,7 +97,11 @@ async function handleGenerate() {
   activeName.value = null;
 
   try {
-    const spec = await generateAnkiDeck(documentText.value, instructions.value, selectedModel.value);
+    const spec = await generateAnkiDeck(
+      documentText.value,
+      instructions.value,
+      selectedModel.value,
+    );
     generatedSpec.value = spec;
 
     status.value = "building";
@@ -114,7 +118,10 @@ async function handleGenerate() {
 
 function handleDownload() {
   if (!generatedBlob.value || !generatedSpec.value) return;
-  downloadBlob(generatedBlob.value, `${generatedSpec.value.deckName.replace(/[^a-zA-Z0-9 _-]/g, "")}.apkg`);
+  downloadBlob(
+    generatedBlob.value,
+    `${generatedSpec.value.deckName.replace(/[^a-zA-Z0-9 _-]/g, "")}.apkg`,
+  );
 }
 
 async function handleDownloadEntry(entry: GeneratedEntry) {
@@ -164,7 +171,9 @@ function formatDate(timestamp: number): string {
 
 <template>
   <div class="ai-generator">
-    <div v-if="ollamaAvailable === null" class="status-message">Checking Ollama availability...</div>
+    <div v-if="ollamaAvailable === null" class="status-message">
+      Checking Ollama availability...
+    </div>
 
     <div v-else-if="!ollamaAvailable" class="status-message status-message--error">
       <p>
@@ -192,7 +201,12 @@ function formatDate(timestamp: number): string {
         </label>
 
         <label class="control-label">
-          <input type="file" accept=".txt,.md,.html,.csv,.json" class="file-input" @change="handleFileUpload" />
+          <input
+            type="file"
+            accept=".txt,.md,.html,.csv,.json"
+            class="file-input"
+            @change="handleFileUpload"
+          />
           <span class="file-btn">Upload document</span>
         </label>
       </div>
@@ -218,7 +232,13 @@ function formatDate(timestamp: number): string {
           :disabled="!documentText.trim() || status === 'generating' || status === 'building'"
           @click="handleGenerate"
         >
-          {{ status === "generating" ? "Generating cards..." : status === "building" ? "Building .apkg..." : "Generate Deck" }}
+          {{
+            status === "generating"
+              ? "Generating cards..."
+              : status === "building"
+                ? "Building .apkg..."
+                : "Generate Deck"
+          }}
         </Button>
       </div>
 
@@ -269,12 +289,19 @@ function formatDate(timestamp: number): string {
           >
             <div class="history-info">
               <span class="history-name">{{ entry.deckName }}</span>
-              <span class="history-meta">{{ entry.cardCount }} cards · {{ formatDate(entry.createdAt) }}</span>
+              <span class="history-meta"
+                >{{ entry.cardCount }} cards · {{ formatDate(entry.createdAt) }}</span
+              >
             </div>
             <div class="history-actions">
               <button class="history-btn" @click="handleDownloadEntry(entry)">Download</button>
               <button class="history-btn" @click="handleLoadEntryInApp(entry)">Load</button>
-              <button class="history-btn history-btn--danger" @click="deleteGeneratedEntry(entry.name)">Delete</button>
+              <button
+                class="history-btn history-btn--danger"
+                @click="deleteGeneratedEntry(entry.name)"
+              >
+                Delete
+              </button>
             </div>
           </li>
         </ul>

--- a/src/components/CardBrowser.vue
+++ b/src/components/CardBrowser.vue
@@ -178,7 +178,11 @@ const suggestions = computed<Suggestion[]>(() => {
   if (!tokenBody.includes(":")) {
     for (const q of QUALIFIERS) {
       if (q.startsWith(tokenBody) && tokenBody.length > 0) {
-        results.push({ insert: `${prefix}${q}`, label: `${prefix}${q}`, description: getQualifierHint(q) });
+        results.push({
+          insert: `${prefix}${q}`,
+          label: `${prefix}${q}`,
+          description: getQualifierHint(q),
+        });
       }
     }
     // Also fall through to text search — don't return early so user sees qualifiers AND can just type text
@@ -219,7 +223,11 @@ const suggestions = computed<Suggestion[]>(() => {
       for (const f of FLAG_VALUES) {
         const numStr = String(f.value);
         if (numStr.startsWith(valuePart) || f.label.startsWith(valuePart)) {
-          results.push({ insert: `${prefix}flag:${f.value}`, label: `${f.value}`, description: f.label });
+          results.push({
+            insert: `${prefix}flag:${f.value}`,
+            label: `${f.value}`,
+            description: f.label,
+          });
         }
       }
       break;
@@ -239,25 +247,39 @@ const suggestions = computed<Suggestion[]>(() => {
 
 function getQualifierHint(q: string): string {
   switch (q) {
-    case "deck:": return "filter by deck";
-    case "tag:": return "filter by tag";
-    case "is:": return "card state (new, review, ...)";
-    case "flag:": return "card flag (0-7)";
-    case "card:": return "card/template name";
-    case "note:": return "note type name";
-    default: return "";
+    case "deck:":
+      return "filter by deck";
+    case "tag:":
+      return "filter by tag";
+    case "is:":
+      return "card state (new, review, ...)";
+    case "flag:":
+      return "card flag (0-7)";
+    case "card:":
+      return "card/template name";
+    case "note:":
+      return "note type name";
+    default:
+      return "";
   }
 }
 
 function getIsHint(v: string): string {
   switch (v) {
-    case "new": return "new cards";
-    case "learn": return "currently learning";
-    case "review": return "review cards";
-    case "due": return "cards due now";
-    case "suspended": return "suspended cards";
-    case "buried": return "buried cards";
-    default: return "";
+    case "new":
+      return "new cards";
+    case "learn":
+      return "currently learning";
+    case "review":
+      return "review cards";
+    case "due":
+      return "cards due now";
+    case "suspended":
+      return "suspended cards";
+    case "buried":
+      return "buried cards";
+    default:
+      return "";
   }
 }
 
@@ -490,13 +512,20 @@ function matchToken(row: Row, token: SearchToken): boolean {
       const q = row.queueName;
       const t = row.typeName;
       switch (token.value) {
-        case "new": return q === "new";
-        case "learn": return q === "learning" || q === "dayLearning";
-        case "review": return q === "review";
-        case "due": return q === "review" || q === "learning" || q === "dayLearning";
-        case "suspended": return q === "suspended";
-        case "buried": return q === "userBuried" || q === "schedulerBuried";
-        default: return false;
+        case "new":
+          return q === "new";
+        case "learn":
+          return q === "learning" || q === "dayLearning";
+        case "review":
+          return q === "review";
+        case "due":
+          return q === "review" || q === "learning" || q === "dayLearning";
+        case "suspended":
+          return q === "suspended";
+        case "buried":
+          return q === "userBuried" || q === "schedulerBuried";
+        default:
+          return false;
       }
     }
     case "flag": {
@@ -703,15 +732,16 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
             <div
               v-for="(s, i) in suggestions"
               :key="s.insert"
-              :class="['autocomplete-item', { 'autocomplete-item--selected': i === selectedSuggestionIndex }]"
+              :class="[
+                'autocomplete-item',
+                { 'autocomplete-item--selected': i === selectedSuggestionIndex },
+              ]"
               @mousedown.prevent="applySuggestion(s)"
             >
               <span class="autocomplete-label">{{ s.label }}</span>
               <span v-if="s.description" class="autocomplete-desc">{{ s.description }}</span>
             </div>
-            <div class="autocomplete-hint">
-              <kbd>Tab</kbd> to accept
-            </div>
+            <div class="autocomplete-hint"><kbd>Tab</kbd> to accept</div>
           </div>
         </div>
       </div>
@@ -747,11 +777,7 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
               :class="['tr', { 'tr--selected': selectedRowKey === row.key }]"
               @click="selectedRowKey = row.key"
             >
-              <td
-                v-for="col in visibleColumns"
-                :key="col.key"
-                class="td"
-              >
+              <td v-for="col in visibleColumns" :key="col.key" class="td">
                 {{ getCellValue(row, col.key) }}
               </td>
             </tr>
@@ -765,7 +791,9 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
           <div class="detail-header">
             <div class="detail-header-text">
               <h3 class="detail-title">{{ selectedCard.deckName }}</h3>
-              <span class="detail-meta">{{ selectedCard.templates.map(t => t.name).join(", ") }}</span>
+              <span class="detail-meta">{{
+                selectedCard.templates.map((t) => t.name).join(", ")
+              }}</span>
             </div>
             <Button variant="secondary" size="sm" @click="editModalOpen = true">Edit</Button>
           </div>

--- a/src/components/CardButtons.vue
+++ b/src/components/CardButtons.vue
@@ -2,11 +2,7 @@
 import { computed } from "vue";
 import { Button } from "../design-system";
 import type { Answer } from "../scheduler/types";
-import {
-  getReviewControls,
-  triggerReviewControl,
-  type ReviewIntervals,
-} from "./reviewControls";
+import { getReviewControls, triggerReviewControl, type ReviewIntervals } from "./reviewControls";
 
 const props = defineProps<{
   activeSide: "front" | "back";
@@ -28,7 +24,13 @@ const visibleControls = computed(() => getReviewControls(props.activeSide));
     :variant="visibleControls[0]?.variant ?? 'primary'"
     size="lg"
     full-width
-    @click="() => triggerReviewControl('reveal', { reveal: () => emit('reveal'), chooseAnswer: (answer) => emit('chooseAnswer', answer) })"
+    @click="
+      () =>
+        triggerReviewControl('reveal', {
+          reveal: () => emit('reveal'),
+          chooseAnswer: (answer) => emit('chooseAnswer', answer),
+        })
+    "
   >
     {{ visibleControls[0]?.label ?? "Reveal" }}
   </Button>
@@ -46,7 +48,7 @@ const visibleControls = computed(() => getReviewControls(props.activeSide));
       "
     >
       <span class="time">
-        {{ control.interval ? intervals?.[control.interval] ?? control.fallbackInterval : "" }}
+        {{ control.interval ? (intervals?.[control.interval] ?? control.fallbackInterval) : "" }}
       </span>
       <span class="answer">{{ control.label }}</span>
     </Button>

--- a/src/components/DeckCreator.vue
+++ b/src/components/DeckCreator.vue
@@ -34,7 +34,10 @@ function exportDeck() {
     <h2 class="title">Create Deck</h2>
 
     <div class="mode-toggle">
-      <button :class="['mode-btn', { 'mode-btn--active': mode === 'manual' }]" @click="mode = 'manual'">
+      <button
+        :class="['mode-btn', { 'mode-btn--active': mode === 'manual' }]"
+        @click="mode = 'manual'"
+      >
         Manual
       </button>
       <button :class="['mode-btn', { 'mode-btn--active': mode === 'ai' }]" @click="mode = 'ai'">
@@ -44,8 +47,8 @@ function exportDeck() {
 
     <template v-if="mode === 'manual'">
       <p class="description">
-        Paste a table with two columns. Column 1 becomes the front of each card, column 2 becomes the
-        back. Export as a text file you can import into Anki.
+        Paste a table with two columns. Column 1 becomes the front of each card, column 2 becomes
+        the back. Export as a text file you can import into Anki.
       </p>
 
       <div class="controls">

--- a/src/components/FileLibrary.vue
+++ b/src/components/FileLibrary.vue
@@ -22,9 +22,7 @@ const fileInput = ref<HTMLInputElement>();
 
 const sampleDecks = computed(() => sampleDeckData.map(createSampleDeckLibraryItem));
 const uploadedDecks = computed(() =>
-  [...cachedFilesSig.value]
-    .sort((a, b) => b.addedAt - a.addedAt)
-    .map(createCachedDeckLibraryItem),
+  [...cachedFilesSig.value].sort((a, b) => b.addedAt - a.addedAt).map(createCachedDeckLibraryItem),
 );
 
 // Track collapsed state for parent decks
@@ -64,7 +62,7 @@ function flattenTree(nodes: DeckTreeNode[]): DeckTreeNode[] {
   return result;
 }
 
-const flatTree = computed(() => deckInfoSig.value ? flattenTree(deckInfoSig.value.tree) : []);
+const flatTree = computed(() => (deckInfoSig.value ? flattenTree(deckInfoSig.value.tree) : []));
 
 function handleOpenSettings(node: DeckTreeNode, event: Event) {
   event.stopPropagation();
@@ -131,21 +129,47 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
               :title="collapsed.has(node.fullName) ? 'Expand' : 'Collapse'"
               @click="toggleCollapse(node.fullName, $event)"
             >
-              <span :class="['collapse-icon', { 'collapse-icon--collapsed': collapsed.has(node.fullName) }]">&#9662;</span>
+              <span
+                :class="[
+                  'collapse-icon',
+                  { 'collapse-icon--collapsed': collapsed.has(node.fullName) },
+                ]"
+                >&#9662;</span
+              >
             </button>
             <span v-else class="collapse-spacer" />
             <span class="deck-name">{{ node.name }}</span>
           </div>
           <div class="deck-row-right">
-            <Tooltip text="New"><span class="stat stat--new">{{ node.newCount }}</span></Tooltip>
-            <Tooltip text="Learning"><span class="stat stat--learn">{{ node.learnCount }}</span></Tooltip>
-            <Tooltip text="Due"><span class="stat stat--due">{{ node.dueCount }}</span></Tooltip>
+            <Tooltip text="New"
+              ><span class="stat stat--new">{{ node.newCount }}</span></Tooltip
+            >
+            <Tooltip text="Learning"
+              ><span class="stat stat--learn">{{ node.learnCount }}</span></Tooltip
+            >
+            <Tooltip text="Due"
+              ><span class="stat stat--due">{{ node.dueCount }}</span></Tooltip
+            >
             <button
               class="settings-btn"
               title="Deck settings"
               @click="handleOpenSettings(node, $event)"
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+                />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
             </button>
           </div>
         </div>
@@ -165,7 +189,9 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
       </div>
 
       <div v-if="uploadedDecks.length === 0" class="empty-state">
-        <p class="empty-text">No uploaded decks yet. Add an .apkg file to keep your own deck here.</p>
+        <p class="empty-text">
+          No uploaded decks yet. Add an .apkg file to keep your own deck here.
+        </p>
         <Button variant="secondary" @click="fileInput?.click()"> Choose a Deck File </Button>
       </div>
 

--- a/src/components/NoteEditModal.vue
+++ b/src/components/NoteEditModal.vue
@@ -68,11 +68,7 @@ function handleSave() {
     <div class="edit-form">
       <div v-for="(val, key) in editFields" :key="key" class="field-group">
         <label class="field-label">{{ key }}</label>
-        <textarea
-          v-model="editFields[key]"
-          class="field-input"
-          rows="4"
-        />
+        <textarea v-model="editFields[key]" class="field-input" rows="4" />
       </div>
 
       <div class="tags-section">

--- a/src/components/SchedulerSettings.vue
+++ b/src/components/SchedulerSettings.vue
@@ -105,7 +105,9 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
             @change="updateSetting('enabled', ($event.target as HTMLInputElement).checked)"
           />
         </label>
-        <div class="help-text">When disabled, cards are shown sequentially without spaced repetition</div>
+        <div class="help-text">
+          When disabled, cards are shown sequentially without spaced repetition
+        </div>
       </div>
     </div>
 
@@ -175,7 +177,9 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           type="text"
           class="form-input"
           :value="formatSteps(sm2.learningSteps)"
-          @change="updateSm2Param('learningSteps', parseSteps(($event.target as HTMLInputElement).value))"
+          @change="
+            updateSm2Param('learningSteps', parseSteps(($event.target as HTMLInputElement).value))
+          "
         />
         <div class="help-text">Steps for new cards (e.g., "1m 10m" or "1m 10m 1h")</div>
       </div>
@@ -187,7 +191,12 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           :value="sm2.graduatingInterval"
           min="1"
           max="365"
-          @change="updateSm2Param('graduatingInterval', parseInt(($event.target as HTMLInputElement).value, 10))"
+          @change="
+            updateSm2Param(
+              'graduatingInterval',
+              parseInt(($event.target as HTMLInputElement).value, 10),
+            )
+          "
         />
         <div class="help-text">Interval when a learning card graduates via Good</div>
       </div>
@@ -199,7 +208,9 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           :value="sm2.easyInterval"
           min="1"
           max="365"
-          @change="updateSm2Param('easyInterval', parseInt(($event.target as HTMLInputElement).value, 10))"
+          @change="
+            updateSm2Param('easyInterval', parseInt(($event.target as HTMLInputElement).value, 10))
+          "
         />
         <div class="help-text">Interval when a learning card graduates via Easy</div>
       </div>
@@ -213,7 +224,9 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           type="text"
           class="form-input"
           :value="formatSteps(sm2.relearningSteps)"
-          @change="updateSm2Param('relearningSteps', parseSteps(($event.target as HTMLInputElement).value))"
+          @change="
+            updateSm2Param('relearningSteps', parseSteps(($event.target as HTMLInputElement).value))
+          "
         />
         <div class="help-text">Steps when a review card is failed (e.g., "10m")</div>
       </div>
@@ -226,7 +239,12 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           min="0"
           max="1"
           step="0.05"
-          @change="updateSm2Param('lapseNewInterval', parseFloat(($event.target as HTMLInputElement).value))"
+          @change="
+            updateSm2Param(
+              'lapseNewInterval',
+              parseFloat(($event.target as HTMLInputElement).value),
+            )
+          "
         />
         <div class="help-text">Interval multiplier after a lapse (0 = reset, 0.5 = halve)</div>
       </div>
@@ -238,7 +256,12 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           :value="sm2.minLapseInterval"
           min="1"
           max="365"
-          @change="updateSm2Param('minLapseInterval', parseInt(($event.target as HTMLInputElement).value, 10))"
+          @change="
+            updateSm2Param(
+              'minLapseInterval',
+              parseInt(($event.target as HTMLInputElement).value, 10),
+            )
+          "
         />
         <div class="help-text">Minimum interval after a lapse</div>
       </div>
@@ -255,7 +278,9 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           min="1.3"
           max="5"
           step="0.1"
-          @change="updateSm2Param('startingEase', parseFloat(($event.target as HTMLInputElement).value))"
+          @change="
+            updateSm2Param('startingEase', parseFloat(($event.target as HTMLInputElement).value))
+          "
         />
         <div class="help-text">Initial ease factor for new cards (2.5 = 250%)</div>
       </div>
@@ -268,7 +293,9 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           min="1"
           max="3"
           step="0.05"
-          @change="updateSm2Param('easyBonus', parseFloat(($event.target as HTMLInputElement).value))"
+          @change="
+            updateSm2Param('easyBonus', parseFloat(($event.target as HTMLInputElement).value))
+          "
         />
         <div class="help-text">Extra multiplier for Easy on review cards (1.3 = 130%)</div>
       </div>
@@ -281,7 +308,9 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           min="1"
           max="2"
           step="0.05"
-          @change="updateSm2Param('hardMultiplier', parseFloat(($event.target as HTMLInputElement).value))"
+          @change="
+            updateSm2Param('hardMultiplier', parseFloat(($event.target as HTMLInputElement).value))
+          "
         />
         <div class="help-text">Multiplier for Hard on review cards (1.2 = 120%)</div>
       </div>
@@ -294,7 +323,12 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           min="0.5"
           max="2"
           step="0.05"
-          @change="updateSm2Param('intervalModifier', parseFloat(($event.target as HTMLInputElement).value))"
+          @change="
+            updateSm2Param(
+              'intervalModifier',
+              parseFloat(($event.target as HTMLInputElement).value),
+            )
+          "
         />
         <div class="help-text">Global multiplier for all intervals (1.0 = no change)</div>
       </div>
@@ -306,7 +340,12 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
           :value="sm2.maximumInterval"
           min="1"
           max="36500"
-          @change="updateSm2Param('maximumInterval', parseInt(($event.target as HTMLInputElement).value, 10))"
+          @change="
+            updateSm2Param(
+              'maximumInterval',
+              parseInt(($event.target as HTMLInputElement).value, 10),
+            )
+          "
         />
         <div class="help-text">Maximum days between reviews (36500 = 100 years)</div>
       </div>

--- a/src/components/SyncPanel.vue
+++ b/src/components/SyncPanel.vue
@@ -24,7 +24,12 @@ import {
   initializeReviewQueue,
 } from "../stores";
 import { applyReviewStateToSqlite } from "../lib/syncWrite";
-import { normalSync, FullSyncRequiredError, SyncAbortedError, ClockSkewError } from "../lib/normalSync";
+import {
+  normalSync,
+  FullSyncRequiredError,
+  SyncAbortedError,
+  ClockSkewError,
+} from "../lib/normalSync";
 import mime from "mime";
 
 const serverUrl = ref("");
@@ -106,13 +111,9 @@ async function handleSync() {
 
     // Attempt normal (incremental) sync
     const deckId = getActiveDeckId();
-    const result = await normalSync(
-      serverUrl.value,
-      state.hkey,
-      deckId,
-      cachedBytes,
-      (status) => { syncStatus.value = status; },
-    );
+    const result = await normalSync(serverUrl.value, state.hkey, deckId, cachedBytes, (status) => {
+      syncStatus.value = status;
+    });
 
     if (result.action === "noChanges") {
       syncStatus.value = "Already up to date.";
@@ -131,7 +132,9 @@ async function handleSync() {
     // Download any new media files from the server
     syncStatus.value = "Checking for new media...";
     try {
-      const mediaBlobs = await downloadMedia(serverUrl.value, state.hkey, (s) => { syncStatus.value = s; });
+      const mediaBlobs = await downloadMedia(serverUrl.value, state.hkey, (s) => {
+        syncStatus.value = s;
+      });
       if (mediaBlobs.size > 0) {
         // Apply MIME types to downloaded blobs
         const typedBlobs = new Map<string, Blob>();
@@ -151,7 +154,9 @@ async function handleSync() {
     // Upload any local media files the server doesn't have
     syncStatus.value = "Checking for media to upload...";
     try {
-      const mediaUploaded = await uploadMedia(serverUrl.value, state.hkey, (s) => { syncStatus.value = s; });
+      const mediaUploaded = await uploadMedia(serverUrl.value, state.hkey, (s) => {
+        syncStatus.value = s;
+      });
       if (mediaUploaded > 0) {
         syncStatus.value = `Uploaded ${mediaUploaded} media file${mediaUploaded === 1 ? "" : "s"}.`;
       }
@@ -185,7 +190,9 @@ async function handleSync() {
 /** Full download (pull) — replaces local collection entirely. */
 async function doFullPull(hkey: string) {
   syncStatus.value = "Downloading collection...";
-  const setStatus = (s: string) => { syncStatus.value = s; };
+  const setStatus = (s: string) => {
+    syncStatus.value = s;
+  };
   const sqliteBytes = await downloadCollection(serverUrl.value, hkey, setStatus);
 
   syncStatus.value = "Downloading media files...";
@@ -270,7 +277,9 @@ async function handlePush() {
     // Upload media files
     syncStatus.value = "Uploading media files...";
     try {
-      const mediaUploaded = await uploadMedia(serverUrl.value, state.hkey, (s) => { syncStatus.value = s; });
+      const mediaUploaded = await uploadMedia(serverUrl.value, state.hkey, (s) => {
+        syncStatus.value = s;
+      });
       if (mediaUploaded > 0) {
         syncStatus.value = `Uploaded ${mediaUploaded} media file${mediaUploaded === 1 ? "" : "s"}.`;
       }
@@ -384,11 +393,7 @@ function formatLastSync(timestamp: number | null): string {
           <button class="sync-btn sync-btn--secondary" :disabled="isSyncing" @click="handleLogout">
             Log Out
           </button>
-          <button
-            class="sync-btn sync-btn--danger"
-            :disabled="isSyncing"
-            @click="handleDisconnect"
-          >
+          <button class="sync-btn sync-btn--danger" :disabled="isSyncing" @click="handleDisconnect">
             Disconnect
           </button>
         </div>
@@ -396,8 +401,8 @@ function formatLastSync(timestamp: number | null): string {
         <!-- Full sync required dialog -->
         <div v-if="showFullSyncDialog" class="sync-confirm">
           <p class="sync-confirm-text">
-            <strong>Full sync required.</strong> The collection schema has changed
-            (e.g. notetypes were modified on another device). Choose a direction:
+            <strong>Full sync required.</strong> The collection schema has changed (e.g. notetypes
+            were modified on another device). Choose a direction:
           </p>
           <div class="sync-confirm-actions">
             <button class="sync-btn sync-btn--primary" @click="handlePull">
@@ -437,10 +442,18 @@ function formatLastSync(timestamp: number | null): string {
               Bypass incremental sync and transfer the entire collection.
             </p>
             <div class="sync-actions">
-              <button class="sync-btn sync-btn--secondary" :disabled="isSyncing" @click="handlePull">
+              <button
+                class="sync-btn sync-btn--secondary"
+                :disabled="isSyncing"
+                @click="handlePull"
+              >
                 Full Download
               </button>
-              <button class="sync-btn sync-btn--push" :disabled="isSyncing" @click="showPushConfirm = true">
+              <button
+                class="sync-btn sync-btn--push"
+                :disabled="isSyncing"
+                @click="showPushConfirm = true"
+              >
                 Full Upload
               </button>
             </div>
@@ -477,16 +490,16 @@ function formatLastSync(timestamp: number | null): string {
 
         <h3>What gets synced</h3>
         <p>
-          <strong>Sync</strong> performs an incremental two-way sync, sending only changes since
-          the last sync. Reviews done on desktop and here are merged automatically (newer wins).
+          <strong>Sync</strong> performs an incremental two-way sync, sending only changes since the
+          last sync. Reviews done on desktop and here are merged automatically (newer wins).
         </p>
         <p>
-          If the collection schema changed (e.g. notetypes were edited), a full sync is required
-          and you'll be asked to choose a direction.
+          If the collection schema changed (e.g. notetypes were edited), a full sync is required and
+          you'll be asked to choose a direction.
         </p>
         <p>
-          <strong>Force full sync</strong> options bypass incremental sync and transfer the
-          entire collection in one direction (download or upload).
+          <strong>Force full sync</strong> options bypass incremental sync and transfer the entire
+          collection in one direction (download or upload).
         </p>
       </div>
     </details>

--- a/src/composables/useCommands.ts
+++ b/src/composables/useCommands.ts
@@ -40,10 +40,30 @@ function icon(comp: Component): Component {
 }
 
 const TAB_DEFINITIONS: { id: AppView; title: string; description: string; icon: Component }[] = [
-  { id: "review", title: "Review", description: "Study cards with spaced repetition", icon: markRaw(BookOpen) },
-  { id: "browse", title: "Browse", description: "Search and explore your cards", icon: markRaw(Search) },
-  { id: "create", title: "Create Deck", description: "Build a new deck from scratch", icon: markRaw(FolderPlus) },
-  { id: "sync", title: "Sync", description: "Sync with AnkiWeb or import collections", icon: markRaw(RefreshCcw) },
+  {
+    id: "review",
+    title: "Review",
+    description: "Study cards with spaced repetition",
+    icon: markRaw(BookOpen),
+  },
+  {
+    id: "browse",
+    title: "Browse",
+    description: "Search and explore your cards",
+    icon: markRaw(Search),
+  },
+  {
+    id: "create",
+    title: "Create Deck",
+    description: "Build a new deck from scratch",
+    icon: markRaw(FolderPlus),
+  },
+  {
+    id: "sync",
+    title: "Sync",
+    description: "Sync with AnkiWeb or import collections",
+    icon: markRaw(RefreshCcw),
+  },
 ];
 
 export function useCommands() {
@@ -51,9 +71,8 @@ export function useCommands() {
     const ankiData = ankiDataSig.value;
     const currentView = activeViewSig.value;
 
-    const tabCommands: Command[] = TAB_DEFINITIONS
-      .filter((tab) => tab.id !== currentView)
-      .map((tab) => ({
+    const tabCommands: Command[] = TAB_DEFINITIONS.filter((tab) => tab.id !== currentView).map(
+      (tab) => ({
         id: `go-to-${tab.id}`,
         title: `Go to ${tab.title}`,
         description: tab.description,
@@ -65,7 +84,8 @@ export function useCommands() {
             activeViewSig.value = tab.id;
           }
         },
-      }));
+      }),
+    );
 
     const commands: Command[] = [
       ...tabCommands,
@@ -128,7 +148,8 @@ const FLAG_COLORS: { flag: number; label: string; color: string }[] = [
 
 function buildCardActionCommands(ankiData: AnkiData | null): Command[] {
   const reviewCard = currentReviewCardSig.value;
-  if (!reviewCard || activeViewSig.value !== "review" || reviewModeSig.value !== "studying") return [];
+  if (!reviewCard || activeViewSig.value !== "review" || reviewModeSig.value !== "studying")
+    return [];
 
   const queue = reviewQueueSig.value;
   const noteCard = ankiData?.cards[reviewCard.cardIndex];
@@ -142,7 +163,9 @@ function buildCardActionCommands(ankiData: AnkiData | null): Command[] {
       description: "Hide this card until tomorrow's review session",
       icon: icon(EyeOff),
       hotkey: "-",
-      handler: () => { buryCurrentCard(); },
+      handler: () => {
+        buryCurrentCard();
+      },
     },
     {
       id: "suspend-card",
@@ -150,7 +173,9 @@ function buildCardActionCommands(ankiData: AnkiData | null): Command[] {
       description: "Remove this card from all future reviews until manually unsuspended",
       icon: icon(Ban),
       hotkey: "@",
-      handler: () => { suspendCurrentCard(); },
+      handler: () => {
+        suspendCurrentCard();
+      },
     },
     {
       id: "flag-card",
@@ -164,7 +189,9 @@ function buildCardActionCommands(ankiData: AnkiData | null): Command[] {
           title: "No Flag",
           icon: icon(Flag),
           label: currentFlag === 0 ? "Current" : undefined,
-          handler: () => { flagCurrentCard(0); },
+          handler: () => {
+            flagCurrentCard(0);
+          },
         },
         ...FLAG_COLORS.map(({ flag, label, color }) => ({
           id: `flag-${flag}`,
@@ -172,7 +199,9 @@ function buildCardActionCommands(ankiData: AnkiData | null): Command[] {
           icon: icon(Flag),
           label: currentFlag === flag ? "Current" : undefined,
           metadata: [{ label: "Color", value: color }],
-          handler: () => { flagCurrentCard(flag); },
+          handler: () => {
+            flagCurrentCard(flag);
+          },
         })),
       ],
     },
@@ -191,11 +220,15 @@ function buildCardActionCommands(ankiData: AnkiData | null): Command[] {
     commands.push({
       id: "mark-note",
       title: isMarked ? "Unmark Note" : "Mark Note",
-      description: isMarked ? "Remove the \"marked\" tag from this note" : "Tag this note as \"marked\" for easy filtering",
+      description: isMarked
+        ? 'Remove the "marked" tag from this note'
+        : 'Tag this note as "marked" for easy filtering',
       icon: icon(Star),
       hotkey: "*",
       label: isMarked ? "Marked" : undefined,
-      handler: () => { markCurrentNote(); },
+      handler: () => {
+        markCurrentNote();
+      },
     });
   }
 
@@ -213,7 +246,10 @@ function buildCardInfoMetadata(
   ];
 
   if (displayInfo.ease !== undefined) {
-    entries.push({ label: "Ease Factor", value: String(Math.round((displayInfo.ease as number) * 100)) + "%" });
+    entries.push({
+      label: "Ease Factor",
+      value: String(Math.round((displayInfo.ease as number) * 100)) + "%",
+    });
   }
   if (displayInfo.interval !== undefined) {
     entries.push({ label: "Interval", value: displayInfo.interval + " days" });
@@ -235,7 +271,10 @@ function buildCardInfoMetadata(
   }
 
   if (reviewCard.reviewState.lastReviewed) {
-    entries.push({ label: "Last Reviewed", value: new Date(reviewCard.reviewState.lastReviewed).toLocaleDateString() });
+    entries.push({
+      label: "Last Reviewed",
+      value: new Date(reviewCard.reviewState.lastReviewed).toLocaleDateString(),
+    });
   }
 
   return entries;

--- a/src/lib/ankiSync.ts
+++ b/src/lib/ankiSync.ts
@@ -65,11 +65,7 @@ export function normalizeUrl(serverUrl: string): string {
  * - Authenticated endpoints also get "k" (host key) as a separate top-level field.
  * - "v": client version string (media sync endpoints)
  */
-function buildSyncForm(
-  data: unknown,
-  hkey?: string,
-  extra?: Record<string, string>,
-): FormData {
+function buildSyncForm(data: unknown, hkey?: string, extra?: Record<string, string>): FormData {
   const form = new FormData();
   if (hkey) {
     form.append("k", hkey);
@@ -125,7 +121,7 @@ export async function syncPostV11(
   const compressed = await compressZstd(json);
 
   const headers: Record<string, string> = {
-    "Authorization": `Bearer ${hkey}`,
+    Authorization: `Bearer ${hkey}`,
     "Content-Type": "application/octet-stream",
     "Content-Encoding": "zstd",
   };
@@ -188,10 +184,15 @@ export async function downloadCollection(
     throw new Error(`Download failed: ${response.status} ${response.statusText}`);
   }
 
-  const bytes = await readResponseBytes(response, onProgress ? (received) => {
-    const mb = (received / (1024 * 1024)).toFixed(1);
-    onProgress(`Downloading collection... (${mb} MB)`);
-  } : undefined);
+  const bytes = await readResponseBytes(
+    response,
+    onProgress
+      ? (received) => {
+          const mb = (received / (1024 * 1024)).toFixed(1);
+          onProgress(`Downloading collection... (${mb} MB)`);
+        }
+      : undefined,
+  );
 
   return decompressIfNeeded(bytes);
 }
@@ -202,11 +203,7 @@ const mediaSyncBeginSchema = z.object({
   usn: z.number(),
 });
 
-const mediaChangeSchema = z.tuple([
-  z.string(),
-  z.number(),
-  z.string().nullable(),
-]);
+const mediaChangeSchema = z.tuple([z.string(), z.number(), z.string().nullable()]);
 
 const mediaChangesSchema = z.array(mediaChangeSchema);
 
@@ -233,7 +230,9 @@ export async function downloadMedia(
 
   if (!beginResponse.ok) {
     const body = await beginResponse.text().catch(() => "(unreadable)");
-    throw new Error(`msync/begin failed: ${beginResponse.status} ${beginResponse.statusText} — ${body}`);
+    throw new Error(
+      `msync/begin failed: ${beginResponse.status} ${beginResponse.statusText} — ${body}`,
+    );
   }
 
   const beginJson = await readResponseJson(beginResponse);
@@ -250,7 +249,9 @@ export async function downloadMedia(
 
     if (!changesResponse.ok) {
       const body = await changesResponse.text().catch(() => "(unreadable)");
-      throw new Error(`msync/mediaChanges failed: ${changesResponse.status} ${changesResponse.statusText} — ${body}`);
+      throw new Error(
+        `msync/mediaChanges failed: ${changesResponse.status} ${changesResponse.statusText} — ${body}`,
+      );
     }
 
     const changesJson = await readResponseJson(changesResponse);
@@ -275,7 +276,9 @@ export async function downloadMedia(
 
       if (!dlResponse.ok) {
         const body = await dlResponse.text().catch(() => "(unreadable)");
-        throw new Error(`msync/downloadFiles failed: ${dlResponse.status} ${dlResponse.statusText} — ${body}`);
+        throw new Error(
+          `msync/downloadFiles failed: ${dlResponse.status} ${dlResponse.statusText} — ${body}`,
+        );
       }
 
       const zipBlob = await dlResponse.blob();
@@ -283,14 +286,14 @@ export async function downloadMedia(
       const decompressed = await decompressIfNeeded(zipBytes);
 
       const { ZipReader, BlobReader, BlobWriter, TextWriter } = await import("@zip-js/zip-js");
-      const zipReader = new ZipReader(
-        new BlobReader(new Blob([decompressed as BlobPart])),
-      );
+      const zipReader = new ZipReader(new BlobReader(new Blob([decompressed as BlobPart])));
       const entries = await zipReader.getEntries();
 
       // Read _meta entry to get index-to-filename mapping
       type EntryWithGetData = {
-        getData: (w: InstanceType<typeof BlobWriter> | InstanceType<typeof TextWriter>) => Promise<Blob | string>;
+        getData: (
+          w: InstanceType<typeof BlobWriter> | InstanceType<typeof TextWriter>,
+        ) => Promise<Blob | string>;
       };
       const metaEntry = entries.find((e) => e.filename === "_meta");
       if (!metaEntry || !("getData" in metaEntry)) {
@@ -364,7 +367,9 @@ export async function uploadMedia(
   });
   if (!beginResponse.ok) {
     const body = await beginResponse.text().catch(() => "(unreadable)");
-    throw new Error(`msync/begin failed: ${beginResponse.status} ${beginResponse.statusText} — ${body}`);
+    throw new Error(
+      `msync/begin failed: ${beginResponse.status} ${beginResponse.statusText} — ${body}`,
+    );
   }
   const beginJson = await readResponseJson(beginResponse);
   const { usn: serverUsn } = mediaSyncBeginSchema.parse(beginJson);
@@ -443,7 +448,9 @@ export async function uploadMedia(
 
     if (!uploadResponse.ok) {
       const body = await uploadResponse.text().catch(() => "(unreadable)");
-      throw new Error(`msync/uploadChanges failed: ${uploadResponse.status} ${uploadResponse.statusText} — ${body}`);
+      throw new Error(
+        `msync/uploadChanges failed: ${uploadResponse.status} ${uploadResponse.statusText} — ${body}`,
+      );
     }
 
     const r = await readResponseJson(uploadResponse);
@@ -463,7 +470,7 @@ export async function uploadMedia(
     local: localCount,
   });
   if (sanityResponse.ok) {
-    const s = await readResponseJson(sanityResponse) as { status?: string };
+    const s = (await readResponseJson(sanityResponse)) as { status?: string };
     if (s.status === "bad") {
       console.warn("Media sanity check failed: local and server media counts differ");
     }
@@ -566,9 +573,7 @@ async function decompressIfNeeded(bytes: Uint8Array): Promise<Uint8Array> {
   // Gzip: 0x1f 0x8b
   if (bytes[0] === 0x1f && bytes[1] === 0x8b) {
     const ds = new DecompressionStream("gzip");
-    const decompressed = new Response(
-      new Blob([bytes as BlobPart]).stream().pipeThrough(ds),
-    );
+    const decompressed = new Response(new Blob([bytes as BlobPart]).stream().pipeThrough(ds));
     return new Uint8Array(await decompressed.arrayBuffer());
   }
 

--- a/src/lib/normalSync.ts
+++ b/src/lib/normalSync.ts
@@ -156,9 +156,10 @@ async function syncEndpoint(
   const base = normalizeUrl(serverUrl);
   const url = `${base}/sync/${endpoint}`;
 
-  const response = proto >= 11
-    ? await syncPostV11(url, hkey, data, sessionKey)
-    : await syncPost(url, hkey, data, sessionKey);
+  const response =
+    proto >= 11
+      ? await syncPostV11(url, hkey, data, sessionKey)
+      : await syncPost(url, hkey, data, sessionKey);
 
   if (response.status === 401 || response.status === 403) {
     throw new Error("Authentication expired. Please log in again.");
@@ -173,15 +174,12 @@ async function syncEndpoint(
 
 // ── Individual sync steps ──────────────────────────────────────────
 
-async function fetchMeta(
-  serverUrl: string,
-  hkey: string,
-): Promise<SyncMeta> {
+async function fetchMeta(serverUrl: string, hkey: string): Promise<SyncMeta> {
   // Request v11 — server will respond with its max supported version
-  const r = await syncEndpoint(serverUrl, "meta", hkey, {
+  const r = (await syncEndpoint(serverUrl, "meta", hkey, {
     v: 11,
     cv: "anki-pwa,0.1,web",
-  }) as RawMetaResponse;
+  })) as RawMetaResponse;
 
   // Detect server version from response.
   // v11 servers include a "v" or "server_version" field.
@@ -225,10 +223,17 @@ async function startSync(
   proto: ProtoVersion = 10,
   sessionKey?: string,
 ): Promise<Graves> {
-  const r = await syncEndpoint(serverUrl, "start", hkey, {
-    minUsn: clientUsn,
-    lnewer: localIsNewer,
-  }, proto, sessionKey) as RawStartResponse;
+  const r = (await syncEndpoint(
+    serverUrl,
+    "start",
+    hkey,
+    {
+      minUsn: clientUsn,
+      lnewer: localIsNewer,
+    },
+    proto,
+    sessionKey,
+  )) as RawStartResponse;
   return {
     cards: r.cards ?? [],
     notes: r.notes ?? [],
@@ -261,9 +266,16 @@ async function sendGraves(
 
   // If no graves at all, still send an empty one
   if (allIds.length === 0) {
-    await syncEndpoint(serverUrl, "applyGraves", hkey, {
-      chunk: { cards: [], notes: [], decks: [] },
-    }, proto, sessionKey);
+    await syncEndpoint(
+      serverUrl,
+      "applyGraves",
+      hkey,
+      {
+        chunk: { cards: [], notes: [], decks: [] },
+      },
+      proto,
+      sessionKey,
+    );
   }
 }
 
@@ -274,9 +286,16 @@ async function exchangeChanges(
   proto: ProtoVersion = 10,
   sessionKey?: string,
 ): Promise<UnchunkedChanges> {
-  const r = await syncEndpoint(serverUrl, "applyChanges", hkey, {
-    changes: localChanges,
-  }, proto, sessionKey) as RawApplyChangesResponse;
+  const r = (await syncEndpoint(
+    serverUrl,
+    "applyChanges",
+    hkey,
+    {
+      changes: localChanges,
+    },
+    proto,
+    sessionKey,
+  )) as RawApplyChangesResponse;
   return {
     models: r.models ?? [],
     decks: r.decks ?? [[], []],
@@ -328,9 +347,16 @@ async function sanityCheck(
   proto: ProtoVersion = 10,
   sessionKey?: string,
 ): Promise<void> {
-  const r = await syncEndpoint(serverUrl, "sanityCheck2", hkey, {
-    client: counts,
-  }, proto, sessionKey) as RawSanityCheckResponse;
+  const r = (await syncEndpoint(
+    serverUrl,
+    "sanityCheck2",
+    hkey,
+    {
+      client: counts,
+    },
+    proto,
+    sessionKey,
+  )) as RawSanityCheckResponse;
   if (r.status === "bad") {
     throw new FullSyncRequiredError(
       "Sync sanity check failed: client and server counts do not match. A full sync is required.",
@@ -438,24 +464,41 @@ export async function normalSync(
     const localIsNewer = localMeta.mod > remoteMeta.mod;
     onProgress("Starting sync session...");
     sessionStarted = true;
-    const remoteGraves = await startSync(serverUrl, hkey, localMeta.usn, localIsNewer, proto, sessionKey);
+    const remoteGraves = await startSync(
+      serverUrl,
+      hkey,
+      localMeta.usn,
+      localIsNewer,
+      proto,
+      sessionKey,
+    );
 
     // Apply remote graves (deletions from server)
-    const remoteGraveCount = remoteGraves.cards.length + remoteGraves.notes.length + remoteGraves.decks.length;
-    onProgress(`Applying ${remoteGraveCount} remote deletion${remoteGraveCount !== 1 ? "s" : ""}...`);
+    const remoteGraveCount =
+      remoteGraves.cards.length + remoteGraves.notes.length + remoteGraves.decks.length;
+    onProgress(
+      `Applying ${remoteGraveCount} remote deletion${remoteGraveCount !== 1 ? "s" : ""}...`,
+    );
     await applyRemoteGraves(db, remoteGraves);
 
     // Step 4: Send local graves
     const localGraves = buildLocalGraves(db);
-    const localGraveCount = localGraves.cards.length + localGraves.notes.length + localGraves.decks.length;
+    const localGraveCount =
+      localGraves.cards.length + localGraves.notes.length + localGraves.decks.length;
     onProgress(`Sending ${localGraveCount} local deletion${localGraveCount !== 1 ? "s" : ""}...`);
     await sendGraves(serverUrl, hkey, localGraves, proto, sessionKey);
 
     // Step 5: Exchange unchunked changes (models, decks, config, tags)
     const anki21b = isAnki21bFormat(db);
     const localChanges = buildLocalUnchunkedChanges(db, anki21b, localIsNewer);
-    const localUnchunkedCount = localChanges.models.length + localChanges.decks[0].length + localChanges.decks[1].length + localChanges.tags.length;
-    onProgress(`Exchanging metadata (${localUnchunkedCount} local change${localUnchunkedCount !== 1 ? "s" : ""})...`);
+    const localUnchunkedCount =
+      localChanges.models.length +
+      localChanges.decks[0].length +
+      localChanges.decks[1].length +
+      localChanges.tags.length;
+    onProgress(
+      `Exchanging metadata (${localUnchunkedCount} local change${localUnchunkedCount !== 1 ? "s" : ""})...`,
+    );
     const remoteChanges = await exchangeChanges(serverUrl, hkey, localChanges, proto, sessionKey);
     applyRemoteUnchunkedChanges(db, remoteChanges, anki21b);
 
@@ -495,7 +538,11 @@ export async function normalSync(
     if (sessionStarted) {
       await abortSync(serverUrl, hkey, proto, sessionKey);
     }
-    try { db.close(); } catch { /* already closed */ }
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
     throw error;
   }
 }

--- a/src/lib/syncMerge.ts
+++ b/src/lib/syncMerge.ts
@@ -19,26 +19,56 @@ export interface Graves {
  * A revlog row: [id, cid, usn, ease, ivl, lastIvl, factor, time, type]
  */
 export type RevlogRow = [
-  id: number, cid: number, usn: number, ease: number,
-  ivl: number, lastIvl: number, factor: number, time: number, type: number,
+  id: number,
+  cid: number,
+  usn: number,
+  ease: number,
+  ivl: number,
+  lastIvl: number,
+  factor: number,
+  time: number,
+  type: number,
 ];
 
 /**
  * A note row: [id, guid, mid, mod, usn, tags, flds, sfld, csum, flags, data]
  */
 export type NoteRow = [
-  id: number, guid: string, mid: number, mod: number, usn: number,
-  tags: string, flds: string, sfld: string, csum: number, flags: number, data: string,
+  id: number,
+  guid: string,
+  mid: number,
+  mod: number,
+  usn: number,
+  tags: string,
+  flds: string,
+  sfld: string,
+  csum: number,
+  flags: number,
+  data: string,
 ];
 
 /**
  * A card row: [id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data]
  */
 export type CardRow = [
-  id: number, nid: number, did: number, ord: number, mod: number, usn: number,
-  type: number, queue: number, due: number, ivl: number, factor: number,
-  reps: number, lapses: number, left: number, odue: number, odid: number,
-  flags: number, data: string,
+  id: number,
+  nid: number,
+  did: number,
+  ord: number,
+  mod: number,
+  usn: number,
+  type: number,
+  queue: number,
+  due: number,
+  ivl: number,
+  factor: number,
+  reps: number,
+  lapses: number,
+  left: number,
+  odue: number,
+  odid: number,
+  flags: number,
+  data: string,
 ];
 
 export interface Chunk {
@@ -138,19 +168,14 @@ function mergeColJsonField<T extends { id: number; mod?: number }>(
 
 /** Returns true if the DB uses the anki21b format (separate notetypes table). */
 export function isAnki21bFormat(db: Database): boolean {
-  const result = db.exec(
-    "SELECT name FROM sqlite_master WHERE type='table' AND name='notetypes'",
-  );
+  const result = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='notetypes'");
   return (result[0]?.values.length ?? 0) > 0;
 }
 
 // ── Apply remote data ─────────��────────────────────────────────────
 
 /** Delete cards/notes/decks from SQLite and IndexedDB based on remote graves. */
-export async function applyRemoteGraves(
-  db: Database,
-  graves: Graves,
-): Promise<void> {
+export async function applyRemoteGraves(db: Database, graves: Graves): Promise<void> {
   const { reviewDB } = await import("../scheduler/db");
 
   // Delete cards
@@ -196,10 +221,7 @@ export async function applyRemoteGraves(
 }
 
 /** Apply a chunk of incoming cards/notes/revlog from the server. */
-export async function applyRemoteChunk(
-  db: Database,
-  chunk: Chunk,
-): Promise<void> {
+export async function applyRemoteChunk(db: Database, chunk: Chunk): Promise<void> {
   // Apply revlog entries (always merge, no conflict)
   for (const [id, cid, usn, ease, ivl, lastIvl, factor, time, type] of chunk.revlog ?? []) {
     db.run(
@@ -226,7 +248,26 @@ export async function applyRemoteChunk(
 
   // Apply cards
   const { reviewDB } = await import("../scheduler/db");
-  for (const [id, nid, did, ord, mod, usn, ctype, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data] of chunk.cards ?? []) {
+  for (const [
+    id,
+    nid,
+    did,
+    ord,
+    mod,
+    usn,
+    ctype,
+    queue,
+    due,
+    ivl,
+    factor,
+    reps,
+    lapses,
+    left,
+    odue,
+    odid,
+    flags,
+    data,
+  ] of chunk.cards ?? []) {
     // Check if we have a local version
     const existing = db.exec("SELECT mod, usn FROM cards WHERE id=?", [id]);
     if (existing[0]?.values[0]) {
@@ -237,7 +278,26 @@ export async function applyRemoteChunk(
     }
     db.run(
       "INSERT OR REPLACE INTO cards (id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-      [id, nid, did, ord, mod, usn, ctype, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data],
+      [
+        id,
+        nid,
+        did,
+        ord,
+        mod,
+        usn,
+        ctype,
+        queue,
+        due,
+        ivl,
+        factor,
+        reps,
+        lapses,
+        left,
+        odue,
+        odid,
+        flags,
+        data,
+      ],
     );
     // Also update IndexedDB if this card exists there — remote is newer
     await reviewDB.deleteCard(String(id));
@@ -257,10 +317,7 @@ export function applyRemoteUnchunkedChanges(
   }
 }
 
-function applyRemoteUnchunkedAnki2(
-  db: Database,
-  changes: UnchunkedChanges,
-): void {
+function applyRemoteUnchunkedAnki2(db: Database, changes: UnchunkedChanges): void {
   // Models, decks, deck configs — merge with mod-time conflict resolution
   mergeColJsonField(db, "models", changes.models);
   const [remoteDecks, remoteDconf] = changes.decks;
@@ -289,10 +346,7 @@ function applyRemoteUnchunkedAnki2(
   }
 }
 
-function applyRemoteUnchunkedAnki21b(
-  db: Database,
-  changes: UnchunkedChanges,
-): void {
+function applyRemoteUnchunkedAnki21b(db: Database, changes: UnchunkedChanges): void {
   // Models (notetypes) — stored in notetypes table
   for (const m of changes.models) {
     const mtimeSecs = (m as SyncModel & { mtime_secs?: number }).mtime_secs;
@@ -315,10 +369,13 @@ function applyRemoteUnchunkedAnki21b(
       const localMtime = existing[0].values[0][0] as number;
       if ((d.mtime ?? 0) < localMtime) continue;
     }
-    db.run(
-      "INSERT OR REPLACE INTO decks (id, name, mtime, usn, common) VALUES (?,?,?,?,?)",
-      [d.id, d.name ?? "", d.mtime ?? 0, d.usn ?? 0, JSON.stringify(d)],
-    );
+    db.run("INSERT OR REPLACE INTO decks (id, name, mtime, usn, common) VALUES (?,?,?,?,?)", [
+      d.id,
+      d.name ?? "",
+      d.mtime ?? 0,
+      d.usn ?? 0,
+      JSON.stringify(d),
+    ]);
   }
 
   // Deck configs
@@ -328,10 +385,13 @@ function applyRemoteUnchunkedAnki21b(
       const localMtime = existing[0].values[0][0] as number;
       if ((c.mtime ?? 0) < localMtime) continue;
     }
-    db.run(
-      "INSERT OR REPLACE INTO deck_config (id, name, mtime, usn, config) VALUES (?,?,?,?,?)",
-      [c.id, c.name ?? "", c.mtime ?? 0, c.usn ?? 0, JSON.stringify(c)],
-    );
+    db.run("INSERT OR REPLACE INTO deck_config (id, name, mtime, usn, config) VALUES (?,?,?,?,?)", [
+      c.id,
+      c.name ?? "",
+      c.mtime ?? 0,
+      c.usn ?? 0,
+      JSON.stringify(c),
+    ]);
   }
 
   // Tags
@@ -378,10 +438,7 @@ export function buildLocalUnchunkedChanges(
   return buildLocalUnchunkedAnki2(db, localIsNewer);
 }
 
-function buildLocalUnchunkedAnki2(
-  db: Database,
-  localIsNewer: boolean,
-): UnchunkedChanges {
+function buildLocalUnchunkedAnki2(db: Database, localIsNewer: boolean): UnchunkedChanges {
   const changes: UnchunkedChanges = {
     models: [],
     decks: [[], []],
@@ -413,7 +470,11 @@ function buildLocalUnchunkedAnki2(
     const result = db.exec("SELECT conf, crt FROM col");
     if (result[0]?.values[0]) {
       const confStr = result[0].values[0][0] as string;
-      try { changes.conf = JSON.parse(confStr); } catch { /* skip */ }
+      try {
+        changes.conf = JSON.parse(confStr);
+      } catch {
+        /* skip */
+      }
       changes.crt = result[0].values[0][1] as number;
     }
   }
@@ -421,10 +482,7 @@ function buildLocalUnchunkedAnki2(
   return changes;
 }
 
-function buildLocalUnchunkedAnki21b(
-  db: Database,
-  localIsNewer: boolean,
-): UnchunkedChanges {
+function buildLocalUnchunkedAnki21b(db: Database, localIsNewer: boolean): UnchunkedChanges {
   const changes: UnchunkedChanges = {
     models: [],
     decks: [[], []],
@@ -432,48 +490,75 @@ function buildLocalUnchunkedAnki21b(
   };
 
   // Notetypes with pending changes (usn=-1)
-  const ntResult = db.exec(
-    "SELECT id, name, mtime_secs, usn, config FROM notetypes WHERE usn=-1",
-  );
+  const ntResult = db.exec("SELECT id, name, mtime_secs, usn, config FROM notetypes WHERE usn=-1");
   if (ntResult[0]) {
     for (const row of ntResult[0].values) {
       let obj: SyncModel;
       try {
-        obj = { ...JSON.parse(row[4] as string), id: row[0], name: row[1], mtime_secs: row[2], usn: row[3] };
+        obj = {
+          ...JSON.parse(row[4] as string),
+          id: row[0],
+          name: row[1],
+          mtime_secs: row[2],
+          usn: row[3],
+        };
       } catch {
-        obj = { id: row[0] as number, name: row[1] as string, mtime_secs: row[2] as number, usn: row[3] as number };
+        obj = {
+          id: row[0] as number,
+          name: row[1] as string,
+          mtime_secs: row[2] as number,
+          usn: row[3] as number,
+        };
       }
       changes.models.push(obj);
     }
   }
 
   // Decks with pending changes (usn=-1)
-  const decksResult = db.exec(
-    "SELECT id, name, mtime, usn, common FROM decks WHERE usn=-1",
-  );
+  const decksResult = db.exec("SELECT id, name, mtime, usn, common FROM decks WHERE usn=-1");
   if (decksResult[0]) {
     for (const row of decksResult[0].values) {
       let obj: SyncDeck;
       try {
-        obj = { ...JSON.parse(row[4] as string), id: row[0], name: row[1], mtime: row[2], usn: row[3] };
+        obj = {
+          ...JSON.parse(row[4] as string),
+          id: row[0],
+          name: row[1],
+          mtime: row[2],
+          usn: row[3],
+        };
       } catch {
-        obj = { id: row[0] as number, name: row[1] as string, mtime: row[2] as number, usn: row[3] as number };
+        obj = {
+          id: row[0] as number,
+          name: row[1] as string,
+          mtime: row[2] as number,
+          usn: row[3] as number,
+        };
       }
       changes.decks[0].push(obj);
     }
   }
 
   // Deck configs with pending changes (usn=-1)
-  const dcResult = db.exec(
-    "SELECT id, name, mtime, usn, config FROM deck_config WHERE usn=-1",
-  );
+  const dcResult = db.exec("SELECT id, name, mtime, usn, config FROM deck_config WHERE usn=-1");
   if (dcResult[0]) {
     for (const row of dcResult[0].values) {
       let obj: SyncDeckConfig;
       try {
-        obj = { ...JSON.parse(row[4] as string), id: row[0], name: row[1], mtime: row[2], usn: row[3] };
+        obj = {
+          ...JSON.parse(row[4] as string),
+          id: row[0],
+          name: row[1],
+          mtime: row[2],
+          usn: row[3],
+        };
       } catch {
-        obj = { id: row[0] as number, name: row[1] as string, mtime: row[2] as number, usn: row[3] as number };
+        obj = {
+          id: row[0] as number,
+          name: row[1] as string,
+          mtime: row[2] as number,
+          usn: row[3] as number,
+        };
       }
       changes.decks[1].push(obj);
     }
@@ -491,7 +576,11 @@ function buildLocalUnchunkedAnki21b(
     const result = db.exec("SELECT conf, crt FROM col");
     if (result[0]?.values[0]) {
       const confStr = result[0].values[0][0] as string;
-      try { changes.conf = JSON.parse(confStr); } catch { /* skip */ }
+      try {
+        changes.conf = JSON.parse(confStr);
+      } catch {
+        /* skip */
+      }
       changes.crt = result[0].values[0][1] as number;
     }
   }
@@ -533,7 +622,9 @@ export function* buildLocalChunks(db: Database): Generator<Chunk> {
   }
 
   // Yield in chunks of CHUNK_SIZE (interleaving types)
-  let ci = 0, ni = 0, ri = 0;
+  let ci = 0,
+    ni = 0,
+    ri = 0;
   const total = pendingCards.length + pendingNotes.length + pendingRevlog.length;
   if (total === 0) {
     yield { done: true, cards: [], notes: [], revlog: [] };
@@ -570,10 +661,7 @@ export function* buildLocalChunks(db: Database): Generator<Chunk> {
 
 // ── Sanity check counts ──────────���─────────────────────────────────
 
-export function getSanityCounts(
-  db: Database,
-  anki21b: boolean,
-): SanityCheckCounts {
+export function getSanityCounts(db: Database, anki21b: boolean): SanityCheckCounts {
   const scalar = (sql: string): number => {
     const r = db.exec(sql);
     return (r[0]?.values[0]?.[0] as number) ?? 0;

--- a/src/lib/syncWrite.ts
+++ b/src/lib/syncWrite.ts
@@ -1,5 +1,5 @@
 import { createDatabase } from "~/utils/sql";
-import type { CardReviewState, StoredReviewLog } from "../scheduler/types";
+import type { CardReviewState } from "../scheduler/types";
 import { MS_PER_DAY } from "../utils/constants";
 
 /**
@@ -17,8 +17,8 @@ interface SM2CardState {
 }
 
 /** Queue constants matching official Anki desktop. */
-const QUEUE_SUSPENDED = -1;
-const QUEUE_SCHED_BURIED = -2;
+export const QUEUE_SUSPENDED = -1;
+export const QUEUE_SCHED_BURIED = -2;
 export const QUEUE_USER_BURIED = -3;
 
 /** SQL used to update card rows during sync write-back. */
@@ -26,18 +26,21 @@ export const CARD_UPDATE_SQL =
   "UPDATE cards SET type=?, queue=?, due=?, ivl=?, factor=?, reps=?, lapses=?, left=?, flags=?, mod=?, data=?, odue=?, odid=?, usn=? WHERE id=?";
 
 /** SQL used to insert graves (deleted objects) during sync write-back. */
-export const GRAVES_INSERT_SQL =
-  "INSERT INTO graves (usn, oid, type) VALUES (?, ?, ?)";
+export const GRAVES_INSERT_SQL = "INSERT INTO graves (usn, oid, type) VALUES (?, ?, ?)";
 
 /**
  * Map SM-2 phase to Anki card.type column.
  */
 function phaseToType(phase: SM2CardState["phase"]): number {
   switch (phase) {
-    case "new": return 0;
-    case "learning": return 1;
-    case "review": return 2;
-    case "relearning": return 3;
+    case "new":
+      return 0;
+    case "learning":
+      return 1;
+    case "review":
+      return 2;
+    case "relearning":
+      return 3;
   }
 }
 
@@ -47,11 +50,13 @@ function phaseToType(phase: SM2CardState["phase"]): number {
  */
 function phaseToQueue(phase: SM2CardState["phase"], interval?: number): number {
   switch (phase) {
-    case "new": return 0;
+    case "new":
+      return 0;
     case "learning":
     case "relearning":
       return (interval ?? 0) >= 1 ? 3 : 1;
-    case "review": return 2;
+    case "review":
+      return 2;
   }
 }
 
@@ -105,11 +110,16 @@ export function encodeLeft(
  */
 export function phaseToRevlogType(phase: string, daysLate?: number): number {
   switch (phase) {
-    case "new": return 0;
-    case "learning": return 0;
-    case "review": return (daysLate !== undefined && daysLate < 0) ? 3 : 1;
-    case "relearning": return 2;
-    default: return 1;
+    case "new":
+      return 0;
+    case "learning":
+      return 0;
+    case "review":
+      return daysLate !== undefined && daysLate < 0 ? 3 : 1;
+    case "relearning":
+      return 2;
+    default:
+      return 1;
   }
 }
 
@@ -148,8 +158,7 @@ export async function mergeIndexedDBToSqlite(
 ): Promise<void> {
   // Get collection creation time for due-date conversion
   const crtResult = db.exec("SELECT crt FROM col");
-  const collectionCreationSecs =
-    (crtResult[0]?.values[0]?.[0] as number | undefined) ?? 0;
+  const collectionCreationSecs = (crtResult[0]?.values[0]?.[0] as number | undefined) ?? 0;
 
   // Read all reviewed cards from IndexedDB
   const { reviewDB } = await import("../scheduler/db");
@@ -183,19 +192,34 @@ export async function mergeIndexedDBToSqlite(
     const due = convertDue(state, collectionCreationSecs);
     const ivl = Math.max(0, Math.round(state.interval));
     const factor = encodeFactor(state.ease, card.algorithm);
-    const totalSteps =
-      state.phase === "relearning" ? defaultRelearnSteps : defaultLearnSteps;
+    const totalSteps = state.phase === "relearning" ? defaultRelearnSteps : defaultLearnSteps;
     const stepsRemaining = Math.max(0, totalSteps - state.step);
     const left = encodeLeft(state, totalSteps, stepsRemaining);
     const flags = card.flags ?? 0;
     const data = serializeCardData(card);
 
-    updateStmt.run([type, queue, due, ivl, factor, state.reps, state.lapses, left, flags, nowSecs, data, 0, 0, -1, ankiCardId]);
+    updateStmt.run([
+      type,
+      queue,
+      due,
+      ivl,
+      factor,
+      state.reps,
+      state.lapses,
+      left,
+      flags,
+      nowSecs,
+      data,
+      0,
+      0,
+      -1,
+      ankiCardId,
+    ]);
   }
   updateStmt.free();
 
   // Insert review logs into revlog table
-  await insertRevlogs(db, deckId, reviewedCards);
+  await insertRevlogs(db, reviewedCards);
 
   // Insert graves for deleted cards
   await insertGraves(db, deckId);
@@ -270,16 +294,10 @@ export function serializeCardData(card: CardReviewState): string {
  */
 async function insertRevlogs(
   db: import("sql.js").Database,
-  _deckId: string,
   reviewedCards: CardReviewState[],
 ): Promise<void> {
-  const allLogs: StoredReviewLog[] = [];
-
   const { reviewDB } = await import("../scheduler/db");
-  for (const card of reviewedCards) {
-    const logs = await reviewDB.getReviewLogsForCard(card.cardId);
-    allLogs.push(...logs);
-  }
+  const allLogs = await reviewDB.getReviewLogsForCards(reviewedCards.map((c) => c.cardId));
 
   if (allLogs.length === 0) return;
 
@@ -307,9 +325,7 @@ async function insertRevlogs(
     const ankiCardId = Number(log.cardId);
     if (isNaN(ankiCardId)) continue;
 
-    const ease = typeof log.rating === "number"
-      ? log.rating
-      : (ANSWER_TO_EASE[log.rating] ?? 3);
+    const ease = typeof log.rating === "number" ? log.rating : (ANSWER_TO_EASE[log.rating] ?? 3);
 
     // Extract interval and factor from the review log if available
     const reviewLog = log.reviewLog as {
@@ -326,14 +342,16 @@ async function insertRevlogs(
     // Encode factor based on algorithm
     const cardState = cardStateMap.get(log.cardId);
     const algorithm = cardState?.algorithm ?? "sm2";
-    const factor = algorithm === "fsrs"
-      ? encodeFactor(0, "fsrs", reviewLog?.ease ?? 5.0)
-      : Math.round((reviewLog?.ease ?? 2.5) * 1000);
+    const factor =
+      algorithm === "fsrs"
+        ? encodeFactor(0, "fsrs", reviewLog?.ease ?? 5.0)
+        : Math.round((reviewLog?.ease ?? 2.5) * 1000);
 
     const time = reviewLog?.reviewTime ?? 0; // ms
 
     // Determine revlog type from card phase (0=learning, 1=review, 2=relearning)
-    const phase = reviewLog?.phase ?? (cardState?.cardState as SM2CardState | undefined)?.phase ?? "review";
+    const phase =
+      reviewLog?.phase ?? (cardState?.cardState as SM2CardState | undefined)?.phase ?? "review";
     const type = phaseToRevlogType(phase);
 
     insertStmt.run([id, ankiCardId, -1, ease, ivl, lastIvl, factor, time, type]);
@@ -345,13 +363,12 @@ async function insertRevlogs(
 /**
  * Insert graves entries for any deleted cards in this deck.
  */
-async function insertGraves(
-  db: import("sql.js").Database,
-  deckId: string,
-): Promise<void> {
+async function insertGraves(db: import("sql.js").Database, deckId: string): Promise<void> {
   const { reviewDB } = await import("../scheduler/db");
-  const db_ = reviewDB as unknown as { getDeletedCardsForDeck?: (deckId: string) => Promise<{ cardId: string }[]> };
-  const deletedCards = await db_.getDeletedCardsForDeck?.(deckId) ?? [];
+  const db_ = reviewDB as unknown as {
+    getDeletedCardsForDeck?: (deckId: string) => Promise<{ cardId: string }[]>;
+  };
+  const deletedCards = (await db_.getDeletedCardsForDeck?.(deckId)) ?? [];
   if (deletedCards.length === 0) return;
 
   const insertStmt = db.prepare(GRAVES_INSERT_SQL);

--- a/src/sampleDecks.ts
+++ b/src/sampleDecks.ts
@@ -17,7 +17,7 @@ type SampleDeck = {
 const basicTemplate = {
   name: "Card 1",
   qfmt: "{{Front}}",
-  afmt: "{{FrontSide}}<hr id=\"answer\">{{Back}}",
+  afmt: '{{FrontSide}}<hr id="answer">{{Back}}',
 };
 
 const basicCss = ANKI_DEFAULT_CSS;

--- a/src/scheduler/__tests__/queue.test.ts
+++ b/src/scheduler/__tests__/queue.test.ts
@@ -3,9 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { ReviewQueue, type ReviewCard } from "../queue";
 import { DEFAULT_SCHEDULER_SETTINGS } from "../types";
 
-function makeReviewCard(
-  overrides: Partial<ReviewCard> & { cardId: string },
-): ReviewCard {
+function makeReviewCard(overrides: Partial<ReviewCard> & { cardId: string }): ReviewCard {
   const now = Date.now();
   return {
     cardIndex: 0,

--- a/src/scheduler/anki-sm2-algorithm.ts
+++ b/src/scheduler/anki-sm2-algorithm.ts
@@ -50,7 +50,7 @@ function clampInterval(interval: number, params: SM2Params): number {
  * Matches Anki's approach of seeding fuzz from card reps.
  */
 function seededRandom(seed: number): number {
-  let t = (seed + 0x6D2B79F5) | 0;
+  let t = (seed + 0x6d2b79f5) | 0;
   t = Math.imul(t ^ (t >>> 15), t | 1);
   t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
   return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
@@ -63,10 +63,11 @@ function seededRandom(seed: number): number {
  */
 function addFuzz(interval: number, seed: number, minimum = 1, maximum = 36500): number {
   if (interval < 2.5) return Math.max(minimum, Math.round(interval));
-  const delta = 1.0
-    + 0.15 * Math.max(0, Math.min(interval, 7) - 2.5)
-    + 0.1  * Math.max(0, Math.min(interval, 20) - 7)
-    + 0.05 * Math.max(0, interval - 20);
+  const delta =
+    1.0 +
+    0.15 * Math.max(0, Math.min(interval, 7) - 2.5) +
+    0.1 * Math.max(0, Math.min(interval, 20) - 7) +
+    0.05 * Math.max(0, interval - 20);
   let lower = Math.round(interval - delta);
   let upper = Math.round(interval + delta);
   lower = Math.max(minimum, Math.min(lower, maximum));
@@ -103,7 +104,11 @@ function daysLate(card: AnkiSM2CardState): number {
  * - Negative = seconds (learning/relearning cards with sub-day intervals)
  * Uses the due timestamp to compute the actual scheduled delay for learning cards.
  */
-function encodeIntervalForRevlog(state: AnkiSM2CardState, now?: number, _secsUntilRollover?: number): number {
+function encodeIntervalForRevlog(
+  state: AnkiSM2CardState,
+  now?: number,
+  _secsUntilRollover?: number,
+): number {
   if (state.phase === "learning" || state.phase === "relearning" || state.phase === "new") {
     // For learning/relearning, compute delay from due timestamp
     const refTime = now ?? Date.now();
@@ -145,10 +150,7 @@ function reviewCardForAnswer(
     case "again": {
       ease = Math.max(MIN_EASE, ease - 0.2);
       const rawLapseIvl = Math.max(1, Math.round(interval * params.lapseNewInterval));
-      const newIvl = Math.max(
-        params.minLapseInterval,
-        addFuzz(rawLapseIvl, reps ^ callSeed),
-      );
+      const newIvl = Math.max(params.minLapseInterval, addFuzz(rawLapseIvl, reps ^ callSeed));
       const steps = params.relearningSteps;
       if (steps.length === 0) {
         return {
@@ -179,7 +181,10 @@ function reviewCardForAnswer(
       const hardRawIvl = interval * params.hardMultiplier * params.intervalModifier;
       const hardMinimum = params.hardMultiplier > 1 ? interval + 1 : 1;
       const hardCandiate = Math.max(hardMinimum, Math.round(hardRawIvl));
-      const newIvl = clampInterval(addFuzz(hardCandiate, reps ^ callSeed, hardMinimum, params.maximumInterval), params);
+      const newIvl = clampInterval(
+        addFuzz(hardCandiate, reps ^ callSeed, hardMinimum, params.maximumInterval),
+        params,
+      );
       return {
         phase: "review",
         step: 0,
@@ -195,11 +200,20 @@ function reviewCardForAnswer(
       const hardRawIvl = interval * params.hardMultiplier * params.intervalModifier;
       const hardMinimum = params.hardMultiplier > 1 ? interval + 1 : 1;
       const hardCandidate = Math.max(hardMinimum, Math.round(hardRawIvl));
-      const hardIvl = clampInterval(addFuzz(hardCandidate, reps ^ callSeed, hardMinimum, params.maximumInterval), params);
+      const hardIvl = clampInterval(
+        addFuzz(hardCandidate, reps ^ callSeed, hardMinimum, params.maximumInterval),
+        params,
+      );
 
       const goodMinimum = params.hardMultiplier <= 1 ? interval + 1 : hardIvl + 1;
-      const goodCandidate = Math.max(goodMinimum, Math.round((interval + daysLatePositive / 2) * ease * params.intervalModifier));
-      const newIvl = clampInterval(addFuzz(goodCandidate, (reps + 1) ^ callSeed, goodMinimum, params.maximumInterval), params);
+      const goodCandidate = Math.max(
+        goodMinimum,
+        Math.round((interval + daysLatePositive / 2) * ease * params.intervalModifier),
+      );
+      const newIvl = clampInterval(
+        addFuzz(goodCandidate, (reps + 1) ^ callSeed, goodMinimum, params.maximumInterval),
+        params,
+      );
       return {
         phase: "review",
         step: 0,
@@ -217,14 +231,31 @@ function reviewCardForAnswer(
       const hardRawIvl = interval * params.hardMultiplier * params.intervalModifier;
       const hardMinimum = params.hardMultiplier > 1 ? interval + 1 : 1;
       const hardCandidate = Math.max(hardMinimum, Math.round(hardRawIvl));
-      const hardIvl = clampInterval(addFuzz(hardCandidate, reps ^ callSeed, hardMinimum, params.maximumInterval), params);
+      const hardIvl = clampInterval(
+        addFuzz(hardCandidate, reps ^ callSeed, hardMinimum, params.maximumInterval),
+        params,
+      );
 
       const goodMinimum = params.hardMultiplier <= 1 ? interval + 1 : hardIvl + 1;
-      const goodCandidate = Math.max(goodMinimum, Math.round((interval + daysLatePositive / 2) * (ease - 0.15) * params.intervalModifier));
-      const goodIvl = clampInterval(addFuzz(goodCandidate, (reps + 1) ^ callSeed, goodMinimum, params.maximumInterval), params);
+      const goodCandidate = Math.max(
+        goodMinimum,
+        Math.round((interval + daysLatePositive / 2) * (ease - 0.15) * params.intervalModifier),
+      );
+      const goodIvl = clampInterval(
+        addFuzz(goodCandidate, (reps + 1) ^ callSeed, goodMinimum, params.maximumInterval),
+        params,
+      );
 
-      const easyCandidate = Math.max(goodIvl + 1, Math.round((interval + daysLatePositive) * ease * params.easyBonus * params.intervalModifier));
-      const newIvl = clampInterval(addFuzz(easyCandidate, (reps + 2) ^ callSeed, goodIvl + 1, params.maximumInterval), params);
+      const easyCandidate = Math.max(
+        goodIvl + 1,
+        Math.round(
+          (interval + daysLatePositive) * ease * params.easyBonus * params.intervalModifier,
+        ),
+      );
+      const newIvl = clampInterval(
+        addFuzz(easyCandidate, (reps + 2) ^ callSeed, goodIvl + 1, params.maximumInterval),
+        params,
+      );
       return {
         phase: "review",
         step: 0,
@@ -259,7 +290,10 @@ function earlyReviewForAnswer(
       const factor = params.hardMultiplier;
       const halfUsual = factor / 2;
       const rawIvl = Math.max(elapsed * factor, interval * halfUsual);
-      const newIvl = clampInterval(Math.max(1, Math.round(rawIvl * params.intervalModifier)), params);
+      const newIvl = clampInterval(
+        Math.max(1, Math.round(rawIvl * params.intervalModifier)),
+        params,
+      );
       return {
         phase: "review",
         step: 0,
@@ -272,7 +306,10 @@ function earlyReviewForAnswer(
     }
     case "good": {
       const rawIvl = Math.max(elapsed * ease, interval);
-      const newIvl = clampInterval(Math.max(1, Math.round(rawIvl * params.intervalModifier)), params);
+      const newIvl = clampInterval(
+        Math.max(1, Math.round(rawIvl * params.intervalModifier)),
+        params,
+      );
       return {
         phase: "review",
         step: 0,
@@ -287,7 +324,10 @@ function earlyReviewForAnswer(
       const newEase = ease + 0.15;
       const reducedBonus = params.easyBonus - (params.easyBonus - 1) / 2;
       const rawIvl = Math.max(elapsed * ease, interval) * reducedBonus;
-      const newIvl = clampInterval(Math.max(1, Math.round(rawIvl * params.intervalModifier)), params);
+      const newIvl = clampInterval(
+        Math.max(1, Math.round(rawIvl * params.intervalModifier)),
+        params,
+      );
       return {
         phase: "review",
         step: 0,
@@ -354,9 +394,10 @@ function learningCardForAnswer(
     case "good": {
       const nextStep = card.step + 1;
       if (nextStep >= steps.length) {
-        const ivl = card.phase === "relearning"
-          ? Math.max(params.minLapseInterval, card.interval)
-          : clampInterval(graduatingInterval, params);
+        const ivl =
+          card.phase === "relearning"
+            ? Math.max(params.minLapseInterval, card.interval)
+            : clampInterval(graduatingInterval, params);
         return {
           phase: "review",
           step: 0,
@@ -435,9 +476,7 @@ export class AnkiSM2Algorithm implements SchedulingAlgorithm {
         const steps = params.learningSteps;
         if (steps.length === 0) {
           // No learning steps: graduate immediately
-          const ivl = answer === "easy"
-            ? params.easyInterval
-            : params.graduatingInterval;
+          const ivl = answer === "easy" ? params.easyInterval : params.graduatingInterval;
           newState = {
             phase: "review",
             step: 0,
@@ -494,9 +533,11 @@ export class AnkiSM2Algorithm implements SchedulingAlgorithm {
     }
 
     const reviewNow = Date.now();
-    const leeched = card.phase === "review" && answer === "again"
-      && newState.lapses >= params.leechThreshold
-      && ((newState.lapses - params.leechThreshold) % Math.ceil(params.leechThreshold / 2) === 0);
+    const leeched =
+      card.phase === "review" &&
+      answer === "again" &&
+      newState.lapses >= params.leechThreshold &&
+      (newState.lapses - params.leechThreshold) % Math.ceil(params.leechThreshold / 2) === 0;
     const reviewLog: AnkiSM2ReviewLog = {
       answer,
       previousPhase: card.phase,

--- a/src/scheduler/db.ts
+++ b/src/scheduler/db.ts
@@ -119,28 +119,32 @@ class ReviewDB {
     return new Promise((resolve, reject) => {
       const tx = db.transaction(storeNames, mode);
       const request = fn(tx);
-      request.onsuccess = () => resolve(mapResult ? mapResult(request.result) : (request.result as T));
+      request.onsuccess = () =>
+        resolve(mapResult ? mapResult(request.result) : (request.result as T));
       request.onerror = () => reject(request.error);
     });
   }
 
   async getCard(cardId: string): Promise<CardReviewState | null> {
-    return this.run(["cards"], "readonly", (tx) =>
-      tx.objectStore("cards").get(cardId),
-      (r) => r as CardReviewState | null ?? null,
+    return this.run(
+      ["cards"],
+      "readonly",
+      (tx) => tx.objectStore("cards").get(cardId),
+      (r) => (r as CardReviewState | null) ?? null,
     );
   }
 
   async saveCard(card: CardReviewState): Promise<void> {
-    await this.run(["cards"], "readwrite", (tx) =>
-      tx.objectStore("cards").put(card),
-    );
+    await this.run(["cards"], "readwrite", (tx) => tx.objectStore("cards").put(card));
   }
 
   /**
    * Partially update a card's fields without replacing the whole record.
    */
-  async patchCard(cardId: string, patch: Partial<CardReviewState>): Promise<CardReviewState | null> {
+  async patchCard(
+    cardId: string,
+    patch: Partial<CardReviewState>,
+  ): Promise<CardReviewState | null> {
     const db = await this.ensureInit();
     return new Promise((resolve, reject) => {
       const tx = db.transaction("cards", "readwrite");
@@ -148,7 +152,10 @@ class ReviewDB {
       const getReq = store.get(cardId);
       getReq.onsuccess = () => {
         const existing = getReq.result as CardReviewState | undefined;
-        if (!existing) { resolve(null); return; }
+        if (!existing) {
+          resolve(null);
+          return;
+        }
         const updated = { ...existing, ...patch };
         const putReq = store.put(updated);
         putReq.onsuccess = () => resolve(updated);
@@ -171,9 +178,7 @@ class ReviewDB {
   }
 
   async saveReviewLog(log: StoredReviewLog): Promise<void> {
-    await this.run(["reviewLogs"], "readwrite", (tx) =>
-      tx.objectStore("reviewLogs").put(log),
-    );
+    await this.run(["reviewLogs"], "readwrite", (tx) => tx.objectStore("reviewLogs").put(log));
   }
 
   async getReviewLogsForCard(cardId: string): Promise<StoredReviewLog[]> {
@@ -182,23 +187,46 @@ class ReviewDB {
     );
   }
 
+  async getReviewLogsForCards(cardIds: string[]): Promise<StoredReviewLog[]> {
+    if (cardIds.length === 0) return [];
+    const db = await this.ensureInit();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("reviewLogs", "readonly");
+      const index = tx.objectStore("reviewLogs").index("cardId");
+      const results: StoredReviewLog[] = [];
+      let completed = 0;
+      for (const cardId of cardIds) {
+        const request = index.getAll(cardId);
+        request.onsuccess = () => {
+          results.push(...(request.result as StoredReviewLog[]));
+          completed++;
+          if (completed === cardIds.length) resolve(results);
+        };
+        request.onerror = () => reject(request.error);
+      }
+    });
+  }
+
   async getDailyStats(date: string): Promise<DailyStats | null> {
-    return this.run(["dailyStats"], "readonly", (tx) =>
-      tx.objectStore("dailyStats").get(date),
-      (r) => r as DailyStats | null ?? null,
+    return this.run(
+      ["dailyStats"],
+      "readonly",
+      (tx) => tx.objectStore("dailyStats").get(date),
+      (r) => (r as DailyStats | null) ?? null,
     );
   }
 
   async saveDailyStats(stats: DailyStats): Promise<void> {
-    await this.run(["dailyStats"], "readwrite", (tx) =>
-      tx.objectStore("dailyStats").put(stats),
-    );
+    await this.run(["dailyStats"], "readwrite", (tx) => tx.objectStore("dailyStats").put(stats));
   }
 
   async getSettings(deckId: string): Promise<SchedulerSettings> {
-    return this.run(["settings"], "readonly", (tx) =>
-      tx.objectStore("settings").get(deckId),
-      (r) => (r as { settings?: SchedulerSettings } | undefined)?.settings ?? DEFAULT_SCHEDULER_SETTINGS,
+    return this.run(
+      ["settings"],
+      "readonly",
+      (tx) => tx.objectStore("settings").get(deckId),
+      (r) =>
+        (r as { settings?: SchedulerSettings } | undefined)?.settings ?? DEFAULT_SCHEDULER_SETTINGS,
     );
   }
 
@@ -212,9 +240,7 @@ class ReviewDB {
    * Delete a card from the cards store (e.g. when applying remote graves).
    */
   async deleteCard(cardId: string): Promise<void> {
-    await this.run(["cards"], "readwrite", (tx) =>
-      tx.objectStore("cards").delete(cardId),
-    );
+    await this.run(["cards"], "readwrite", (tx) => tx.objectStore("cards").delete(cardId));
   }
 
   /**

--- a/src/scheduler/queue.ts
+++ b/src/scheduler/queue.ts
@@ -3,6 +3,7 @@ import { reviewDB } from "./db";
 import type { SchedulingAlgorithm } from "./algorithm";
 import { FSRSAlgorithm } from "./fsrs-algorithm";
 import { AnkiSM2Algorithm } from "./anki-sm2-algorithm";
+import { QUEUE_SUSPENDED, QUEUE_SCHED_BURIED, QUEUE_USER_BURIED } from "../lib/syncWrite";
 
 /**
  * Represents a card ready for review, combining deck data with review state
@@ -90,7 +91,7 @@ export class ReviewQueue {
   private async unburyCards(): Promise<void> {
     const cards = await reviewDB.getCardsForDeck(this.deckId);
     for (const card of cards) {
-      if (card.queueOverride === -3) {
+      if (card.queueOverride === QUEUE_USER_BURIED) {
         await reviewDB.patchCard(card.cardId, { queueOverride: undefined });
       }
     }
@@ -109,7 +110,11 @@ export class ReviewQueue {
    * @param templatesPerCard Number of templates for each card (assumes all cards have same templates)
    * @param ankiCardIds Optional array of native Anki card IDs (from SQLite) — when provided, used as card IDs instead of positional indices
    */
-  async buildQueue(totalCards: number, templatesPerCard: number, ankiCardIds?: number[]): Promise<ReviewCard[]> {
+  async buildQueue(
+    totalCards: number,
+    templatesPerCard: number,
+    ankiCardIds?: number[],
+  ): Promise<ReviewCard[]> {
     // Get existing review states
     const existingStates = await reviewDB.getCardsForDeck(this.deckId);
     const stateMap = new Map<string, CardReviewState>(
@@ -163,9 +168,13 @@ export class ReviewQueue {
     for (const card of queue) {
       try {
         // Skip suspended cards entirely
-        if (card.reviewState.queueOverride === -1) continue;
+        if (card.reviewState.queueOverride === QUEUE_SUSPENDED) continue;
         // Skip buried cards (they'll be unburied on day rollover)
-        if (card.reviewState.queueOverride === -3 || card.reviewState.queueOverride === -2) continue;
+        if (
+          card.reviewState.queueOverride === QUEUE_USER_BURIED ||
+          card.reviewState.queueOverride === QUEUE_SCHED_BURIED
+        )
+          continue;
 
         const dueDate = this.algorithm.getDueDate(card.reviewState.cardState);
         const dueMs = dueDate.getTime();
@@ -193,9 +202,7 @@ export class ReviewQueue {
     const selectedReviews = dueReviews.slice(0, reviewLeft);
 
     const includeAhead =
-      this.settings.showAheadOfSchedule &&
-      selectedReviews.length === 0 &&
-      selectedNew.length === 0
+      this.settings.showAheadOfSchedule && selectedReviews.length === 0 && selectedNew.length === 0
         ? aheadCards
         : [];
 

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -28,6 +28,7 @@ import {
   clearMediaCache,
   filterMediaKeys,
 } from "./utils/mediaCache";
+import { QUEUE_USER_BURIED, QUEUE_SUSPENDED } from "./lib/syncWrite";
 
 /** Revoke object URLs from the previous media map to prevent memory leaks. */
 function revokeOldMediaUrls() {
@@ -203,16 +204,10 @@ export async function deleteCachedFile(name: string) {
 
 const SYNC_COLLECTION_ID = "sync-collection";
 
-export async function loadSyncedCollection(
-  bytes: Uint8Array,
-  mediaBlobs?: Map<string, Blob>,
-) {
+export async function loadSyncedCollection(bytes: Uint8Array, mediaBlobs?: Map<string, Blob>) {
   // Cache SQLite bytes and media blobs so they survive page reloads
   const cache = await ankiCachePromise;
-  await cache.put(
-    "/sync/collection.sqlite",
-    new Response(new Blob([bytes as BlobPart])),
-  );
+  await cache.put("/sync/collection.sqlite", new Response(new Blob([bytes as BlobPart])));
 
   // Revoke old object URLs before clearing
   revokeOldMediaUrls();
@@ -234,9 +229,7 @@ export async function loadSyncedCollection(
 
   // Clear old media entries that weren't replaced by new ones
   const oldMediaKeys = filterMediaKeys(await cache.keys());
-  const deletes = oldMediaKeys.filter(
-    (req) => !newMediaFilenames.has(mediaKeyToFilename(req)),
-  );
+  const deletes = oldMediaKeys.filter((req) => !newMediaFilenames.has(mediaKeyToFilename(req)));
   await Promise.all(deletes.map((req) => cache.delete(req)));
 
   persistActiveDeckSourceId(SYNC_COLLECTION_ID);
@@ -261,15 +254,11 @@ export async function getCachedSqlite(): Promise<Uint8Array | null> {
  */
 export async function refreshSyncedCollection(bytes: Uint8Array) {
   const cache = await ankiCachePromise;
-  await cache.put(
-    "/sync/collection.sqlite",
-    new Response(new Blob([bytes as BlobPart])),
-  );
+  await cache.put("/sync/collection.sqlite", new Response(new Blob([bytes as BlobPart])));
 
   // Recover existing media object URLs from the current activeDeckInputSig
   const currentInput = activeDeckInputSig.value;
-  const existingMedia =
-    currentInput?.kind === "sqlite" ? currentInput.mediaFiles : undefined;
+  const existingMedia = currentInput?.kind === "sqlite" ? currentInput.mediaFiles : undefined;
 
   persistActiveDeckSourceId(SYNC_COLLECTION_ID);
   activeDeckInputSig.value = { kind: "sqlite", bytes, mediaFiles: existingMedia };
@@ -289,8 +278,7 @@ export async function addMediaToCache(mediaBlobs: Map<string, Blob>) {
   const currentInput = activeDeckInputSig.value;
 
   // Get or create the media files map
-  const existingMedia =
-    currentInput?.kind === "sqlite" ? currentInput.mediaFiles : undefined;
+  const existingMedia = currentInput?.kind === "sqlite" ? currentInput.mediaFiles : undefined;
   const mediaFiles = existingMedia ? new Map(existingMedia) : new Map<string, string>();
 
   for (const [filename, blob] of mediaBlobs) {
@@ -552,9 +540,7 @@ export function moveToNextReviewCard() {
       if (card.cardId === currentId) continue;
       if (!queue.isCardInLearning(card)) continue;
       try {
-        const dueMs = new Date(
-          (card.reviewState.cardState as { due: number }).due,
-        ).getTime();
+        const dueMs = new Date((card.reviewState.cardState as { due: number }).due).getTime();
         if (dueMs <= nowMs) {
           currentReviewCardSig.value = card;
           return;
@@ -624,8 +610,8 @@ function removeCurrentCardAndAdvance() {
 export async function buryCurrentCard() {
   const card = currentReviewCardSig.value;
   if (!card) return;
-  await reviewDB.patchCard(card.cardId, { queueOverride: -3 });
-  card.reviewState.queueOverride = -3;
+  await reviewDB.patchCard(card.cardId, { queueOverride: QUEUE_USER_BURIED });
+  card.reviewState.queueOverride = QUEUE_USER_BURIED;
   removeCurrentCardAndAdvance();
 }
 
@@ -635,8 +621,8 @@ export async function buryCurrentCard() {
 export async function suspendCurrentCard() {
   const card = currentReviewCardSig.value;
   if (!card) return;
-  await reviewDB.patchCard(card.cardId, { queueOverride: -1 });
-  card.reviewState.queueOverride = -1;
+  await reviewDB.patchCard(card.cardId, { queueOverride: QUEUE_SUSPENDED });
+  card.reviewState.queueOverride = QUEUE_SUSPENDED;
   removeCurrentCardAndAdvance();
 }
 
@@ -722,19 +708,20 @@ export async function updateNote(
     const mod = Math.floor(Date.now() / 1000);
     const tagsStr = newTags.length > 0 ? ` ${newTags.join(" ")} ` : "";
 
-    db.run(
-      "UPDATE notes SET flds=?, sfld=?, csum=?, mod=?, usn=-1, tags=? WHERE id=?",
-      [flds, sfld, csum, mod, tagsStr, noteId],
-    );
+    db.run("UPDATE notes SET flds=?, sfld=?, csum=?, mod=?, usn=-1, tags=? WHERE id=?", [
+      flds,
+      sfld,
+      csum,
+      mod,
+      tagsStr,
+      noteId,
+    ]);
 
     const newBytes = new Uint8Array(db.export());
 
     // Write to cache for sync
     const cache = await caches.open("anki-cache");
-    await cache.put(
-      "/sync/collection.sqlite",
-      new Response(new Blob([newBytes as BlobPart])),
-    );
+    await cache.put("/sync/collection.sqlite", new Response(new Blob([newBytes as BlobPart])));
 
     // Update in-place without triggering re-parse
     (input as { bytes: Uint8Array }).bytes = newBytes;

--- a/src/utils/__tests__/renderGaps.test.ts
+++ b/src/utils/__tests__/renderGaps.test.ts
@@ -267,8 +267,7 @@ describe("Rendering Gaps (expected to fail)", () => {
       // The regex approach may fail because {{#A}}...{{/A}} with (.|\\n)+?
       // could match "x{{/A}}{{#B}}y{{/B}}{{#A}}z" as the content
       const html = getRenderedCardString({
-        templateString:
-          "{{#A}}x{{/A}}{{#B}}y{{/B}}{{#A}}z{{/A}}",
+        templateString: "{{#A}}x{{/A}}{{#B}}y{{/B}}{{#A}}z{{/A}}",
         variables,
         mediaFiles: new Map(),
       });
@@ -424,7 +423,7 @@ describe("Rendering Gaps (expected to fail)", () => {
   describe("#20 - anki-mathjax tags", () => {
     it("should render <anki-mathjax> inline tags", () => {
       const variables = {
-        Front: 'The formula is <anki-mathjax>x^2 + y^2 = r^2</anki-mathjax>.',
+        Front: "The formula is <anki-mathjax>x^2 + y^2 = r^2</anki-mathjax>.",
       };
 
       const html = getRenderedCardString({

--- a/src/utils/deckInfo.ts
+++ b/src/utils/deckInfo.ts
@@ -2,9 +2,7 @@ import type { SubDeckInfo, DeckTreeNode } from "../types";
 import type { AnkiData } from "../ankiParser";
 
 export function computeDeckInfo(ankiData: AnkiData) {
-  const nameToDeckId = new Map(
-    Object.entries(ankiData.decks).map(([id, deck]) => [deck.name, id]),
-  );
+  const nameToDeckId = new Map(Object.entries(ankiData.decks).map(([id, deck]) => [deck.name, id]));
 
   const cardsWithDeckIds = ankiData.cards.map((card) => ({
     card,

--- a/src/utils/mediaCache.ts
+++ b/src/utils/mediaCache.ts
@@ -7,18 +7,14 @@ const MEDIA_PATH_PREFIX = "/sync/media/";
 
 /** Filter cache keys that belong to synced media entries. */
 export function filterMediaKeys(allKeys: readonly Request[]): Request[] {
-  return allKeys.filter((req) =>
-    new URL(req.url).pathname.startsWith(MEDIA_PATH_PREFIX),
-  );
+  return allKeys.filter((req) => new URL(req.url).pathname.startsWith(MEDIA_PATH_PREFIX));
 }
 
 /** Extract the filename from a media cache key. */
 export function mediaKeyToFilename(req: Request): string {
   // decodeURIComponent is needed because the Cache API URL-encodes pathnames
   // (e.g., spaces → %20, unicode → %XX), but card HTML references raw filenames.
-  return decodeURIComponent(
-    new URL(req.url).pathname.slice(MEDIA_PATH_PREFIX.length),
-  );
+  return decodeURIComponent(new URL(req.url).pathname.slice(MEDIA_PATH_PREFIX.length));
 }
 
 /** Build a cache key path for a media filename. */
@@ -29,9 +25,7 @@ export function mediaCachePath(filename: string): string {
 /**
  * Load all cached media entries as filename → Blob.
  */
-export async function getLocalMediaEntries(
-  cache: Cache,
-): Promise<Map<string, Blob>> {
+export async function getLocalMediaEntries(cache: Cache): Promise<Map<string, Blob>> {
   const mediaKeys = filterMediaKeys(await cache.keys());
   const entries = new Map<string, Blob>();
   for (const req of mediaKeys) {
@@ -47,9 +41,7 @@ export async function getLocalMediaEntries(
  * Load all cached media entries as filename → object URL string.
  * Caller is responsible for revoking the returned URLs when no longer needed.
  */
-export async function loadMediaObjectUrls(
-  cache: Cache,
-): Promise<Map<string, string>> {
+export async function loadMediaObjectUrls(cache: Cache): Promise<Map<string, string>> {
   const mediaKeys = filterMediaKeys(await cache.keys());
   const urls = new Map<string, string>();
   for (const req of mediaKeys) {

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -309,8 +309,10 @@ function applyFilter(
 const RUBY_RE = / ?([^\s[]+)\[([^\]]+)\]/g;
 
 function applyFuriganaFilter(text: string): string {
-  return text.replace(RUBY_RE, (_m, base: string, reading: string) =>
-    `<ruby>${base}<rt>${reading}</rt></ruby>`);
+  return text.replace(
+    RUBY_RE,
+    (_m, base: string, reading: string) => `<ruby>${base}<rt>${reading}</rt></ruby>`,
+  );
 }
 
 function applyKanjiFilter(text: string): string {
@@ -591,7 +593,10 @@ function replaceLatex(renderedString: string, macros: Record<string, string> = {
   return (
     renderedString
       // <anki-mathjax block="true">...</anki-mathjax> → display math
-      .replace(/<anki-mathjax\s+block="true"\s*>([\s\S]+?)<\/anki-mathjax>/g, replaceDisplayMathBlock)
+      .replace(
+        /<anki-mathjax\s+block="true"\s*>([\s\S]+?)<\/anki-mathjax>/g,
+        replaceDisplayMathBlock,
+      )
       // <anki-mathjax>...</anki-mathjax> → inline math
       .replace(/<anki-mathjax>([\s\S]+?)<\/anki-mathjax>/g, replaceInlineMathBlock)
       // [$$]...[/$$] is display math
@@ -657,10 +662,7 @@ function replaceTemplatingSyntax(renderedString: string) {
  * When isCloze is true, first unwraps cloze markers to check if
  * the underlying content is non-empty.
  */
-function fieldIsNotEmpty(
-  value: string | null | undefined,
-  isCloze?: boolean,
-): boolean {
+function fieldIsNotEmpty(value: string | null | undefined, isCloze?: boolean): boolean {
   if (!value) return false;
   const processed = isCloze
     ? parseClozeNodes(value)

--- a/src/utils/sound.ts
+++ b/src/utils/sound.ts
@@ -22,9 +22,7 @@ export function getAutoplayAudioSources(html: string): string[] {
   const allAudioContainers = new DOMParser()
     .parseFromString(html, "text/html")
     .querySelectorAll<HTMLAudioElement>("div.audio-container[data-autoplay] audio");
-  return [...allAudioContainers]
-    .map((audio) => audio.getAttribute("src"))
-    .filter(isTruthy);
+  return [...allAudioContainers].map((audio) => audio.getAttribute("src")).filter(isTruthy);
 }
 
 export function playAudio(src: string): void {

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -1,6 +1,6 @@
 import { type Database } from "sql.js";
 
-let sqlJsPromise: Promise<Awaited<ReturnType<typeof import("sql.js")["default"]>>> | null = null;
+let sqlJsPromise: Promise<Awaited<ReturnType<(typeof import("sql.js"))["default"]>>> | null = null;
 
 export async function createDatabase(data?: Uint8Array): Promise<Database> {
   if (!sqlJsPromise) {


### PR DESCRIPTION
## Summary

- Export `QUEUE_SUSPENDED` and `QUEUE_SCHED_BURIED` constants and replace magic numbers in `queue.ts` and `stores.ts`
- Add `getReviewLogsForCards()` batch method to ReviewDB, eliminating N+1 IndexedDB queries in `insertRevlogs`
- Extract `skipUnknownField` helper in `parseMediaProto.ts` to deduplicate wire-type skip logic
- Remove unused import and variable