### PR TITLE
Add focus-visible styles to file library buttons

### DIFF
--- a/src/components/FileLibrary.vue
+++ b/src/components/FileLibrary.vue
@@ -491,6 +491,12 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
   background: var(--color-surface-hover);
 }
 
+.collapse-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  color: var(--color-text-primary);
+}
+
 .collapse-icon {
   display: inline-block;
   font-size: 10px;
@@ -544,6 +550,12 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
   background: var(--color-surface-hover);
 }
 
+.settings-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  color: var(--color-text-primary);
+}
+
 .stat {
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
@@ -585,5 +597,11 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
 .delete-btn:hover {
   color: var(--color-error);
   background: var(--color-surface-hover);
+}
+
+.delete-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  color: var(--color-text-primary);
 }
 </style>


### PR DESCRIPTION
## Summary

- Collapse, settings, and delete buttons in FileLibrary.vue had `:hover` styles but no `:focus-visible` styles, making them invisible to keyboard navigation.
- Added consistent `focus-visible` outlines (`2px solid var(--color-primary)`) to all three button classes.

## Test plan

- Tab through the file library UI and verify each button (collapse, settings, delete) shows a visible outline on focus
- Confirm mouse clicks do not trigger the focus outline (`:focus-visible` only fires for keyboard navigation)
- Verify hover styles still work as before