### PR TITLE
Add congrats screen and learn ahead

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,7 @@ import DeckCreator from "./components/DeckCreator.vue";
 
 import CardBrowser from "./components/CardBrowser.vue";
 import SyncPanel from "./components/SyncPanel.vue";
+import CongratsScreen from "./components/CongratsScreen.vue";
 import SchedulerSettings from "./components/SchedulerSettings.vue";
 import FlagSettings from "./components/FlagSettings.vue";
 import CommandPalette from "./components/CommandPalette.vue";
@@ -255,6 +256,7 @@ async function handleChooseAnswer(answer: Answer) {
           @choose-answer="handleChooseAnswer"
         />
       </template>
+      <CongratsScreen v-else-if="schedulerEnabledSig && cardsSig.length > 0" />
       <p v-else-if="cardsSig.length === 0" class="no-deck-message">
         No deck loaded. Click the
         <button class="link-btn" @click="reviewModeSig = 'deck-list'">Review</button> tab to choose

--- a/src/components/CongratsScreen.vue
+++ b/src/components/CongratsScreen.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+  reviewQueueSig,
+  fullQueueSig,
+  reviewModeSig,
+} from "../stores";
+import { Button } from "../design-system";
+
+const stats = computed(() => {
+  const queue = reviewQueueSig.value;
+  if (!queue) return null;
+  return queue.getTodayStats();
+});
+
+const nextDue = computed(() => {
+  const queue = reviewQueueSig.value;
+  if (!queue) return null;
+  return queue.getNextDueDate(fullQueueSig.value);
+});
+
+const timeSpent = computed(() => {
+  const ms = stats.value?.totalTimeMs ?? 0;
+  if (ms < 60_000) return "< 1 minute";
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `${mins} minute${mins === 1 ? "" : "s"}`;
+  const hrs = Math.floor(mins / 60);
+  const rem = mins % 60;
+  return rem > 0 ? `${hrs}h ${rem}m` : `${hrs} hour${hrs === 1 ? "" : "s"}`;
+});
+
+const nextDueText = computed(() => {
+  const d = nextDue.value;
+  if (!d) return "No more cards scheduled";
+  const diffMs = d.getTime() - Date.now();
+  if (diffMs <= 0) return "Now";
+  const mins = Math.ceil(diffMs / 60_000);
+  if (mins < 60) return `in ${mins} minute${mins === 1 ? "" : "s"}`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `in ~${hrs} hour${hrs === 1 ? "" : "s"}`;
+  const days = Math.floor(hrs / 24);
+  return `in ${days} day${days === 1 ? "" : "s"}`;
+});
+
+const reviewed = computed(() => {
+  if (!stats.value) return 0;
+  return stats.value.newCount + stats.value.reviewCount;
+});
+</script>
+
+<template>
+  <div class="congrats">
+    <div class="congrats-card">
+      <h2 class="congrats-title">Congratulations!</h2>
+      <p class="congrats-subtitle">You've finished this deck for now.</p>
+
+      <dl class="congrats-stats">
+        <div class="stat">
+          <dt>Reviewed today</dt>
+          <dd>{{ reviewed }} card{{ reviewed === 1 ? "" : "s" }}</dd>
+        </div>
+        <div class="stat">
+          <dt>Time spent</dt>
+          <dd>{{ timeSpent }}</dd>
+        </div>
+        <div class="stat">
+          <dt>Next due</dt>
+          <dd>{{ nextDueText }}</dd>
+        </div>
+      </dl>
+
+      <div class="congrats-actions">
+        <Button variant="secondary" @click="reviewModeSig = 'deck-list'">
+          Back to Decks
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.congrats {
+  display: flex;
+  justify-content: center;
+  padding: var(--spacing-8) var(--spacing-4);
+}
+
+.congrats-card {
+  max-width: 400px;
+  width: 100%;
+  text-align: center;
+}
+
+.congrats-title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-2) 0;
+}
+
+.congrats-subtitle {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-base);
+  margin: 0 0 var(--spacing-6) 0;
+}
+
+.congrats-stats {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  margin: 0 0 var(--spacing-6) 0;
+  padding: var(--spacing-4);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.stat dt {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.stat dd {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.congrats-actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-3);
+}
+</style>

--- a/src/components/SchedulerSettings.vue
+++ b/src/components/SchedulerSettings.vue
@@ -264,6 +264,48 @@ function updateFsrsParam<K extends keyof NonNullable<SchedulerSettings["fsrsPara
       </div>
     </div>
 
+    <div v-if="settings.enabled" class="form-section">
+      <div class="section-title">Schedule</div>
+      <div class="form-group">
+        <label class="form-label">Learn Ahead Limit (minutes)</label>
+        <input
+          type="number"
+          class="form-input"
+          :value="settings.learnAheadMins ?? 20"
+          min="0"
+          max="120"
+          @change="
+            updateSetting(
+              'learnAheadMins',
+              parseInt(($event.target as HTMLInputElement).value, 10),
+            )
+          "
+        />
+        <div class="help-text">
+          When the queue is empty, study cards due within this many minutes (0 = off)
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Day Rollover Hour</label>
+        <input
+          type="number"
+          class="form-input"
+          :value="settings.rolloverHour ?? 4"
+          min="0"
+          max="23"
+          @change="
+            updateSetting(
+              'rolloverHour',
+              parseInt(($event.target as HTMLInputElement).value, 10),
+            )
+          "
+        />
+        <div class="help-text">
+          Hour (0-23) when "today" starts. Set to 4 so late-night reviews count as the same day.
+        </div>
+      </div>
+    </div>
+
     <!-- SM-2 Parameters -->
     <div v-if="settings.enabled && settings.algorithm === 'sm2'" class="form-section">
       <div class="section-title">Learning</div>

--- a/src/scheduler/__tests__/db.test.ts
+++ b/src/scheduler/__tests__/db.test.ts
@@ -26,6 +26,8 @@ describe("ReviewDB", () => {
         dailyNewLimit: 30,
         dailyReviewLimit: 300,
         showAheadOfSchedule: false,
+        learnAheadMins: 20,
+        rolloverHour: 4,
         fsrsParams: {
           requestRetention: 0.85,
           maximumInterval: 1000,
@@ -112,6 +114,8 @@ describe("ReviewDB", () => {
         dailyNewLimit: 20,
         dailyReviewLimit: 200,
         showAheadOfSchedule: false,
+        learnAheadMins: 20,
+        rolloverHour: 4,
         fsrsParams: { requestRetention: 0.9, maximumInterval: 36500 },
       });
 
@@ -127,6 +131,8 @@ describe("ReviewDB", () => {
         dailyNewLimit: 30,
         dailyReviewLimit: 300,
         showAheadOfSchedule: false,
+        learnAheadMins: 20,
+        rolloverHour: 4,
         fsrsParams: { requestRetention: 0.85, maximumInterval: 1000 },
       });
 
@@ -145,6 +151,8 @@ describe("ReviewDB", () => {
         dailyNewLimit: 20,
         dailyReviewLimit: 200,
         showAheadOfSchedule: false,
+        learnAheadMins: 20,
+        rolloverHour: 4,
       });
 
       await expect(db.saveSettings("deck-1", settings)).rejects.toThrow();

--- a/src/scheduler/queue.ts
+++ b/src/scheduler/queue.ts
@@ -63,11 +63,17 @@ export class ReviewQueue {
   }
 
   /**
-   * Get today's date as YYYY-MM-DD
+   * Get today's date as YYYY-MM-DD, adjusted for rollover hour.
+   * If the current time is before the rollover hour, the previous
+   * calendar day is considered "today".
    */
   private getTodayString(): string {
-    const today = new Date();
-    return today.toISOString().split("T")[0]!;
+    const now = new Date();
+    const rollover = this.settings.rolloverHour ?? 4;
+    if (now.getHours() < rollover) {
+      now.setDate(now.getDate() - 1);
+    }
+    return now.toISOString().split("T")[0]!;
   }
 
   /**
@@ -201,10 +207,18 @@ export class ReviewQueue {
     const selectedNew = newCards.slice(0, newLeft);
     const selectedReviews = dueReviews.slice(0, reviewLeft);
 
-    const includeAhead =
-      this.settings.showAheadOfSchedule && selectedReviews.length === 0 && selectedNew.length === 0
-        ? aheadCards
-        : [];
+    // Include ahead-of-schedule cards when the regular queue is empty
+    const learnAheadMs = (this.settings.learnAheadMins ?? 20) * 60 * 1000;
+    let includeAhead: ReviewCard[] = [];
+    if (selectedReviews.length === 0 && selectedNew.length === 0 && learningCards.length === 0) {
+      if (this.settings.showAheadOfSchedule) {
+        includeAhead = aheadCards;
+      } else if (learnAheadMs > 0) {
+        includeAhead = aheadCards.filter(
+          (c) => (dueDateCache.get(c.cardId) ?? Infinity) <= nowMs + learnAheadMs,
+        );
+      }
+    }
 
     // Sort learning cards by due time (soonest first)
     learningCards.sort(
@@ -336,6 +350,43 @@ export class ReviewQueue {
       newLeft: Math.max(0, this.settings.dailyNewLimit - this.todayStats.newCount),
       reviewsLeft: Math.max(0, this.settings.dailyReviewLimit - this.todayStats.reviewCount),
     };
+  }
+
+  /**
+   * Get today's stats for the congrats screen
+   */
+  getTodayStats(): DailyStats {
+    return { ...this.todayStats };
+  }
+
+  /**
+   * Get the soonest due date across all non-due cards in the given queue.
+   * Returns null if there are no upcoming cards.
+   */
+  getNextDueDate(queue: ReviewCard[]): Date | null {
+    const nowMs = Date.now();
+    let earliest: number | null = null;
+
+    for (const card of queue) {
+      if (card.reviewState.queueOverride === QUEUE_SUSPENDED) continue;
+      if (
+        card.reviewState.queueOverride === QUEUE_USER_BURIED ||
+        card.reviewState.queueOverride === QUEUE_SCHED_BURIED
+      )
+        continue;
+      if (card.isNew) continue;
+
+      try {
+        const dueMs = this.algorithm.getDueDate(card.reviewState.cardState).getTime();
+        if (dueMs > nowMs && (earliest === null || dueMs < earliest)) {
+          earliest = dueMs;
+        }
+      } catch {
+        // skip
+      }
+    }
+
+    return earliest !== null ? new Date(earliest) : null;
   }
 
   /**

--- a/src/scheduler/types.ts
+++ b/src/scheduler/types.ts
@@ -138,6 +138,18 @@ export interface SchedulerSettings {
   showAheadOfSchedule: boolean;
 
   /**
+   * Learn-ahead limit in minutes. Cards due within this window are
+   * shown when the regular queue is empty. Default 20.
+   */
+  learnAheadMins: number;
+
+  /**
+   * Hour of the day (0-23) when "today" rolls over. Default 4 (4 AM).
+   * Useful for night owls so late-night reviews count as the same day.
+   */
+  rolloverHour: number;
+
+  /**
    * SM-2 specific parameters (only used if algorithm is 'sm2')
    */
   sm2Params?: Partial<SM2Params>;
@@ -172,6 +184,8 @@ export const DEFAULT_SCHEDULER_SETTINGS: SchedulerSettings = {
   dailyNewLimit: 20,
   dailyReviewLimit: 200,
   showAheadOfSchedule: false,
+  learnAheadMins: 20,
+  rolloverHour: 4,
 };
 
 /**

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -464,6 +464,7 @@ export const schedulerEnabledSig = computed(() => schedulerSettingsSig.value.ena
 export const reviewQueueSig = shallowRef<ReviewQueue | null>(null);
 
 const dueCardsSig = shallowRef<ReviewCard[]>([]);
+export const fullQueueSig = shallowRef<ReviewCard[]>([]);
 
 export const currentReviewCardSig = shallowRef<ReviewCard | null>(null);
 
@@ -871,6 +872,7 @@ export function getActiveDeckId(): string {
 function clearReviewQueueState() {
   reviewQueueSig.value = null;
   dueCardsSig.value = [];
+  fullQueueSig.value = [];
   currentReviewCardSig.value = null;
 }
 
@@ -905,6 +907,7 @@ export async function initializeReviewQueue() {
   const dueCards = queue.getDueCards(fullQueue);
 
   reviewQueueSig.value = queue;
+  fullQueueSig.value = fullQueue;
   dueCardsSig.value = dueCards;
 
   if (dueCards.length > 0) {


### PR DESCRIPTION
## Summary
- Show a congratulations screen with today's stats (cards reviewed, time spent, next due date) when the review queue is empty
- Add configurable learn-ahead limit (default 20 minutes) to study cards due soon when the queue is empty
- Add configurable day rollover hour (default 4 AM) so late-night reviews count as the same day

Closes #134