### PR TITLE
Handle errors from async file cache operations

### DIFF
--- a/src/components/FileLibrary.vue
+++ b/src/components/FileLibrary.vue
@@ -38,9 +38,14 @@ const uploadedDecks = computed(() =>
 // Track collapsed state for parent decks
 const collapsed = reactive(new Set<string>());
 
-function handleFileInput(event: Event) {
+async function handleFileInput(event: Event) {
   const file = (event.target as HTMLInputElement).files?.[0];
-  if (file) addCachedFile(file);
+  if (!file) return;
+  try {
+    await addCachedFile(file);
+  } catch (error) {
+    console.error("Failed to load deck file:", error);
+  }
 }
 
 function selectSubdeck(deckId: string) {


### PR DESCRIPTION
## Summary

- `handleFileInput` in `FileLibrary.vue` called `addCachedFile(file)` without awaiting or catching errors, silently swallowing failures
- Made the function async, awaited the call, and wrapped it in a try/catch that logs the error

## Test plan

- Upload a valid `.apkg` file and verify it loads as before
- Simulate a cache failure (e.g. exceed storage quota) and confirm the error is logged to the console instead of silently swallowed