### PR TITLE
add deck rename, delete, and export to settings modal

### DIFF
--- a/src/components/FileLibrary.vue
+++ b/src/components/FileLibrary.vue
@@ -15,12 +15,25 @@ import {
   selectedDeckIdSig,
   reviewModeSig,
   openDeckSettings,
+  adoptedSampleIdsSig,
+  adoptSampleDeck,
+  removeAdoptedSample,
 } from "../stores";
 import type { DeckTreeNode } from "../types";
 
 const fileInput = ref<HTMLInputElement>();
 
-const sampleDecks = computed(() => sampleDeckData.map(createSampleDeckLibraryItem));
+const adoptedIds = computed(() => new Set(adoptedSampleIdsSig.value));
+const sampleDecks = computed(() =>
+  sampleDeckData
+    .filter((d) => !adoptedIds.value.has(d.id))
+    .map(createSampleDeckLibraryItem),
+);
+const adoptedSampleDecks = computed(() =>
+  sampleDeckData
+    .filter((d) => adoptedIds.value.has(d.id))
+    .map(createSampleDeckLibraryItem),
+);
 const uploadedDecks = computed(() =>
   [...cachedFilesSig.value].sort((a, b) => b.addedAt - a.addedAt).map(createCachedDeckLibraryItem),
 );
@@ -64,10 +77,17 @@ function flattenTree(nodes: DeckTreeNode[]): DeckTreeNode[] {
 
 const flatTree = computed(() => (deckInfoSig.value ? flattenTree(deckInfoSig.value.tree) : []));
 
+/** Whether the active deck belongs to "Your Decks" (adopted sample or uploaded file) */
+const isYourDeckActive = computed(() => {
+  const id = activeDeckSourceIdSig.value;
+  if (!id) return false;
+  return adoptedIds.value.has(id) || cachedFilesSig.value.some((f) => f.name === id);
+});
+
 function handleOpenSettings(node: DeckTreeNode, event: Event) {
   event.stopPropagation();
   // Compute the card count for this deck to match the storage key used by initializeReviewQueue
-  openDeckSettings(`deck-${node.cardCount}`);
+  openDeckSettings(`deck-${node.cardCount}`, node);
 }
 </script>
 
@@ -85,7 +105,7 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
       <Button variant="primary" size="sm" @click="fileInput?.click()"> Add File </Button>
     </div>
 
-    <section v-if="!syncActiveSig" class="library-section">
+    <section v-if="!syncActiveSig && sampleDecks.length > 0" class="library-section">
       <div class="section-header">
         <h3 class="section-title">Sample Decks</h3>
         <span class="section-count">{{ sampleDecks.length }}</span>
@@ -94,14 +114,16 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
         <div
           v-for="sampleDeck in sampleDecks"
           :key="sampleDeck.id"
-          :class="['file-card', { 'file-card--active': activeDeckSourceIdSig === sampleDeck.id }]"
-          @click="loadSampleDeck(sampleDeck.id)"
+          class="file-card file-card--static"
         >
           <div class="file-info">
             <span class="file-name">{{ sampleDeck.title }}</span>
             <span class="file-meta">{{ sampleDeck.detail }}</span>
             <span class="file-meta">{{ sampleDeck.meta }}</span>
           </div>
+          <Button variant="secondary" size="sm" @click="adoptSampleDeck(sampleDeck.id)">
+            Add
+          </Button>
         </div>
       </div>
     </section>
@@ -185,37 +207,118 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
     <section class="library-section">
       <div class="section-header">
         <h3 class="section-title">Your Decks</h3>
-        <span class="section-count">{{ uploadedDecks.length }}</span>
+        <span class="section-count">{{ adoptedSampleDecks.length + uploadedDecks.length }}</span>
       </div>
 
-      <div v-if="uploadedDecks.length === 0" class="empty-state">
+      <div v-if="uploadedDecks.length === 0 && adoptedSampleDecks.length === 0" class="empty-state">
         <p class="empty-text">
-          No uploaded decks yet. Add an .apkg file to keep your own deck here.
+          No decks yet. Add an .apkg file or a sample deck to get started.
         </p>
         <Button variant="secondary" @click="fileInput?.click()"> Choose a Deck File </Button>
       </div>
 
-      <div v-else class="file-grid">
-        <div
-          v-for="deck in uploadedDecks"
-          :key="deck.id"
-          :class="['file-card', { 'file-card--active': activeDeckSourceIdSig === deck.id }]"
-          @click="loadCachedFile(deck.id)"
-        >
-          <div class="file-info">
-            <span class="file-name">{{ deck.title }}</span>
-            <span class="file-meta">{{ deck.detail }}</span>
-            <span class="file-meta">{{ deck.meta }}</span>
-          </div>
-          <button
-            class="delete-btn"
-            title="Remove from library"
-            @click.stop="deleteCachedFile(deck.id)"
+      <template v-else>
+        <div class="file-grid">
+          <div
+            v-for="deck in adoptedSampleDecks"
+            :key="deck.id"
+            :class="['file-card', { 'file-card--active': activeDeckSourceIdSig === deck.id }]"
+            @click="loadSampleDeck(deck.id)"
           >
-            &times;
-          </button>
+            <div class="file-info">
+              <span class="file-name">{{ deck.title }}</span>
+              <span class="file-meta">{{ deck.detail }}</span>
+            </div>
+            <button
+              class="delete-btn"
+              title="Remove from library"
+              @click.stop="removeAdoptedSample(deck.id)"
+            >
+              &times;
+            </button>
+          </div>
+          <div
+            v-for="deck in uploadedDecks"
+            :key="deck.id"
+            :class="['file-card', { 'file-card--active': activeDeckSourceIdSig === deck.id }]"
+            @click="loadCachedFile(deck.id)"
+          >
+            <div class="file-info">
+              <span class="file-name">{{ deck.title }}</span>
+              <span class="file-meta">{{ deck.detail }}</span>
+            </div>
+            <button
+              class="delete-btn"
+              title="Remove from library"
+              @click.stop="deleteCachedFile(deck.id)"
+            >
+              &times;
+            </button>
+          </div>
         </div>
-      </div>
+
+        <!-- Deck tree for active your-deck -->
+        <div v-if="!syncActiveSig && isYourDeckActive && deckInfoSig" class="deck-tree your-deck-tree">
+          <div
+            v-for="node in flatTree"
+            :key="node.fullName"
+            :class="['deck-row', { 'deck-row--active': selectedDeckIdSig === node.id }]"
+            :style="{ paddingLeft: `${12 + node.depth * 20}px` }"
+            @click="selectSubdeck(node.id)"
+          >
+            <div class="deck-row-left">
+              <button
+                v-if="node.children.length > 0"
+                class="collapse-btn"
+                :title="collapsed.has(node.fullName) ? 'Expand' : 'Collapse'"
+                @click="toggleCollapse(node.fullName, $event)"
+              >
+                <span
+                  :class="[
+                    'collapse-icon',
+                    { 'collapse-icon--collapsed': collapsed.has(node.fullName) },
+                  ]"
+                  >&#9662;</span
+                >
+              </button>
+              <span v-else class="collapse-spacer" />
+              <span class="deck-name">{{ node.name }}</span>
+            </div>
+            <div class="deck-row-right">
+              <Tooltip text="New"
+                ><span class="stat stat--new">{{ node.newCount }}</span></Tooltip
+              >
+              <Tooltip text="Learning"
+                ><span class="stat stat--learn">{{ node.learnCount }}</span></Tooltip
+              >
+              <Tooltip text="Due"
+                ><span class="stat stat--due">{{ node.dueCount }}</span></Tooltip
+              >
+              <button
+                class="settings-btn"
+                title="Deck settings"
+                @click="handleOpenSettings(node, $event)"
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+                  />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </template>
     </section>
   </div>
 </template>
@@ -310,6 +413,15 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
   background: var(--color-surface-elevated);
 }
 
+.file-card--static {
+  cursor: default;
+}
+
+.file-card--static:hover {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+}
+
 .file-info {
   display: flex;
   flex-direction: column;
@@ -329,6 +441,10 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
 .file-meta {
   font-size: var(--font-size-xs);
   color: var(--color-text-tertiary);
+}
+
+.your-deck-tree {
+  margin-top: var(--spacing-3);
 }
 
 /* Deck tree (synced decks with hierarchy) */

--- a/src/components/SchedulerSettings.vue
+++ b/src/components/SchedulerSettings.vue
@@ -5,7 +5,12 @@ import {
   schedulerSettingsSig,
   initializeReviewQueue,
   settingsTargetDeckIdSig,
+  settingsTargetDeckNodeSig,
   getActiveDeckId,
+  isSyncedCollection,
+  renameDeckInCollection,
+  deleteDeckFromCollection,
+  exportDeckFromCollection,
 } from "../stores";
 import type { SchedulerSettings } from "../scheduler/types";
 import { DEFAULT_SM2_PARAMS } from "../scheduler/types";
@@ -21,13 +26,64 @@ const emit = defineEmits<{
 
 const settings = ref<SchedulerSettings>({ ...schedulerSettingsSig.value });
 
+// Deck management state
+const isRenaming = ref(false);
+const renameValue = ref("");
+const showDeleteConfirm = ref(false);
+const isExporting = ref(false);
+
+const deckNode = computed(() => settingsTargetDeckNodeSig.value);
+const isSynced = computed(() => isSyncedCollection());
+
 // Sync settings when modal opens
 watch(
   () => props.isOpen,
   (isOpen) => {
-    if (isOpen) settings.value = { ...schedulerSettingsSig.value };
+    if (isOpen) {
+      settings.value = { ...schedulerSettingsSig.value };
+      isRenaming.value = false;
+      showDeleteConfirm.value = false;
+    }
   },
 );
+
+function startRename() {
+  if (!deckNode.value) return;
+  renameValue.value = deckNode.value.name;
+  isRenaming.value = true;
+}
+
+async function confirmRename() {
+  const node = deckNode.value;
+  if (!node || !renameValue.value.trim()) return;
+  const newName = renameValue.value.trim();
+  if (newName === node.name) {
+    isRenaming.value = false;
+    return;
+  }
+  await renameDeckInCollection(node.id, node.fullName, newName);
+  isRenaming.value = false;
+  emit("close");
+}
+
+async function confirmDelete() {
+  const node = deckNode.value;
+  if (!node) return;
+  await deleteDeckFromCollection(node.id, node.fullName);
+  showDeleteConfirm.value = false;
+  emit("close");
+}
+
+async function handleExport() {
+  const node = deckNode.value;
+  if (!node) return;
+  isExporting.value = true;
+  try {
+    await exportDeckFromCollection(node.fullName);
+  } finally {
+    isExporting.value = false;
+  }
+}
 
 const sm2 = computed(() => ({
   ...DEFAULT_SM2_PARAMS,
@@ -94,6 +150,54 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
 
 <template>
   <Modal title="Deck Settings" :is-open="isOpen" size="sm" @close="emit('close')">
+    <!-- Deck Management (synced decks only) -->
+    <div v-if="deckNode && isSynced" class="form-section">
+      <div class="section-title">Deck</div>
+
+      <div v-if="!isRenaming && !showDeleteConfirm" class="deck-name-display">
+        <span class="deck-full-name">{{ deckNode.fullName }}</span>
+        <span class="deck-card-count">{{ deckNode.cardCount }} cards</span>
+      </div>
+
+      <!-- Rename inline -->
+      <div v-if="isRenaming" class="form-group">
+        <label class="form-label">New Name</label>
+        <div class="rename-row">
+          <input
+            v-model="renameValue"
+            type="text"
+            class="form-input"
+            @keyup.enter="confirmRename"
+            @keyup.escape="isRenaming = false"
+          />
+          <Button variant="primary" size="sm" @click="confirmRename">Save</Button>
+          <Button variant="secondary" size="sm" @click="isRenaming = false">Cancel</Button>
+        </div>
+        <div class="help-text">Only renames this deck segment, not parent path</div>
+      </div>
+
+      <!-- Delete confirmation -->
+      <div v-if="showDeleteConfirm" class="delete-confirm">
+        <p class="delete-warning">
+          Delete "<strong>{{ deckNode.fullName }}</strong>" and all its
+          {{ deckNode.cardCount }} cards? This cannot be undone.
+        </p>
+        <div class="delete-actions">
+          <Button variant="danger" size="sm" @click="confirmDelete">Delete</Button>
+          <Button variant="secondary" size="sm" @click="showDeleteConfirm = false">Cancel</Button>
+        </div>
+      </div>
+
+      <!-- Action buttons -->
+      <div v-if="!isRenaming && !showDeleteConfirm" class="deck-actions">
+        <Button variant="secondary" size="sm" @click="startRename">Rename</Button>
+        <Button variant="secondary" size="sm" :disabled="isExporting" @click="handleExport">
+          {{ isExporting ? "Exporting..." : "Export" }}
+        </Button>
+        <Button variant="danger" size="sm" @click="showDeleteConfirm = true">Delete</Button>
+      </div>
+    </div>
+
     <div class="form-section">
       <div class="section-title">Scheduler</div>
       <div class="form-group">
@@ -447,5 +551,48 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
   align-items: center;
   justify-content: space-between;
   cursor: pointer;
+}
+.deck-name-display {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-0-5);
+  margin-bottom: var(--spacing-3);
+}
+.deck-full-name {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  word-break: break-word;
+}
+.deck-card-count {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+}
+.deck-actions {
+  display: flex;
+  gap: var(--spacing-2);
+}
+.rename-row {
+  display: flex;
+  gap: var(--spacing-2);
+  align-items: center;
+}
+.rename-row .form-input {
+  flex: 1;
+}
+.delete-confirm {
+  padding: var(--spacing-3);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-error);
+  border-radius: var(--radius-sm);
+}
+.delete-warning {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-3) 0;
+}
+.delete-actions {
+  display: flex;
+  gap: var(--spacing-2);
 }
 </style>

--- a/src/deckLibrary.ts
+++ b/src/deckLibrary.ts
@@ -26,6 +26,7 @@ type DeckLibraryItem = {
 const activeDeckSourceStorageKey = "anki-active-deck";
 const cachedFilesStorageKey = "anki-cached-files";
 const legacyActiveFileStorageKey = "anki-active-file";
+const adoptedSamplesStorageKey = "anki-adopted-samples";
 export const importedDeckFileName = "imported-deck.apkg";
 
 export function readCachedFiles(): CachedFileEntry[] {
@@ -129,4 +130,19 @@ export function createSampleDeckLibraryItem(sampleDeck: {
     meta: `${sampleDeck.data.cards.length} cards · built in`,
     isRemovable: false,
   };
+}
+
+export function readAdoptedSampleIds(): string[] {
+  const stored = localStorage.getItem(adoptedSamplesStorageKey);
+  if (!stored) return [];
+  try {
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeAdoptedSampleIds(ids: string[]) {
+  localStorage.setItem(adoptedSamplesStorageKey, JSON.stringify(ids));
 }

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -2,21 +2,24 @@ import { ref, computed, watch, shallowRef, triggerRef } from "vue";
 import { getAnkiDataFromBlob, getAnkiDataFromSqlite } from "./ankiParser";
 import type { AnkiData } from "./ankiParser";
 import { createDatabase } from "./utils/sql";
+import type { SqlValue } from "sql.js";
 import { stringHash } from "./utils/constants";
 import { ReviewQueue, type ReviewCard } from "./scheduler/queue";
 import { DEFAULT_SCHEDULER_SETTINGS, type SchedulerSettings } from "./scheduler/types";
 import { reviewDB } from "./scheduler/db";
-import type { DeckInfo } from "./types";
+import type { DeckInfo, DeckTreeNode } from "./types";
 import { sampleDeckMap, sampleDecks } from "./sampleDecks";
 import {
   importedDeckFileName,
   persistActiveDeckSourceId as persistStoredActiveDeckSourceId,
+  readAdoptedSampleIds,
   readCachedFiles,
   readStoredActiveDeckSourceId,
   removeCachedFileEntry,
   type CachedFileEntry,
   type DeckInput,
   upsertCachedFileEntry,
+  writeAdoptedSampleIds,
   writeCachedFiles,
 } from "./deckLibrary";
 import { readSyncState } from "./lib/ankiSync";
@@ -181,6 +184,36 @@ export function loadSampleDeck(id: string) {
   activeDeckInputSig.value = { kind: "sample", data: sampleDeck.data };
   activeViewSig.value = "review";
   reviewModeSig.value = "studying";
+}
+
+// Adopted sample decks — sample decks the user has added to "Your Decks"
+export const adoptedSampleIdsSig = ref<string[]>(readAdoptedSampleIds());
+
+export function adoptSampleDeck(id: string) {
+  if (adoptedSampleIdsSig.value.includes(id)) return;
+  adoptedSampleIdsSig.value = [...adoptedSampleIdsSig.value, id];
+  writeAdoptedSampleIds(adoptedSampleIdsSig.value);
+  loadSampleDeck(id);
+}
+
+export function removeAdoptedSample(id: string) {
+  adoptedSampleIdsSig.value = adoptedSampleIdsSig.value.filter((s) => s !== id);
+  writeAdoptedSampleIds(adoptedSampleIdsSig.value);
+
+  if (activeDeckSourceIdSig.value !== id) return;
+
+  // If the removed sample was active, load the next available deck or clear
+  const nextCached = cachedFilesSig.value[0];
+  if (nextCached) {
+    loadCachedFile(nextCached.name);
+  } else {
+    const nextAdopted = adoptedSampleIdsSig.value[0];
+    if (nextAdopted) {
+      loadSampleDeck(nextAdopted);
+    } else {
+      clearLoadedDeck();
+    }
+  }
 }
 
 export async function deleteCachedFile(name: string) {
@@ -416,16 +449,381 @@ export const currentReviewCardSig = shallowRef<ReviewCard | null>(null);
 export const schedulerSettingsModalOpenSig = ref(false);
 /** The deck ID whose settings are being edited in the modal */
 export const settingsTargetDeckIdSig = ref<string | null>(null);
+/** The deck tree node whose settings are being edited */
+export const settingsTargetDeckNodeSig = ref<DeckTreeNode | null>(null);
 
 /**
  * Open the scheduler settings modal for a specific deck.
  * Loads that deck's persisted settings into the form.
  */
-export async function openDeckSettings(deckId: string) {
+export async function openDeckSettings(deckId: string, node?: DeckTreeNode) {
   const settings = await reviewDB.getSettings(deckId);
   schedulerSettingsSig.value = settings;
   settingsTargetDeckIdSig.value = deckId;
+  settingsTargetDeckNodeSig.value = node ?? null;
   schedulerSettingsModalOpenSig.value = true;
+}
+
+/**
+ * Whether the active deck is a synced SQLite collection.
+ */
+export function isSyncedCollection(): boolean {
+  return activeDeckInputSig.value?.kind === "sqlite";
+}
+
+/**
+ * Rename a deck in the synced SQLite collection.
+ * Updates the deck name and all child deck name prefixes.
+ */
+export async function renameDeckInCollection(
+  deckId: string,
+  oldFullName: string,
+  newName: string,
+): Promise<void> {
+  const input = activeDeckInputSig.value;
+  if (input?.kind !== "sqlite") return;
+
+  const db = await createDatabase(input.bytes);
+  try {
+    const tables = db.exec("SELECT name FROM sqlite_master WHERE type='table'");
+    const tableNames = new Set((tables[0]?.values ?? []).map((row) => row[0] as string));
+    const anki21b = tableNames.has("notetypes");
+
+    // Compute new full name: replace the last segment of oldFullName
+    const parts = oldFullName.split("::");
+    parts[parts.length - 1] = newName;
+    const newFullName = parts.join("::");
+
+    const mod = Math.floor(Date.now() / 1000);
+
+    if (anki21b) {
+      // Update the deck itself
+      db.run("UPDATE decks SET name=?, mtime_secs=?, usn=-1 WHERE id=?", [
+        newFullName,
+        mod,
+        deckId,
+      ]);
+      // Update child decks: replace oldFullName:: prefix with newFullName::
+      const children = db.exec("SELECT id, name FROM decks WHERE name LIKE ?", [
+        oldFullName + "::%",
+      ]);
+      if (children[0]) {
+        for (const row of children[0].values) {
+          const childId = row[0] as number;
+          const childName = row[1] as string;
+          const updatedName = newFullName + childName.slice(oldFullName.length);
+          db.run("UPDATE decks SET name=?, mtime_secs=?, usn=-1 WHERE id=?", [
+            updatedName,
+            mod,
+            childId,
+          ]);
+        }
+      }
+    } else {
+      // anki2: decks stored as JSON in col.decks
+      const result = db.exec("SELECT decks FROM col");
+      const decksJson = JSON.parse((result[0]?.values[0]?.[0] as string) ?? "{}");
+      const deck = decksJson[String(deckId)];
+      if (deck) {
+        deck.name = newFullName;
+        deck.mod = mod;
+        deck.usn = -1;
+      }
+      // Update children
+      for (const d of Object.values(decksJson) as { name: string; mod: number; usn: number }[]) {
+        if (d.name.startsWith(oldFullName + "::")) {
+          d.name = newFullName + d.name.slice(oldFullName.length);
+          d.mod = mod;
+          d.usn = -1;
+        }
+      }
+      db.run("UPDATE col SET decks=?", [JSON.stringify(decksJson)]);
+    }
+
+    const newBytes = new Uint8Array(db.export());
+
+    // Update cache
+    const cache = await caches.open("anki-cache");
+    await cache.put("/sync/collection.sqlite", new Response(new Blob([newBytes as BlobPart])));
+
+    // Update in-place and re-parse
+    (input as { bytes: Uint8Array }).bytes = newBytes;
+    const { getAnkiDataFromSqlite } = await import("./ankiParser");
+    ankiDataSig.value = await getAnkiDataFromSqlite(newBytes, input.mediaFiles);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Delete a deck from the synced SQLite collection.
+ * Removes the deck, its cards, orphaned notes, and marks for sync.
+ */
+export async function deleteDeckFromCollection(
+  deckId: string,
+  fullName: string,
+): Promise<void> {
+  const input = activeDeckInputSig.value;
+  if (input?.kind !== "sqlite") return;
+
+  const db = await createDatabase(input.bytes);
+  try {
+    const tables = db.exec("SELECT name FROM sqlite_master WHERE type='table'");
+    const tableNames = new Set((tables[0]?.values ?? []).map((row) => row[0] as string));
+    const anki21b = tableNames.has("notetypes");
+
+    // Collect all deck IDs to delete (this deck + children)
+    const deckIdsToDelete: number[] = [];
+
+    if (anki21b) {
+      const rows = db.exec(
+        "SELECT id FROM decks WHERE id=? OR name LIKE ?",
+        [deckId, fullName + "::%"],
+      );
+      if (rows[0]) {
+        for (const row of rows[0].values) deckIdsToDelete.push(row[0] as number);
+      }
+    } else {
+      const result = db.exec("SELECT decks FROM col");
+      const decksJson = JSON.parse((result[0]?.values[0]?.[0] as string) ?? "{}");
+      for (const [id, d] of Object.entries(decksJson) as [string, { name: string }][]) {
+        if (id === String(deckId) || d.name.startsWith(fullName + "::")) {
+          deckIdsToDelete.push(Number(id));
+        }
+      }
+    }
+
+    // Delete cards in those decks and track orphaned notes
+    for (const did of deckIdsToDelete) {
+      const cardRows = db.exec("SELECT id, nid FROM cards WHERE did=?", [did]);
+      if (cardRows[0]) {
+        for (const row of cardRows[0].values) {
+          const cardId = row[0] as number;
+          const noteId = row[1] as number;
+          db.run("DELETE FROM cards WHERE id=?", [cardId]);
+          await reviewDB.deleteCard(String(cardId));
+          await reviewDB.deleteReviewLogsForCard(String(cardId));
+
+          // Delete note if no more cards reference it
+          const remaining = db.exec("SELECT COUNT(*) FROM cards WHERE nid=?", [noteId]);
+          if ((remaining[0]?.values[0]?.[0] as number) === 0) {
+            db.run("DELETE FROM notes WHERE id=?", [noteId]);
+          }
+        }
+      }
+
+      // Delete the deck and record graves for sync
+      if (anki21b) {
+        db.run("DELETE FROM decks WHERE id=?", [did]);
+      }
+      // Record in graves table for sync
+      db.run("INSERT INTO graves (usn, oid, type) VALUES (-1, ?, 2)", [did]);
+      await reviewDB.markDeckDeleted(String(did));
+    }
+
+    if (!anki21b) {
+      // anki2: remove from JSON
+      const result = db.exec("SELECT decks FROM col");
+      const decksJson = JSON.parse((result[0]?.values[0]?.[0] as string) ?? "{}");
+      for (const did of deckIdsToDelete) delete decksJson[String(did)];
+      db.run("UPDATE col SET decks=?", [JSON.stringify(decksJson)]);
+    }
+
+    const newBytes = new Uint8Array(db.export());
+
+    // Update cache
+    const cache = await caches.open("anki-cache");
+    await cache.put("/sync/collection.sqlite", new Response(new Blob([newBytes as BlobPart])));
+
+    // Update in-place and re-parse
+    (input as { bytes: Uint8Array }).bytes = newBytes;
+    const { getAnkiDataFromSqlite } = await import("./ankiParser");
+    ankiDataSig.value = await getAnkiDataFromSqlite(newBytes, input.mediaFiles);
+
+    // Clear selected deck if it was the deleted one
+    if (selectedDeckIdSig.value === deckId) {
+      selectedDeckIdSig.value = null;
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Export a deck (and its subdecks) from the synced SQLite collection as an .apkg file.
+ */
+export async function exportDeckFromCollection(fullName: string): Promise<void> {
+  const input = activeDeckInputSig.value;
+  if (input?.kind !== "sqlite") return;
+
+  const { BlobWriter, ZipWriter, BlobReader } = await import("@zip-js/zip-js");
+
+  const srcDb = await createDatabase(input.bytes);
+  const destDb = await createDatabase();
+
+  try {
+    const tables = srcDb.exec("SELECT name FROM sqlite_master WHERE type='table'");
+    const tableNames = new Set((tables[0]?.values ?? []).map((row) => row[0] as string));
+    const anki21b = tableNames.has("notetypes");
+
+    // Get the full schema from source and create in destination
+    const schemaRows = srcDb.exec(
+      "SELECT sql FROM sqlite_master WHERE type='table' OR type='index'",
+    );
+    if (schemaRows[0]) {
+      for (const row of schemaRows[0].values) {
+        const sql = row[0] as string | null;
+        if (sql) destDb.run(sql);
+      }
+    }
+
+    // Collect deck IDs to export
+    const deckIds: number[] = [];
+    if (anki21b) {
+      const rows = srcDb.exec("SELECT id FROM decks WHERE name=? OR name LIKE ?", [
+        fullName,
+        fullName + "::%",
+      ]);
+      if (rows[0]) {
+        for (const row of rows[0].values) deckIds.push(row[0] as number);
+      }
+
+      // Copy matching decks
+      for (const did of deckIds) {
+        const deckData = srcDb.exec("SELECT * FROM decks WHERE id=?", [did]);
+        if (deckData[0] && deckData[0].values.length > 0) {
+          const cols = deckData[0].columns.map(() => "?").join(",");
+          destDb.run(`INSERT INTO decks VALUES (${cols})`, deckData[0].values[0] as SqlValue[]);
+        }
+      }
+    } else {
+      const result = srcDb.exec("SELECT decks FROM col");
+      const decksJson = JSON.parse((result[0]?.values[0]?.[0] as string) ?? "{}");
+      const exportDecks: Record<string, unknown> = {};
+      for (const [id, d] of Object.entries(decksJson) as [string, { name: string }][]) {
+        if (d.name === fullName || d.name.startsWith(fullName + "::")) {
+          exportDecks[id] = d;
+          deckIds.push(Number(id));
+        }
+      }
+      // Also include Default deck (id=1) as Anki requires it
+      if (decksJson["1"]) exportDecks["1"] = decksJson["1"];
+
+      // Copy col row with filtered decks
+      const colRow = srcDb.exec("SELECT * FROM col");
+      const colValues = colRow[0]?.values[0];
+      if (colRow[0] && colValues) {
+        const row = [...colValues] as SqlValue[];
+        const decksIdx = colRow[0].columns.indexOf("decks");
+        if (decksIdx !== -1) row[decksIdx] = JSON.stringify(exportDecks);
+        const cols = colRow[0].columns.map(() => "?").join(",");
+        destDb.run(`INSERT INTO col VALUES (${cols})`, row);
+      }
+    }
+
+    // Copy cards for those decks
+    const placeholders = deckIds.map(() => "?").join(",");
+    const cardRows = srcDb.exec(`SELECT * FROM cards WHERE did IN (${placeholders})`, deckIds);
+    const noteIds = new Set<number>();
+    if (cardRows[0]) {
+      const nidIdx = cardRows[0].columns.indexOf("nid");
+      const cols = cardRows[0].columns.map(() => "?").join(",");
+      for (const row of cardRows[0].values) {
+        destDb.run(`INSERT INTO cards VALUES (${cols})`, row as SqlValue[]);
+        noteIds.add(row[nidIdx] as number);
+      }
+    }
+
+    // Copy notes referenced by those cards
+    if (noteIds.size > 0) {
+      const noteIdArr = [...noteIds];
+      const notePlaceholders = noteIdArr.map(() => "?").join(",");
+      const noteRows = srcDb.exec(
+        `SELECT * FROM notes WHERE id IN (${notePlaceholders})`,
+        noteIdArr,
+      );
+      if (noteRows[0]) {
+        const cols = noteRows[0].columns.map(() => "?").join(",");
+        for (const row of noteRows[0].values) {
+          destDb.run(`INSERT INTO notes VALUES (${cols})`, row as SqlValue[]);
+        }
+      }
+    }
+
+    // Copy revlog for exported cards
+    if (cardRows[0]) {
+      const cidIdx = cardRows[0].columns.indexOf("id");
+      const cardIdArr = cardRows[0].values.map((r) => r[cidIdx] as number);
+      if (cardIdArr.length > 0) {
+        const revPlaceholders = cardIdArr.map(() => "?").join(",");
+        const revRows = srcDb.exec(
+          `SELECT * FROM revlog WHERE cid IN (${revPlaceholders})`,
+          cardIdArr,
+        );
+        if (revRows[0]) {
+          const cols = revRows[0].columns.map(() => "?").join(",");
+          for (const row of revRows[0].values) {
+            destDb.run(`INSERT INTO revlog VALUES (${cols})`, row as SqlValue[]);
+          }
+        }
+      }
+    }
+
+    // For anki21b, copy notetypes and deck_config referenced by notes/decks
+    if (anki21b) {
+      // Copy notetypes used by the notes
+      if (noteIds.size > 0) {
+        const midSet = new Set<number>();
+        const noteIdArr = [...noteIds];
+        const notePlaceholders = noteIdArr.map(() => "?").join(",");
+        const midRows = srcDb.exec(
+          `SELECT DISTINCT mid FROM notes WHERE id IN (${notePlaceholders})`,
+          noteIdArr,
+        );
+        if (midRows[0]) {
+          for (const row of midRows[0].values) midSet.add(row[0] as number);
+        }
+        for (const mid of midSet) {
+          const ntRows = srcDb.exec("SELECT * FROM notetypes WHERE id=?", [mid]);
+          if (ntRows[0] && ntRows[0].values.length > 0) {
+            const cols = ntRows[0].columns.map(() => "?").join(",");
+            destDb.run(`INSERT INTO notetypes VALUES (${cols})`, ntRows[0].values[0] as SqlValue[]);
+          }
+        }
+      }
+
+      // Copy col row for anki21b
+      const colRow = srcDb.exec("SELECT * FROM col");
+      if (colRow[0] && colRow[0].values.length > 0) {
+        const cols = colRow[0].columns.map(() => "?").join(",");
+        destDb.run(`INSERT INTO col VALUES (${cols})`, colRow[0].values[0] as SqlValue[]);
+      }
+    }
+
+    // Build the APKG zip
+    const dbData = destDb.export();
+    const zipWriter = new ZipWriter(new BlobWriter("application/zip"));
+    await zipWriter.add(
+      anki21b ? "collection.anki21b" : "collection.anki2",
+      new BlobReader(new Blob([new Uint8Array(dbData)])),
+    );
+    await zipWriter.add("media", new BlobReader(new Blob([JSON.stringify({})])));
+    const blob = await zipWriter.close();
+
+    // Download
+    const safeName = fullName.replace(/::/g, "_").replace(/[^a-zA-Z0-9_-]/g, "_");
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${safeName}.apkg`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  } finally {
+    srcDb.close();
+    destDb.close();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add deck management section (Rename, Export, Delete) to the Deck Settings modal for synced collections
- Rename updates the deck name segment in SQLite (including child decks) and marks for sync
- Delete removes the deck, its cards, orphaned notes, and records sync graves
- Export copies the deck's data (cards, notes, notetypes, revlog) into a new .apkg file for download