### PR TITLE
Add aria-label to modal close button

### DIFF
--- a/src/design-system/components/primitives/Modal.vue
+++ b/src/design-system/components/primitives/Modal.vue
@@ -65,7 +65,7 @@ function handleContentClick(e: MouseEvent) {
       <div v-if="title || showCloseButton" class="ds-modal__header">
         <h2 v-if="title" class="ds-modal__title">{{ title }}</h2>
         <div v-else />
-        <button v-if="showCloseButton" class="ds-modal__close" @click="emit('close')">
+        <button v-if="showCloseButton" class="ds-modal__close" aria-label="Close" @click="emit('close')">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
             <path
               d="M289.94 256l95-95A24 24 0 0 0 351 127l-95 95l-95-95a24 24 0 0 0-34 34l95 95l-95 95a24 24 0 1 0 34 34l95-95l95 95a24 24 0 0 0 34-34z"


### PR DESCRIPTION
## Summary

- Added `aria-label="Close"` to the modal close button in `Modal.vue`
- The button previously only contained an SVG icon with no accessible name, making it unidentifiable to screen readers

## Test plan

- Open any modal in the app and inspect the close button element — confirm it has `aria-label="Close"`
- Use a screen reader (e.g. VoiceOver, NVDA) to navigate to the close button and verify it announces "Close"