### PR TITLE
Fix card image height cropping

### DIFF
--- a/src/components/SandboxedCard.vue
+++ b/src/components/SandboxedCard.vue
@@ -27,7 +27,7 @@ const BASE_STYLES = `
   }
   :where(html[data-theme="light"]) body { color: #18181b; }
   :where(html[data-theme="dark"]) body { color: #f4f4f5; }
-  img { max-width: 100%; height: 200px; display: block; margin: 0 auto; }
+  img { max-width: 100%; height: auto; display: block; margin: 0 auto; }
   hr { margin: 1rem 0; border: none; border-top: 1px solid; opacity: 0.5; }
   :where(html[data-theme="light"]) hr { border-color: #e4e4e7; }
   :where(html[data-theme="dark"]) hr { border-color: #3f3f46; }


### PR DESCRIPTION
## Summary

- Card images were restricted to a fixed `height: 200px` in `SandboxedCard.vue`, which cropped tall images regardless of aspect ratio.
- Changed to `height: auto` so images scale proportionally within the existing `max-width: 100%` constraint.

## Test plan

- Open a deck containing cards with tall/portrait images
- Verify images are no longer cropped and display at their full aspect ratio
- Verify landscape images still render correctly within the card width
- Check that cards without images are unaffected