### PR TITLE
Load sample decks as default collection when no sync configured

### DIFF
--- a/src/components/FileLibrary.vue
+++ b/src/components/FileLibrary.vue
@@ -18,6 +18,7 @@ import {
   adoptedSampleIdsSig,
   adoptSampleDeck,
   removeAdoptedSample,
+  SAMPLE_COLLECTION_ID,
 } from "../stores";
 import type { DeckTreeNode } from "../types";
 
@@ -25,14 +26,10 @@ const fileInput = ref<HTMLInputElement>();
 
 const adoptedIds = computed(() => new Set(adoptedSampleIdsSig.value));
 const sampleDecks = computed(() =>
-  sampleDeckData
-    .filter((d) => !adoptedIds.value.has(d.id))
-    .map(createSampleDeckLibraryItem),
+  sampleDeckData.filter((d) => !adoptedIds.value.has(d.id)).map(createSampleDeckLibraryItem),
 );
 const adoptedSampleDecks = computed(() =>
-  sampleDeckData
-    .filter((d) => adoptedIds.value.has(d.id))
-    .map(createSampleDeckLibraryItem),
+  sampleDeckData.filter((d) => adoptedIds.value.has(d.id)).map(createSampleDeckLibraryItem),
 );
 const uploadedDecks = computed(() =>
   [...cachedFilesSig.value].sort((a, b) => b.addedAt - a.addedAt).map(createCachedDeckLibraryItem),
@@ -77,6 +74,11 @@ function flattenTree(nodes: DeckTreeNode[]): DeckTreeNode[] {
 
 const flatTree = computed(() => (deckInfoSig.value ? flattenTree(deckInfoSig.value.tree) : []));
 
+/** Whether the sample collection is the active deck (no sync configured) */
+const isSampleCollectionActive = computed(
+  () => !syncActiveSig.value && activeDeckSourceIdSig.value === SAMPLE_COLLECTION_ID,
+);
+
 /** Whether the active deck belongs to "Your Decks" (adopted sample or uploaded file) */
 const isYourDeckActive = computed(() => {
   const id = activeDeckSourceIdSig.value;
@@ -105,32 +107,12 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
       <Button variant="primary" size="sm" @click="fileInput?.click()"> Add File </Button>
     </div>
 
-    <section v-if="!syncActiveSig && sampleDecks.length > 0" class="library-section">
+    <section
+      v-if="(syncActiveSig || isSampleCollectionActive) && deckInfoSig"
+      class="library-section"
+    >
       <div class="section-header">
-        <h3 class="section-title">Sample Decks</h3>
-        <span class="section-count">{{ sampleDecks.length }}</span>
-      </div>
-      <div class="file-grid">
-        <div
-          v-for="sampleDeck in sampleDecks"
-          :key="sampleDeck.id"
-          class="file-card file-card--static"
-        >
-          <div class="file-info">
-            <span class="file-name">{{ sampleDeck.title }}</span>
-            <span class="file-meta">{{ sampleDeck.detail }}</span>
-            <span class="file-meta">{{ sampleDeck.meta }}</span>
-          </div>
-          <Button variant="secondary" size="sm" @click="adoptSampleDeck(sampleDeck.id)">
-            Add
-          </Button>
-        </div>
-      </div>
-    </section>
-
-    <section v-if="syncActiveSig && deckInfoSig" class="library-section">
-      <div class="section-header">
-        <h3 class="section-title">Synced Decks</h3>
+        <h3 class="section-title">{{ syncActiveSig ? "Synced Decks" : "Sample Decks" }}</h3>
         <span class="section-count">{{ deckInfoSig.subdecks.length }}</span>
       </div>
       <div v-if="deckInfoSig.subdecks.length === 0" class="empty-state">
@@ -211,9 +193,7 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
       </div>
 
       <div v-if="uploadedDecks.length === 0 && adoptedSampleDecks.length === 0" class="empty-state">
-        <p class="empty-text">
-          No decks yet. Add an .apkg file or a sample deck to get started.
-        </p>
+        <p class="empty-text">No decks yet. Add an .apkg file or a sample deck to get started.</p>
         <Button variant="secondary" @click="fileInput?.click()"> Choose a Deck File </Button>
       </div>
 
@@ -258,7 +238,10 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
         </div>
 
         <!-- Deck tree for active your-deck -->
-        <div v-if="!syncActiveSig && isYourDeckActive && deckInfoSig" class="deck-tree your-deck-tree">
+        <div
+          v-if="!syncActiveSig && isYourDeckActive && deckInfoSig"
+          class="deck-tree your-deck-tree"
+        >
           <div
             v-for="node in flatTree"
             :key="node.fullName"

--- a/src/sampleDecks.ts
+++ b/src/sampleDecks.ts
@@ -150,3 +150,15 @@ export const sampleDecks: SampleDeck[] = [
 ];
 
 export const sampleDeckMap = new Map(sampleDecks.map((deck) => [deck.id, deck] as const));
+
+/** All sample decks merged into a single AnkiData, used as the default collection when no sync is configured. */
+export const mergedSampleDeckData = {
+  files: new Map(),
+  cards: sampleDecks.flatMap((d) => [...d.data.cards]),
+  deckName: "Sample Decks",
+  decks: Object.fromEntries(sampleDecks.flatMap((d) => Object.entries(d.data.decks))),
+  notesTypes: [],
+  collectionCreationTime: 0,
+  deckConfigs: {},
+  colConf: null,
+} as AnkiData;

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -8,7 +8,7 @@ import { ReviewQueue, type ReviewCard } from "./scheduler/queue";
 import { DEFAULT_SCHEDULER_SETTINGS, type SchedulerSettings } from "./scheduler/types";
 import { reviewDB } from "./scheduler/db";
 import type { DeckInfo, DeckTreeNode } from "./types";
-import { sampleDeckMap, sampleDecks } from "./sampleDecks";
+import { sampleDeckMap, sampleDecks, mergedSampleDeckData } from "./sampleDecks";
 import {
   importedDeckFileName,
   persistActiveDeckSourceId as persistStoredActiveDeckSourceId,
@@ -97,6 +97,13 @@ ankiCachePromise.then(async (cache) => {
   }
 
   if (!activeDeckSourceIdSig.value) {
+    // Auto-load sample decks when no sync is configured and nothing else is active
+    if (!syncActiveSig.value) {
+      persistActiveDeckSourceId(SAMPLE_COLLECTION_ID);
+      activeDeckInputSig.value = { kind: "sample", data: mergedSampleDeckData };
+      activeViewSig.value = "review";
+      reviewModeSig.value = "deck-list";
+    }
     return;
   }
 
@@ -120,6 +127,18 @@ ankiCachePromise.then(async (cache) => {
       return;
     }
     persistActiveDeckSourceId(null);
+    return;
+  }
+
+  // Restore merged sample collection
+  if (activeDeckSourceIdSig.value === SAMPLE_COLLECTION_ID) {
+    if (syncActiveSig.value) {
+      persistActiveDeckSourceId(null);
+      return;
+    }
+    activeDeckInputSig.value = { kind: "sample", data: mergedSampleDeckData };
+    activeViewSig.value = "review";
+    reviewModeSig.value = "deck-list";
     return;
   }
 
@@ -237,6 +256,7 @@ export async function deleteCachedFile(name: string) {
 }
 
 const SYNC_COLLECTION_ID = "sync-collection";
+export const SAMPLE_COLLECTION_ID = "sample-collection";
 
 export async function loadSyncedCollection(bytes: Uint8Array, mediaBlobs?: Map<string, Blob>) {
   // Cache SQLite bytes and media blobs so they survive page reloads
@@ -531,7 +551,11 @@ export async function renameDeckInCollection(
         deck.usn = -1;
       }
       // Update children
-      for (const d of Object.values(decksJson) as Array<{ name: string; mod: number; usn: number }>) {
+      for (const d of Object.values(decksJson) as Array<{
+        name: string;
+        mod: number;
+        usn: number;
+      }>) {
         if (d.name.startsWith(oldFullName + "::")) {
           d.name = newFullName + d.name.slice(oldFullName.length);
           d.mod = mod;
@@ -561,10 +585,7 @@ export async function renameDeckInCollection(
  * Delete a deck from the synced SQLite collection.
  * Removes the deck, its cards, orphaned notes, and marks for sync.
  */
-export async function deleteDeckFromCollection(
-  deckId: string,
-  fullName: string,
-): Promise<void> {
+export async function deleteDeckFromCollection(deckId: string, fullName: string): Promise<void> {
   const input = activeDeckInputSig.value;
   if (input?.kind !== "sqlite") return;
 
@@ -578,16 +599,19 @@ export async function deleteDeckFromCollection(
     const deckIdsToDelete: number[] = [];
 
     if (anki21b) {
-      const rows = db.exec(
-        "SELECT id FROM decks WHERE id=? OR name LIKE ?",
-        [deckId, fullName + "::%"],
-      );
+      const rows = db.exec("SELECT id FROM decks WHERE id=? OR name LIKE ?", [
+        deckId,
+        fullName + "::%",
+      ]);
       if (rows[0]) {
         for (const row of rows[0].values) deckIdsToDelete.push(Number(row[0]));
       }
     } else {
       const result = db.exec("SELECT decks FROM col");
-      const decksJson = JSON.parse(String(result[0]?.values[0]?.[0] ?? "{}")) as Record<string, { name: string }>;
+      const decksJson = JSON.parse(String(result[0]?.values[0]?.[0] ?? "{}")) as Record<
+        string,
+        { name: string }
+      >;
       for (const [id, d] of Object.entries(decksJson)) {
         if (id === String(deckId) || d.name.startsWith(fullName + "::")) {
           deckIdsToDelete.push(Number(id));
@@ -702,7 +726,10 @@ export async function exportDeckFromCollection(fullName: string): Promise<void> 
       }
     } else {
       const result = srcDb.exec("SELECT decks FROM col");
-      const decksJson = JSON.parse(String(result[0]?.values[0]?.[0] ?? "{}")) as Record<string, { name: string }>;
+      const decksJson = JSON.parse(String(result[0]?.values[0]?.[0] ?? "{}")) as Record<
+        string,
+        { name: string }
+      >;
       const exportDecks: Record<string, unknown> = {};
       for (const [id, d] of Object.entries(decksJson)) {
         if (d.name === fullName || d.name.startsWith(fullName + "::")) {
@@ -872,9 +899,7 @@ export async function initializeReviewQueue() {
   await queue.init();
 
   const mappedIds = cards.map((c) => c.ankiCardId);
-  const ankiCardIds = mappedIds.every((id): id is number => id != null)
-    ? mappedIds
-    : undefined;
+  const ankiCardIds = mappedIds.every((id): id is number => id != null) ? mappedIds : undefined;
   const fullQueue = await queue.buildQueue(cards.length, templates.length, ankiCardIds);
   const dueCards = queue.getDueCards(fullQueue);
 


### PR DESCRIPTION
## Summary
- Auto-load merged sample decks on first visit when no sync is configured
- Show sample decks in the same deck tree UI as synced decks (settings cog, stats, collapse)
- Remove old "Sample Decks" section that required manual adoption via Add button

## Test plan
- [ ] Open app with no sync configured — sample decks should appear in deck tree automatically
- [ ] Verify settings cog, new/learn/due stats, and collapse toggles work on sample decks
- [ ] Configure sync — sample deck section should switch to "Synced Decks"
- [ ] Disconnect sync — should revert to sample decks