### PR TITLE
Fix backwards responsive breakpoints for card width

### DIFF
--- a/src/components/CardButtons.vue
+++ b/src/components/CardButtons.vue
@@ -60,7 +60,7 @@ const visibleControls = computed(() => getReviewControls(props.activeSide));
   width: 500px;
   max-width: 100%;
 }
-@media (max-width: 1200px) {
+@media (min-width: 1200px) {
   .reveal-button {
     width: 800px;
   }
@@ -84,7 +84,7 @@ const visibleControls = computed(() => getReviewControls(props.activeSide));
 .button-set .time {
   opacity: 0.5;
 }
-@media (max-width: 1200px) {
+@media (min-width: 1200px) {
   .button-set {
     width: 800px;
   }

--- a/src/components/FlashCard.vue
+++ b/src/components/FlashCard.vue
@@ -69,7 +69,7 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeyDown));
   position: relative;
   overflow: hidden;
 }
-@media (max-width: 1200px) {
+@media (min-width: 1200px) {
   .card {
     width: 800px;
   }


### PR DESCRIPTION
## Summary

The `@media (max-width: 1200px)` breakpoints in `FlashCard.vue` and `CardButtons.vue` were backwards — they caused the card, reveal button, and button set to expand from 500px to 800px when the viewport shrank below 1200px, rather than when it grew above 1200px.

Changed all three occurrences to `@media (min-width: 1200px)` so the wider 800px layout only applies on larger screens.

## Test plan

- Resize browser below 1200px and verify card width stays at 500px (or 100% on mobile)
- Resize above 1200px and verify card width expands to 800px
- Confirm the 768px mobile breakpoint still works as expected