### PR TITLE
feat: type-in-the-answer cards with diff comparison

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,8 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import FlashCard from "./components/FlashCard.vue";
 import CardButtons from "./components/CardButtons.vue";
 import type { Answer } from "./scheduler/types";
-import { getRenderedCardString } from "./utils/render";
+import { getRenderedCardString, hasTypeAnswerField, extractExpectedAnswer } from "./utils/render";
+import { renderDiffHtml } from "./utils/typeansDiff";
 import { computeDeckInfo } from "./utils/deckInfo";
 import { pushUndo } from "./undoRedo";
 import { executeUndo, executeRedo } from "./undoRedoExecutor";
@@ -53,6 +54,7 @@ const activeSide = ref<"front" | "back">("front");
 const reviewStartTime = ref<number>(Date.now());
 const editModalOpen = ref(false);
 const shortcutsModalOpen = ref(false);
+const typedAnswer = ref("");
 
 const commands = useCommands({
   onEditCard: () => {
@@ -172,7 +174,31 @@ const renderedCard = computed(() => {
     mediaFiles: mediaFilesSig.value,
   });
 
-  return { frontSideHtml, backSideHtml, cardCss: card.css ?? "" };
+  const isTypeAnswer = hasTypeAnswerField(frontSideHtml);
+  return { frontSideHtml, backSideHtml, cardCss: card.css ?? "", isTypeAnswer };
+});
+
+// Compute the back HTML with type-answer diff when applicable
+const backHtmlWithDiff = computed(() => {
+  const card = renderedCard.value;
+  if (!card) return "";
+  if (!card.isTypeAnswer) return card.backSideHtml;
+
+  const expected = extractExpectedAnswer(card.backSideHtml);
+  if (expected === null) return card.backSideHtml;
+
+  const diffHtml = renderDiffHtml(typedAnswer.value, expected);
+
+  // Replace the typeans span with the diff HTML
+  return card.backSideHtml.replace(
+    /<span id="typeans"[^>]*>[\s\S]*?<\/span>/,
+    diffHtml,
+  );
+});
+
+// Reset typed answer when the card changes
+watch(renderedCard, () => {
+  typedAnswer.value = "";
 });
 
 // Autoplay front-side audio when entering studying mode or when the card changes
@@ -244,6 +270,7 @@ function handleEditKeydown(e: KeyboardEvent) {
     reviewModeSig.value === "studying" &&
     activeViewSig.value === "review" &&
     currentNoteCard.value &&
+    !renderedCard.value?.isTypeAnswer &&
     !(e.target instanceof HTMLInputElement) &&
     !(e.target instanceof HTMLTextAreaElement)
   ) {
@@ -418,12 +445,15 @@ onUnmounted(clearAutoAdvanceTimer);
         <FlashCard
           :active-side="activeSide"
           :front-html="renderedCard.frontSideHtml"
-          :back-html="renderedCard.backSideHtml"
+          :back-html="backHtmlWithDiff"
           :card-css="renderedCard.cardCss"
           :intervals="intervals"
+          :has-type-answer="renderedCard.isTypeAnswer"
           @reveal="handleReveal"
           @choose-answer="handleChooseAnswer"
           @audio-button-click="handleAudioButtonClick"
+          @type-answer-input="(v: string) => (typedAnswer = v)"
+          @type-answer-submit="handleReveal"
         />
         <CardButtons
           :active-side="activeSide"

--- a/src/components/FlashCard.vue
+++ b/src/components/FlashCard.vue
@@ -14,15 +14,27 @@ const props = defineProps<{
   backHtml: string;
   cardCss: string;
   intervals?: { again: string; hard: string; good: string; easy: string };
+  hasTypeAnswer?: boolean;
 }>();
 
 const emit = defineEmits<{
   reveal: [];
   chooseAnswer: [answer: Answer];
   audioButtonClick: [src: string];
+  typeAnswerInput: [value: string];
+  typeAnswerSubmit: [];
 }>();
 
 function handleKeyDown(e: KeyboardEvent) {
+  // When there's a type-answer input on the front side, don't intercept
+  // keyboard shortcuts — let the iframe input handle them.
+  // Only allow Enter (which the iframe emits as typeAnswerSubmit) and
+  // Space (which should still reveal for non-type cards).
+  if (props.hasTypeAnswer && props.activeSide === "front") {
+    // On the front side with type answer, only the iframe's Enter triggers reveal
+    return;
+  }
+
   const control = findReviewControl(props.activeSide, e.key);
   if (!control) return;
 
@@ -51,6 +63,8 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeyDown));
         :theme="theme"
         @audio-button-click="(src: string) => emit('audioButtonClick', src)"
         @background-detected="(color: string | null) => (cardBackground = color)"
+        @type-answer-input="(value: string) => emit('typeAnswerInput', value)"
+        @type-answer-submit="emit('typeAnswerSubmit')"
       />
     </div>
   </div>

--- a/src/components/SandboxedCard.vue
+++ b/src/components/SandboxedCard.vue
@@ -12,10 +12,77 @@ const props = defineProps<{
 const emit = defineEmits<{
   audioButtonClick: [src: string];
   backgroundDetected: [color: string | null];
+  typeAnswerInput: [value: string];
+  typeAnswerSubmit: [];
 }>();
 
 const iframeRef = ref<HTMLIFrameElement | null>(null);
 let resizeObserver: ResizeObserver | null = null;
+
+const TYPEANS_STYLES = `
+  .typeans-input {
+    display: block;
+    width: 100%;
+    max-width: 400px;
+    margin: 0.75rem auto;
+    padding: 0.5rem 0.75rem;
+    font-size: 1rem;
+    font-family: inherit;
+    border: 2px solid #888;
+    border-radius: 6px;
+    text-align: center;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+  .typeans-input:focus {
+    border-color: #4a90d9;
+  }
+  :where(html[data-theme="dark"]) .typeans-input {
+    background: #27272a;
+    color: #f4f4f5;
+    border-color: #52525b;
+  }
+  :where(html[data-theme="dark"]) .typeans-input:focus {
+    border-color: #60a5fa;
+  }
+  #typeans {
+    display: block;
+    text-align: center;
+    margin: 0.5rem auto;
+    font-family: monospace;
+    font-size: 1rem;
+  }
+  .typeans-correct {
+    color: #0a0;
+  }
+  :where(html[data-theme="dark"]) .typeans-correct {
+    color: #4ade80;
+  }
+  .typeans-row {
+    margin: 0.25rem 0;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  .typeGood {
+    color: #0a0;
+  }
+  :where(html[data-theme="dark"]) .typeGood {
+    color: #4ade80;
+  }
+  .typeBad {
+    color: #f00;
+  }
+  :where(html[data-theme="dark"]) .typeBad {
+    color: #f87171;
+  }
+  .typeMissed {
+    color: #888;
+    text-decoration: line-through;
+  }
+  :where(html[data-theme="dark"]) .typeMissed {
+    color: #a1a1aa;
+  }
+`;
 
 const BASE_STYLES = `
   *, *::before, *::after { box-sizing: border-box; }
@@ -44,6 +111,7 @@ const BASE_STYLES = `
   }
   .audio-container button svg { pointer-events: none; }
   audio { display: none; }
+  ${TYPEANS_STYLES}
 `;
 
 // srcdoc excludes theme so theme changes don't cause full iframe reloads
@@ -91,6 +159,35 @@ function setupIframe() {
       if (src) {
         emit("audioButtonClick", src);
       }
+    });
+  }
+
+  // Wire up type-answer input fields
+  const typeans = doc.querySelector<HTMLInputElement>('input.typeans-input');
+  if (typeans) {
+    // Focus the input automatically
+    setTimeout(() => typeans.focus(), 50);
+
+    // Emit input value as user types
+    typeans.addEventListener("input", () => {
+      emit("typeAnswerInput", typeans.value);
+    });
+
+    // Enter key submits/reveals
+    typeans.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        emit("typeAnswerSubmit");
+      }
+    });
+
+    // Prevent keyboard shortcuts from leaking through the iframe
+    typeans.addEventListener("keydown", (e) => {
+      // Allow Enter (handled above), Tab, and modifier combos to pass through
+      if (e.key === "Enter" || e.key === "Tab") return;
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      // Stop all other keys from bubbling to parent document
+      e.stopPropagation();
     });
   }
 

--- a/src/utils/__tests__/render.test.ts
+++ b/src/utils/__tests__/render.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getRenderedCardString } from "../render";
+import { getRenderedCardString, hasTypeAnswerField, extractExpectedAnswer } from "../render";
 
 describe("getRenderedCardString", () => {
   it("should correctly render Template 1 from German deck", () => {
@@ -500,6 +500,92 @@ describe("getRenderedCardString", () => {
       });
 
       expect(htmlEmpty).toBe("No extra");
+    });
+  });
+
+  describe("type:FieldName filter", () => {
+    it("should render input field on question side", () => {
+      const html = getRenderedCardString({
+        templateString: "{{type:Back}}",
+        variables: { Back: "to have" },
+        mediaFiles: new Map(),
+      });
+
+      expect(html).toContain('<input type="text"');
+      expect(html).toContain('id="typeans"');
+      expect(html).toContain('class="typeans-input"');
+      expect(html).toContain('placeholder="type answer"');
+    });
+
+    it("should render expected answer with data attribute on answer side", () => {
+      const html = getRenderedCardString({
+        templateString: "{{type:Back}}",
+        variables: { Back: "to have" },
+        mediaFiles: new Map(),
+        isAnswer: true,
+      });
+
+      expect(html).toContain('id="typeans"');
+      expect(html).toContain('data-expected="to have"');
+      expect(html).toContain("to have");
+    });
+
+    it("should strip HTML from expected answer", () => {
+      const html = getRenderedCardString({
+        templateString: "{{type:Back}}",
+        variables: { Back: "<b>answer</b> here" },
+        mediaFiles: new Map(),
+        isAnswer: true,
+      });
+
+      expect(html).toContain('data-expected="answer here"');
+      expect(html).not.toContain("<b>");
+    });
+
+    it("should detect type answer field in HTML", () => {
+      const frontHtml = getRenderedCardString({
+        templateString: "What is the answer? {{type:Back}}",
+        variables: { Back: "test" },
+        mediaFiles: new Map(),
+      });
+
+      expect(hasTypeAnswerField(frontHtml)).toBe(true);
+    });
+
+    it("should not detect type answer field in normal HTML", () => {
+      const frontHtml = getRenderedCardString({
+        templateString: "{{Front}}",
+        variables: { Front: "test" },
+        mediaFiles: new Map(),
+      });
+
+      expect(hasTypeAnswerField(frontHtml)).toBe(false);
+    });
+
+    it("should extract expected answer from back HTML", () => {
+      const backHtml = getRenderedCardString({
+        templateString: "{{type:Back}}",
+        variables: { Back: "Paris" },
+        mediaFiles: new Map(),
+        isAnswer: true,
+      });
+
+      expect(extractExpectedAnswer(backHtml)).toBe("Paris");
+    });
+
+    it("should strip type inputs from FrontSide on answer side", () => {
+      const backHtml = getRenderedCardString({
+        templateString: "{{FrontSide}}<hr>{{type:Back}}",
+        variables: { Back: "answer" },
+        mediaFiles: new Map(),
+        isAnswer: true,
+        frontTemplate: "Question {{type:Back}}",
+      });
+
+      // FrontSide should not contain the input from the front
+      expect(backHtml).not.toContain('<input type="text"');
+      // But should still contain the typeans span from the back template
+      expect(backHtml).toContain('id="typeans"');
     });
   });
 

--- a/src/utils/__tests__/typeansDiff.test.ts
+++ b/src/utils/__tests__/typeansDiff.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { computeDiff, renderDiffHtml, stripHtmlForComparison } from "../typeansDiff";
+
+describe("computeDiff", () => {
+  it("returns all correct when strings match exactly", () => {
+    const diff = computeDiff("hello", "hello");
+    expect(diff).toEqual([
+      { type: "correct", value: "h" },
+      { type: "correct", value: "e" },
+      { type: "correct", value: "l" },
+      { type: "correct", value: "l" },
+      { type: "correct", value: "o" },
+    ]);
+  });
+
+  it("detects missing characters", () => {
+    const diff = computeDiff("hllo", "hello");
+    // 'h' correct, 'e' missing, 'l' correct, 'l' correct, 'o' correct
+    expect(diff.filter((d) => d.type === "correct")).toHaveLength(4);
+    expect(diff.filter((d) => d.type === "missing")).toHaveLength(1);
+  });
+
+  it("detects extra characters", () => {
+    const diff = computeDiff("helloo", "hello");
+    expect(diff.filter((d) => d.type === "correct")).toHaveLength(5);
+    expect(diff.filter((d) => d.type === "extra")).toHaveLength(1);
+  });
+
+  it("detects incorrect characters", () => {
+    const diff = computeDiff("hxllo", "hello");
+    // 'h' correct, 'x' vs 'e' incorrect, 'l' correct, 'l' correct, 'o' correct
+    const incorrectEntries = diff.filter((d) => d.type === "incorrect");
+    expect(incorrectEntries.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles empty typed string", () => {
+    const diff = computeDiff("", "hello");
+    expect(diff).toEqual([{ type: "missing", value: "hello" }]);
+  });
+
+  it("handles empty expected string", () => {
+    const diff = computeDiff("hello", "");
+    expect(diff).toEqual([{ type: "extra", value: "hello" }]);
+  });
+
+  it("handles completely different strings", () => {
+    const diff = computeDiff("abc", "xyz");
+    // No common subsequence
+    const hasIncorrect = diff.some((d) => d.type === "incorrect");
+    const hasExtra = diff.some((d) => d.type === "extra");
+    const hasMissing = diff.some((d) => d.type === "missing");
+    expect(hasIncorrect || (hasExtra && hasMissing)).toBe(true);
+  });
+});
+
+describe("renderDiffHtml", () => {
+  it("shows green text for exact match", () => {
+    const html = renderDiffHtml("hello", "hello");
+    expect(html).toContain('class="typeans-correct"');
+    expect(html).toContain("hello");
+  });
+
+  it("shows diff with correct and incorrect spans for partial match", () => {
+    const html = renderDiffHtml("hxllo", "hello");
+    expect(html).toContain('class="typeGood"');
+    expect(html).toContain('class="typeBad"');
+  });
+
+  it("shows missing spans for incomplete typed answer", () => {
+    const html = renderDiffHtml("hel", "hello");
+    expect(html).toContain('class="typeGood"');
+    expect(html).toContain('class="typeMissed"');
+  });
+
+  it("escapes HTML in output", () => {
+    const html = renderDiffHtml("<script>", "<script>");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("wraps output in typeans div", () => {
+    const html = renderDiffHtml("test", "test");
+    expect(html).toContain('id="typeans"');
+  });
+});
+
+describe("stripHtmlForComparison", () => {
+  it("strips HTML tags", () => {
+    expect(stripHtmlForComparison("<b>hello</b>")).toBe("hello");
+  });
+
+  it("converts <br> to newline", () => {
+    expect(stripHtmlForComparison("hello<br>world")).toBe("hello\nworld");
+  });
+
+  it("decodes HTML entities", () => {
+    expect(stripHtmlForComparison("&amp; &lt; &gt;")).toBe("& < >");
+  });
+
+  it("trims whitespace", () => {
+    expect(stripHtmlForComparison("  hello  ")).toBe("hello");
+  });
+
+  it("handles complex HTML", () => {
+    expect(stripHtmlForComparison('<div class="foo"><span>answer</span></div>')).toBe("answer");
+  });
+});

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -1,5 +1,6 @@
 import katex from "katex";
 import { isClozeNode, parseClozeNodes, renderTemplateString } from "./templateParser";
+import { stripHtmlForComparison } from "./typeansDiff";
 
 type Variables = { [key: string]: string | null };
 
@@ -164,7 +165,7 @@ function stripAvTags(html: string): string {
  * Strip type: input fields from FrontSide HTML when injecting into answer side.
  */
 function stripTypeInputs(html: string): string {
-  return html.replace(/<input type="text" id="typeans"[^>]*>/g, "");
+  return html.replace(/<input[^>]*id="typeans"[^>]*>/g, "").replace(/<input[^>]*class="typeans-input"[^>]*>/g, "");
 }
 
 /**
@@ -246,10 +247,11 @@ function processTypeCloze(text: string, cardOrd: number, isAnswer: boolean): str
     const answers: string[] = [];
     for (const node of parseClozeNodes(text)) {
       if (isClozeNode(node) && node.ordinal === clozeNum) {
-        answers.push(node.answer);
+        answers.push(stripHtmlForComparison(node.answer));
       }
     }
-    return `<span id="typeans">${answers.join(", ")}</span>`;
+    const expectedPlain = answers.join(", ");
+    return `<span id="typeans" data-expected="${expectedPlain.replace(/"/g, "&quot;")}">${expectedPlain}</span>`;
   }
 
   return parseClozeNodes(text)
@@ -258,7 +260,7 @@ function processTypeCloze(text: string, cardOrd: number, isAnswer: boolean): str
         return node.value;
       }
       if (node.ordinal === clozeNum) {
-        return `<input type="text" id="typeans" placeholder="type answer">`;
+        return `<input type="text" id="typeans" class="typeans-input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="type answer">`;
       }
       return node.answer;
     })
@@ -286,9 +288,10 @@ function applyFilter(
       return `<a class="hint" onclick="this.style.display='none';this.nextSibling.style.display='inline-block';">Show ${fieldName}</a><span style="display:none">${value}</span>`;
     case "type":
       if (isAnswer) {
-        return `<span id="typeans">${value}</span>`;
+        const expectedPlain = stripHtmlForComparison(value);
+        return `<span id="typeans" data-expected="${expectedPlain.replace(/"/g, "&quot;")}">${expectedPlain}</span>`;
       }
-      return `<input type="text" id="typeans" placeholder="type answer">`;
+      return `<input type="text" id="typeans" class="typeans-input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="type answer">`;
     case "furigana":
       return applyFuriganaFilter(value);
     case "kanji":
@@ -671,4 +674,20 @@ function fieldIsNotEmpty(value: string | null | undefined, isCloze?: boolean): b
     : value;
   const stripped = processed.replace(/<[^>]*>/g, "").trim();
   return stripped.length > 0;
+}
+
+/**
+ * Check if a rendered card HTML contains a type-answer input field.
+ */
+export function hasTypeAnswerField(html: string): boolean {
+  return html.includes('id="typeans"');
+}
+
+/**
+ * Extract the expected answer from the back-side HTML's typeans element.
+ */
+export function extractExpectedAnswer(backHtml: string): string | null {
+  const match = backHtml.match(/id="typeans"\s+data-expected="([^"]*)"/);
+  if (!match) return null;
+  return match[1]!.replace(/&quot;/g, '"').replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">");
 }

--- a/src/utils/typeansDiff.ts
+++ b/src/utils/typeansDiff.ts
@@ -1,0 +1,223 @@
+/**
+ * Character-by-character diff for type-in-the-answer cards.
+ * Matches Anki desktop's color-coded diff display:
+ * - Green (#0a0) for correct characters
+ * - Red (#f00) for incorrect characters typed
+ * - Grey (#888) with strikethrough for missing characters
+ */
+
+type DiffEntry =
+  | { type: "correct"; value: string }
+  | { type: "incorrect"; typed: string; expected: string }
+  | { type: "missing"; value: string }
+  | { type: "extra"; value: string };
+
+/**
+ * Compute a character-level diff between the typed and expected strings.
+ * Uses a simple LCS (Longest Common Subsequence) approach to align characters.
+ */
+export function computeDiff(typed: string, expected: string): DiffEntry[] {
+  const lcs = computeLCS(typed, expected);
+  const entries: DiffEntry[] = [];
+
+  let ti = 0; // typed index
+  let ei = 0; // expected index
+  let li = 0; // lcs index
+
+  while (ti < typed.length || ei < expected.length) {
+    if (li < lcs.length) {
+      const lcsChar = lcs[li]!;
+
+      // Advance through typed chars not in LCS (extra/incorrect)
+      let extraTyped = "";
+      while (ti < typed.length && typed[ti] !== lcsChar) {
+        extraTyped += typed[ti];
+        ti++;
+      }
+
+      // Advance through expected chars not in LCS (missing)
+      let missingExpected = "";
+      while (ei < expected.length && expected[ei] !== lcsChar) {
+        missingExpected += expected[ei];
+        ei++;
+      }
+
+      // Pair up extra typed with missing expected as "incorrect"
+      if (extraTyped.length > 0 && missingExpected.length > 0) {
+        const minLen = Math.min(extraTyped.length, missingExpected.length);
+        entries.push({
+          type: "incorrect",
+          typed: extraTyped.slice(0, minLen),
+          expected: missingExpected.slice(0, minLen),
+        });
+        if (extraTyped.length > minLen) {
+          entries.push({ type: "extra", value: extraTyped.slice(minLen) });
+        }
+        if (missingExpected.length > minLen) {
+          entries.push({ type: "missing", value: missingExpected.slice(minLen) });
+        }
+      } else if (extraTyped.length > 0) {
+        entries.push({ type: "extra", value: extraTyped });
+      } else if (missingExpected.length > 0) {
+        entries.push({ type: "missing", value: missingExpected });
+      }
+
+      // The matching LCS character
+      entries.push({ type: "correct", value: lcsChar });
+      ti++;
+      ei++;
+      li++;
+    } else {
+      // No more LCS chars — remaining typed are extra, remaining expected are missing
+      let extraTyped = "";
+      while (ti < typed.length) {
+        extraTyped += typed[ti];
+        ti++;
+      }
+      let missingExpected = "";
+      while (ei < expected.length) {
+        missingExpected += expected[ei];
+        ei++;
+      }
+
+      if (extraTyped.length > 0 && missingExpected.length > 0) {
+        const minLen = Math.min(extraTyped.length, missingExpected.length);
+        entries.push({
+          type: "incorrect",
+          typed: extraTyped.slice(0, minLen),
+          expected: missingExpected.slice(0, minLen),
+        });
+        if (extraTyped.length > minLen) {
+          entries.push({ type: "extra", value: extraTyped.slice(minLen) });
+        }
+        if (missingExpected.length > minLen) {
+          entries.push({ type: "missing", value: missingExpected.slice(minLen) });
+        }
+      } else if (extraTyped.length > 0) {
+        entries.push({ type: "extra", value: extraTyped });
+      } else if (missingExpected.length > 0) {
+        entries.push({ type: "missing", value: missingExpected });
+      }
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Compute the Longest Common Subsequence of two strings.
+ */
+function computeLCS(a: string, b: string): string {
+  const m = a.length;
+  const n = b.length;
+
+  // DP table
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0) as number[]);
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i]![j] = dp[i - 1]![j - 1]! + 1;
+      } else {
+        dp[i]![j] = Math.max(dp[i - 1]![j]!, dp[i]![j - 1]!);
+      }
+    }
+  }
+
+  // Backtrack to find LCS
+  let result = "";
+  let i = m;
+  let j = n;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      result = a[i - 1] + result;
+      i--;
+      j--;
+    } else if (dp[i - 1]![j]! > dp[i]![j - 1]!) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Render a diff as HTML matching Anki desktop's display.
+ * Shows two rows: the typed answer (with correct/incorrect/extra highlighting)
+ * and the expected answer (with correct/missing highlighting).
+ */
+export function renderDiffHtml(typed: string, expected: string): string {
+  if (typed === expected) {
+    return `<div id="typeans" class="typeans-correct">${escapeHtml(expected)}</div>`;
+  }
+
+  const diff = computeDiff(typed, expected);
+
+  // Build the "typed" row showing what was typed
+  let typedRow = "";
+  for (const entry of diff) {
+    switch (entry.type) {
+      case "correct":
+        typedRow += `<span class="typeGood">${escapeHtml(entry.value)}</span>`;
+        break;
+      case "incorrect":
+        typedRow += `<span class="typeBad">${escapeHtml(entry.typed)}</span>`;
+        break;
+      case "extra":
+        typedRow += `<span class="typeBad">${escapeHtml(entry.value)}</span>`;
+        break;
+      case "missing":
+        typedRow += `<span class="typeMissed">-</span>`;
+        break;
+    }
+  }
+
+  // Build the "expected" row
+  let expectedRow = "";
+  for (const entry of diff) {
+    switch (entry.type) {
+      case "correct":
+        expectedRow += `<span class="typeGood">${escapeHtml(entry.value)}</span>`;
+        break;
+      case "incorrect":
+        expectedRow += `<span class="typeBad">${escapeHtml(entry.expected)}</span>`;
+        break;
+      case "missing":
+        expectedRow += `<span class="typeMissed">${escapeHtml(entry.value)}</span>`;
+        break;
+      case "extra":
+        // Extra typed chars don't appear in expected row
+        break;
+    }
+  }
+
+  return `<div id="typeans"><div class="typeans-row">${typedRow}</div><hr><div class="typeans-row">${expectedRow}</div></div>`;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Strip HTML tags from a string and decode HTML entities.
+ * Used to get the plain-text expected answer from a field value.
+ */
+export function stripHtmlForComparison(html: string): string {
+  // Remove HTML tags
+  let text = html.replace(/<br\s*\/?>/gi, "\n").replace(/<[^>]*>/g, "");
+  // Decode common HTML entities
+  text = text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ");
+  return text.trim();
+}


### PR DESCRIPTION
## Summary
- Detect `{{type:FieldName}}` in card templates and render a text input
- LCS-based character-level diff algorithm comparing typed vs expected answer
- Color-coded diff display (green correct, red wrong, grey missing) with dark mode
- Keyboard handling: Enter to submit, shortcut suppression while typing
- 24 new tests covering diff logic and template rendering

Closes #110

## Test plan
- [ ] Create a card with `{{type:Front}}` template
- [ ] Verify input field appears during review
- [ ] Type an answer and press Enter — verify color-coded diff
- [ ] Test on mobile with on-screen keyboard
- [ ] Run `npm test` — all 105 tests should pass