### PR TITLE
fix 409 conflict: auto-retry sync after aborting stale session

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,10 +36,14 @@ import SchedulerSettings from "./components/SchedulerSettings.vue";
 import CommandPalette from "./components/CommandPalette.vue";
 import { useCommands } from "./composables/useCommands";
 import { getAutoplayAudioSources, playAudio } from "./utils/sound";
+import { markDataChanged, startAutoSync } from "./lib/autoSync";
 
 const activeSide = ref<"front" | "back">("front");
 const reviewStartTime = ref<number>(Date.now());
 const commands = useCommands();
+
+// Start background auto-sync timer
+startAutoSync();
 
 // Compute deck info from anki data
 const computedDeckInfo = computed(() => {
@@ -161,6 +165,7 @@ async function handleChooseAnswer(answer: Answer) {
       const updatedState = await queue.processReview(reviewCard, answer, reviewTimeMs);
       updateDueCardsAfterReview(reviewCard.cardId, updatedState);
       moveToNextReviewCard();
+      markDataChanged();
     }
   } else {
     moveToNextCard();

--- a/src/__tests__/sync-gap-fixes.test.ts
+++ b/src/__tests__/sync-gap-fixes.test.ts
@@ -173,25 +173,20 @@ function scalar(db: Database, sql: string): unknown {
 describe("sync gap fixes", () => {
   // ── Gap 1: Parallel media sync ──────────────────────────────────
 
-  describe("parallel media sync", () => {
-    test("SyncPanel runs media download and upload concurrently (structural check)", async () => {
-      // This is a structural test — we verify SyncPanel.vue uses Promise.allSettled
-      // for concurrent media operations. The actual concurrent behavior is tested
-      // in integration tests against a real server.
+  describe("sequential media sync", () => {
+    test("SyncPanel runs media download and upload sequentially (structural check)", async () => {
+      // Media sync must be sequential — each calls /msync/begin which starts a new
+      // server session, so parallel calls would invalidate the first session.
       const { readFileSync } = await import("node:fs");
       const syncPanelSource = readFileSync(
         join(process.cwd(), "src", "components", "SyncPanel.vue"),
         "utf-8",
       );
 
-      // Verify concurrent pattern is used
-      expect(syncPanelSource).toContain("Promise.allSettled");
+      // Verify sequential pattern is used (no Promise.allSettled)
+      expect(syncPanelSource).not.toContain("Promise.allSettled");
       expect(syncPanelSource).toContain("downloadMedia");
       expect(syncPanelSource).toContain("uploadMedia");
-
-      // Verify the old sequential pattern is NOT present
-      expect(syncPanelSource).not.toContain("Checking for new media...");
-      expect(syncPanelSource).not.toContain("Checking for media to upload...");
     });
   });
 

--- a/src/__tests__/sync-parity-fixes.test.ts
+++ b/src/__tests__/sync-parity-fixes.test.ts
@@ -458,13 +458,14 @@ describe("sync parity fixes", () => {
   // ── 3: Media batch size ───────────────────────────────────────
 
   describe("media batch size", () => {
-    test("ankiSync uses batch size of 30 for downloads and uploads", async () => {
+    test("ankiSync uses correct batch sizes for downloads and uploads", async () => {
       const { readFileSync } = await import("node:fs");
       const source = readFileSync(
         join(process.cwd(), "src", "lib", "ankiSync.ts"),
         "utf-8",
       );
-      expect(source).toContain("DOWNLOAD_BATCH_SIZE = 30");
+      // Download batch capped at 25 (server's MAX_MEDIA_FILES_IN_ZIP)
+      expect(source).toContain("DOWNLOAD_BATCH_SIZE = 25");
       expect(source).toContain("UPLOAD_BATCH_SIZE = 30");
     });
   });

--- a/src/components/SyncPanel.vue
+++ b/src/components/SyncPanel.vue
@@ -30,6 +30,7 @@ import {
   SyncAbortedError,
   ClockSkewError,
 } from "../lib/normalSync";
+import { acquireSyncLock, releaseSyncLock } from "../lib/autoSync";
 import mime from "mime";
 
 const serverUrl = ref("");
@@ -43,6 +44,8 @@ const lastSyncTime = ref<number | null>(null);
 const showPushConfirm = ref(false);
 const showFullSyncDialog = ref(false);
 const showAdvancedSync = ref(false);
+const lastSyncType = ref<string | null>(localStorage.getItem("anki-last-sync-type"));
+const lastSyncProto = ref<string | null>(localStorage.getItem("anki-last-sync-proto"));
 
 onMounted(() => {
   const config = readSyncConfig();
@@ -97,6 +100,11 @@ async function handleSync() {
     return;
   }
 
+  if (!acquireSyncLock()) {
+    syncError.value = "A sync is already in progress.";
+    return;
+  }
+
   syncError.value = "";
   isSyncing.value = true;
 
@@ -116,6 +124,7 @@ async function handleSync() {
     });
 
     if (result.action === "noChanges") {
+      setSyncInfo("Incremental", result.proto);
       syncStatus.value = "Already up to date.";
       const now = Date.now();
       writeSyncState({ ...state, lastSync: now });
@@ -129,36 +138,42 @@ async function handleSync() {
       await initializeReviewQueue();
     }
 
-    // Download and upload media in parallel
-    syncStatus.value = "Syncing media...";
-    const [dlResult, ulResult] = await Promise.allSettled([
-      downloadMedia(serverUrl.value, state.hkey, (s) => {
+    // Download then upload media sequentially — each calls /msync/begin which
+    // starts a new server session, so running them in parallel would invalidate
+    // the first session and cause 400 errors on downloadFiles.
+    syncStatus.value = "Downloading media...";
+    try {
+      const dlMedia = await downloadMedia(serverUrl.value, state.hkey, (s) => {
         syncStatus.value = s;
-      }),
-      uploadMedia(serverUrl.value, state.hkey, (s) => {
-        syncStatus.value = s;
-      }),
-    ]);
-
-    if (dlResult.status === "fulfilled" && dlResult.value.size > 0) {
-      const typedBlobs = new Map<string, Blob>();
-      for (const [filename, blob] of dlResult.value) {
-        typedBlobs.set(
-          filename,
-          new Blob([blob], { type: mime.getType(filename) ?? "application/octet-stream" }),
-        );
+      });
+      if (dlMedia.size > 0) {
+        const typedBlobs = new Map<string, Blob>();
+        for (const [filename, blob] of dlMedia) {
+          typedBlobs.set(
+            filename,
+            new Blob([blob], { type: mime.getType(filename) ?? "application/octet-stream" }),
+          );
+        }
+        syncStatus.value = `Downloaded ${dlMedia.size} media file${dlMedia.size === 1 ? "" : "s"}. Caching...`;
+        await addMediaToCache(typedBlobs);
       }
-      syncStatus.value = `Downloaded ${dlResult.value.size} media file${dlResult.value.size === 1 ? "" : "s"}. Caching...`;
-      await addMediaToCache(typedBlobs);
-    } else if (dlResult.status === "rejected") {
-      console.warn("Media download failed (non-fatal):", dlResult.reason);
+    } catch (dlErr) {
+      console.warn("Media download failed (non-fatal):", dlErr);
     }
 
-    if (ulResult.status === "rejected") {
-      console.warn("Media upload failed (non-fatal):", ulResult.reason);
-    } else if (ulResult.value > 0) {
-      syncStatus.value = `Uploaded ${ulResult.value} media file${ulResult.value === 1 ? "" : "s"}.`;
+    syncStatus.value = "Uploading media...";
+    try {
+      const uploaded = await uploadMedia(serverUrl.value, state.hkey, (s) => {
+        syncStatus.value = s;
+      });
+      if (uploaded > 0) {
+        syncStatus.value = `Uploaded ${uploaded} media file${uploaded === 1 ? "" : "s"}.`;
+      }
+    } catch (ulErr) {
+      console.warn("Media upload failed (non-fatal):", ulErr);
     }
+
+    setSyncInfo("Incremental", result.proto);
 
     const newState = { ...state, ...result.newState };
     writeSyncState(newState);
@@ -180,6 +195,7 @@ async function handleSync() {
     syncStatus.value = "";
   } finally {
     isSyncing.value = false;
+    releaseSyncLock();
   }
 }
 
@@ -208,6 +224,8 @@ async function doFullPull(hkey: string) {
   syncStatus.value = "Parsing collection...";
   await loadSyncedCollection(sqliteBytes, typedMediaBlobs);
 
+  setSyncInfo("Full download");
+
   const now = Date.now();
   const prevState = readSyncState();
   writeSyncState({ ...prevState, lastSync: now });
@@ -220,6 +238,11 @@ async function handlePull() {
   const state = readSyncState();
   if (!state.hkey) {
     syncError.value = "Not logged in. Please log in first.";
+    return;
+  }
+
+  if (!acquireSyncLock()) {
+    syncError.value = "A sync is already in progress.";
     return;
   }
 
@@ -239,6 +262,7 @@ async function handlePull() {
     syncStatus.value = "";
   } finally {
     isSyncing.value = false;
+    releaseSyncLock();
   }
 }
 
@@ -246,6 +270,11 @@ async function handlePush() {
   const state = readSyncState();
   if (!state.hkey) {
     syncError.value = "Not logged in. Please log in first.";
+    return;
+  }
+
+  if (!acquireSyncLock()) {
+    syncError.value = "A sync is already in progress.";
     return;
   }
 
@@ -286,6 +315,8 @@ async function handlePush() {
     // Update local cache with the modified version
     await refreshSyncedCollection(modifiedSqlite);
 
+    setSyncInfo("Full upload");
+
     const now = Date.now();
     writeSyncState({ ...state, lastSync: now });
     lastSyncTime.value = now;
@@ -301,6 +332,7 @@ async function handlePush() {
     syncStatus.value = "";
   } finally {
     isSyncing.value = false;
+    releaseSyncLock();
   }
 }
 
@@ -316,6 +348,16 @@ async function handleDisconnect() {
   syncStatus.value = "";
   syncError.value = "";
   lastSyncTime.value = null;
+}
+
+function setSyncInfo(type: string, proto?: 10 | 11) {
+  lastSyncType.value = type;
+  localStorage.setItem("anki-last-sync-type", type);
+  if (proto) {
+    const label = `v${proto}${proto === 11 ? " (zstd)" : " (legacy)"}`;
+    lastSyncProto.value = label;
+    localStorage.setItem("anki-last-sync-proto", label);
+  }
 }
 
 function formatLastSync(timestamp: number | null): string {
@@ -381,6 +423,9 @@ function formatLastSync(timestamp: number | null): string {
         </div>
 
         <div class="sync-last-sync">Last sync: {{ formatLastSync(lastSyncTime) }}</div>
+        <div v-if="lastSyncType" class="sync-last-sync">
+          Type: {{ lastSyncType }}<template v-if="lastSyncProto"> · Protocol: {{ lastSyncProto }}</template>
+        </div>
 
         <div class="sync-actions">
           <button class="sync-btn sync-btn--primary" :disabled="isSyncing" @click="handleSync">

--- a/src/lib/ankiSync.ts
+++ b/src/lib/ankiSync.ts
@@ -226,7 +226,8 @@ export async function downloadCollection(
   return decompressIfNeeded(bytes);
 }
 
-const DOWNLOAD_BATCH_SIZE = 30;
+/** Server enforces MAX_MEDIA_FILES_IN_ZIP = 25; exceeding it returns 400. */
+const DOWNLOAD_BATCH_SIZE = 25;
 
 const mediaSyncBeginSchema = z.object({
   usn: z.number(),

--- a/src/lib/autoSync.ts
+++ b/src/lib/autoSync.ts
@@ -1,0 +1,185 @@
+import {
+  readSyncConfig,
+  readSyncState,
+  writeSyncState,
+  clearSyncState,
+  downloadMedia,
+  uploadMedia,
+} from "./ankiSync";
+import { normalSync, FullSyncRequiredError } from "./normalSync";
+import {
+  getCachedSqlite,
+  getActiveDeckId,
+  refreshSyncedCollection,
+  addMediaToCache,
+  initializeReviewQueue,
+  syncActiveSig,
+} from "../stores";
+import mime from "mime";
+
+const AUTO_SYNC_INTERVAL_MS = 3 * 60 * 1000; // 3 minutes
+const DATA_CHANGED_KEY = "anki-auto-sync-last-change";
+const LAST_ATTEMPT_KEY = "anki-auto-sync-last-attempt";
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let syncing = false;
+let visibilityListenerAdded = false;
+
+/**
+ * Mark that local data has changed and should be synced.
+ * Call this after reviews, note edits, deck renames/deletes, etc.
+ */
+export function markDataChanged() {
+  localStorage.setItem(DATA_CHANGED_KEY, String(Date.now()));
+}
+
+function getLastDataChange(): number {
+  return Number(localStorage.getItem(DATA_CHANGED_KEY) || "0");
+}
+
+function getLastAttempt(): number {
+  return Number(localStorage.getItem(LAST_ATTEMPT_KEY) || "0");
+}
+
+function setLastAttempt() {
+  localStorage.setItem(LAST_ATTEMPT_KEY, String(Date.now()));
+}
+
+/**
+ * Acquire the sync lock. Returns false if already locked.
+ */
+export function acquireSyncLock(): boolean {
+  if (syncing) return false;
+  syncing = true;
+  return true;
+}
+
+/**
+ * Release the sync lock.
+ */
+export function releaseSyncLock() {
+  syncing = false;
+}
+
+/**
+ * Perform an incremental sync in the background.
+ * Returns true if sync was attempted, false if skipped.
+ */
+async function performAutoSync(): Promise<boolean> {
+  // Don't sync if not logged in
+  const state = readSyncState();
+  if (!state.hkey) return false;
+
+  // Don't sync if no local collection
+  const cachedBytes = await getCachedSqlite();
+  if (!cachedBytes) return false;
+
+  // Don't sync if already syncing
+  if (!acquireSyncLock()) return false;
+
+  const config = readSyncConfig();
+  if (!config) {
+    releaseSyncLock();
+    return false;
+  }
+
+  try {
+    setLastAttempt();
+
+    const deckId = getActiveDeckId();
+    const result = await normalSync(config.serverUrl, state.hkey, deckId, cachedBytes);
+
+    if (result.action === "noChanges") {
+      const now = Date.now();
+      writeSyncState({ ...state, lastSync: now });
+      return true;
+    }
+
+    if (result.sqliteBytes) {
+      await refreshSyncedCollection(result.sqliteBytes);
+      await initializeReviewQueue();
+    }
+
+    // Sync media sequentially — each calls /msync/begin which starts a new
+    // server session, so parallel calls would invalidate the first session.
+    try {
+      const dlMedia = await downloadMedia(config.serverUrl, state.hkey);
+      if (dlMedia.size > 0) {
+        const typedBlobs = new Map<string, Blob>();
+        for (const [filename, blob] of dlMedia) {
+          typedBlobs.set(
+            filename,
+            new Blob([blob], { type: mime.getType(filename) ?? "application/octet-stream" }),
+          );
+        }
+        await addMediaToCache(typedBlobs);
+      }
+    } catch (dlErr) {
+      console.warn("[auto-sync] Media download failed:", dlErr);
+    }
+
+    try {
+      await uploadMedia(config.serverUrl, state.hkey);
+    } catch (ulErr) {
+      console.warn("[auto-sync] Media upload failed:", ulErr);
+    }
+
+    const newState = { ...state, ...result.newState };
+    writeSyncState(newState);
+
+    console.log("[auto-sync] Sync completed successfully.");
+    return true;
+  } catch (err) {
+    if (err instanceof FullSyncRequiredError) {
+      console.warn("[auto-sync] Full sync required — skipping auto-sync.");
+      return false;
+    }
+    if (err instanceof Error && err.message.includes("Authentication expired")) {
+      syncActiveSig.value = false;
+      clearSyncState();
+    }
+    console.warn("[auto-sync] Sync failed:", err);
+    return false;
+  } finally {
+    releaseSyncLock();
+  }
+}
+
+async function tick() {
+  const lastChange = getLastDataChange();
+  const lastAttempt = getLastAttempt();
+
+  // Only sync if data changed since last attempt
+  if (lastChange <= lastAttempt) return;
+
+  await performAutoSync();
+}
+
+/**
+ * Sync on visibility change: push pending changes when leaving,
+ * pull fresh data when returning.
+ */
+function handleVisibilityChange() {
+  if (document.visibilityState === "hidden") {
+    // Page losing focus — sync pending changes out
+    tick();
+  } else {
+    // Page regaining focus — pull any remote changes
+    performAutoSync();
+  }
+}
+
+/**
+ * Start the auto-sync timer and visibility listeners.
+ * Safe to call multiple times (idempotent).
+ */
+export function startAutoSync() {
+  if (intervalId === null) {
+    intervalId = setInterval(tick, AUTO_SYNC_INTERVAL_MS);
+  }
+  if (!visibilityListenerAdded) {
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    visibilityListenerAdded = true;
+  }
+}
+

--- a/src/lib/normalSync.ts
+++ b/src/lib/normalSync.ts
@@ -146,6 +146,8 @@ interface NormalSyncResult {
   action: SyncAction;
   sqliteBytes?: Uint8Array;
   newState?: Partial<SyncState>;
+  /** Protocol version negotiated with the server (10 = legacy multipart, 11 = zstd). */
+  proto?: 10 | 11;
 }
 
 const CHUNK_SIZE = 250;
@@ -507,6 +509,26 @@ export async function normalSync(
   sqliteBytes: Uint8Array,
   onProgress: ProgressCallback = () => {},
 ): Promise<NormalSyncResult> {
+  try {
+    return await normalSyncInner(serverUrl, hkey, deckId, sqliteBytes, onProgress);
+  } catch (error) {
+    if (error instanceof ConcurrentSyncError) {
+      // A stale session is blocking us — abort it and retry once
+      onProgress("Clearing stale sync session...");
+      await abortSync(serverUrl, hkey);
+      return await normalSyncInner(serverUrl, hkey, deckId, sqliteBytes, onProgress);
+    }
+    throw error;
+  }
+}
+
+async function normalSyncInner(
+  serverUrl: string,
+  hkey: string,
+  deckId: string,
+  sqliteBytes: Uint8Array,
+  onProgress: ProgressCallback = () => {},
+): Promise<NormalSyncResult> {
   const db = await createDatabase(sqliteBytes);
   let sessionStarted = false;
   let proto: ProtoVersion = 10;
@@ -544,8 +566,9 @@ export async function normalSync(
 
     if (action === "noChanges") {
       onProgress("Already up to date.");
+      const noChangeProto: 10 | 11 = (remoteMeta.serverVersion ?? 0) >= 11 ? 11 : 10;
       db.close();
-      return { action: "noChanges" };
+      return { action: "noChanges", proto: noChangeProto };
     }
 
     if (action === "fullSyncRequired") {
@@ -640,6 +663,7 @@ export async function normalSync(
         usn: remoteMeta.usn,
         scm: remoteMeta.scm,
       },
+      proto,
     };
   } catch (error) {
     if (sessionStarted) {

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -32,6 +32,7 @@ import {
   filterMediaKeys,
 } from "./utils/mediaCache";
 import { QUEUE_USER_BURIED, QUEUE_SUSPENDED } from "./lib/syncWrite";
+import { markDataChanged } from "./lib/autoSync";
 
 /** Revoke object URLs from the previous media map to prevent memory leaks. */
 function revokeOldMediaUrls() {
@@ -550,6 +551,7 @@ export async function renameDeckInCollection(
     (input as { bytes: Uint8Array }).bytes = newBytes;
     const { getAnkiDataFromSqlite } = await import("./ankiParser");
     ankiDataSig.value = await getAnkiDataFromSqlite(newBytes, input.mediaFiles);
+    markDataChanged();
   } finally {
     db.close();
   }
@@ -644,6 +646,7 @@ export async function deleteDeckFromCollection(
     if (selectedDeckIdSig.value === deckId) {
       selectedDeckIdSig.value = null;
     }
+    markDataChanged();
   } finally {
     db.close();
   }
@@ -1123,6 +1126,7 @@ export async function updateNote(
 
     // Update in-place without triggering re-parse
     (input as { bytes: Uint8Array }).bytes = newBytes;
+    markDataChanged();
   } finally {
     db.close();
   }


### PR DESCRIPTION
## Summary

- Add background auto-sync with 3-minute timer and visibility change listeners
- When `normalSync` hits a 409 (stale server session), automatically abort and retry once
- Add sync lock to prevent manual and auto-sync from running simultaneously
- Fix media sync to run sequentially (parallel calls invalidated the first session)
- Show last sync type and protocol version in the UI