### PR TITLE
feat: add extended statistics & graphs with 10 chart types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tiptap/starter-kit": "^3.22.3",
         "@tiptap/vue-3": "^3.22.3",
         "@zip-js/zip-js": "npm:@jsr/zip-js__zip-js@^2.7.57",
+        "chart.js": "^4.5.1",
         "katex": "^0.16.21",
         "lucide-vue-next": "^0.474.0",
         "mime": "^4.0.6",
@@ -22,6 +23,7 @@
         "tailwindcss": "^4.2.2",
         "ts-fsrs": "^5.2.3",
         "vue": "^3.5.13",
+        "vue-chartjs": "^5.3.3",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -2156,6 +2158,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
@@ -5721,6 +5729,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/commander": {
@@ -10275,6 +10295,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
+      "integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tiptap/starter-kit": "^3.22.3",
     "@tiptap/vue-3": "^3.22.3",
     "@zip-js/zip-js": "npm:@jsr/zip-js__zip-js@^2.7.57",
+    "chart.js": "^4.5.1",
     "katex": "^0.16.21",
     "lucide-vue-next": "^0.474.0",
     "mime": "^4.0.6",
@@ -41,6 +42,7 @@
     "tailwindcss": "^4.2.2",
     "ts-fsrs": "^5.2.3",
     "vue": "^3.5.13",
+    "vue-chartjs": "^5.3.3",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -38,6 +38,8 @@ import DeckCreator from "./components/DeckCreator.vue";
 import CardBrowser from "./components/CardBrowser.vue";
 import FindDuplicates from "./components/FindDuplicates.vue";
 import SyncPanel from "./components/SyncPanel.vue";
+import { defineAsyncComponent } from "vue";
+const StatsPanel = defineAsyncComponent(() => import("./components/StatsPanel.vue"));
 import CongratsScreen from "./components/CongratsScreen.vue";
 import SchedulerSettings from "./components/SchedulerSettings.vue";
 import FlagSettings from "./components/FlagSettings.vue";
@@ -428,6 +430,9 @@ onUnmounted(clearAutoAdvanceTimer);
 
   <!-- CREATE DECK VIEW -->
   <DeckCreator v-else-if="activeViewSig === 'create'" />
+
+  <!-- STATS VIEW -->
+  <StatsPanel v-else-if="activeViewSig === 'stats'" />
 
   <!-- SYNC VIEW -->
   <SyncPanel v-else-if="activeViewSig === 'sync'" />

--- a/src/components/StatsPanel.vue
+++ b/src/components/StatsPanel.vue
@@ -1,0 +1,197 @@
+<script setup lang="ts">
+import { ref, shallowRef, watch, onMounted } from "vue";
+import { reviewDB } from "../scheduler/db";
+import { normalizeCard } from "../stats/normalizeCard";
+import {
+  computeCardCounts,
+  computeIntervalDistribution,
+  computeEaseDistribution,
+  computeFutureDue,
+  computeCalendarHeatmap,
+  computeReviewsByHour,
+  computeAnswerButtons,
+  computeTrueRetention,
+  computeAddedCards,
+  computeStudyStreak,
+} from "../stats/computeStats";
+import type { StatsPeriod } from "../stats/types";
+import type {
+  CardCountsData,
+  AnswerButtonsData,
+  TrueRetentionData,
+  BucketData,
+  DayCount,
+} from "../stats/types";
+import { useChartTheme } from "../composables/useChartTheme";
+
+import StatsPeriodSelector from "./stats/StatsPeriodSelector.vue";
+import StatsOverview from "./stats/StatsOverview.vue";
+import CardCountsChart from "./stats/CardCountsChart.vue";
+import AnswerButtonsChart from "./stats/AnswerButtonsChart.vue";
+import CalendarHeatmap from "./stats/CalendarHeatmap.vue";
+import IntervalChart from "./stats/IntervalChart.vue";
+import EaseChart from "./stats/EaseChart.vue";
+import FutureDueChart from "./stats/FutureDueChart.vue";
+import HourlyReviewChart from "./stats/HourlyReviewChart.vue";
+import AddedCardsChart from "./stats/AddedCardsChart.vue";
+
+const { colors } = useChartTheme();
+
+const MS_PER_DAY = 86_400_000;
+
+const period = ref<StatsPeriod>("1m");
+const loading = ref(true);
+
+// Computed stat results
+const cardCounts = shallowRef<CardCountsData>({ new: 0, learning: 0, young: 0, mature: 0 });
+const answerButtons = shallowRef<AnswerButtonsData>({ again: 0, hard: 0, good: 0, easy: 0 });
+const trueRetention = shallowRef<TrueRetentionData>({ retention: 0, total: 0, correct: 0 });
+const intervalDist = shallowRef<BucketData[]>([]);
+const easeDist = shallowRef<BucketData[]>([]);
+const futureDue = shallowRef<DayCount[]>([]);
+const calendarData = shallowRef<DayCount[]>([]);
+const hourlyData = shallowRef<BucketData[]>([]);
+const addedCardsData = shallowRef<DayCount[]>([]);
+const totalReviews = ref(0);
+const totalTimeMs = ref(0);
+const streak = ref(0);
+
+function getPeriodStartMs(p: StatsPeriod): number {
+  const now = Date.now();
+  switch (p) {
+    case "1m":
+      return now - 30 * MS_PER_DAY;
+    case "3m":
+      return now - 90 * MS_PER_DAY;
+    case "1y":
+      return now - 365 * MS_PER_DAY;
+    case "all":
+      return 0;
+  }
+}
+
+async function loadStats() {
+  loading.value = true;
+
+  const startMs = getPeriodStartMs(period.value);
+  const endMs = Date.now();
+
+  const [allCards, logs, dailyStats] = await Promise.all([
+    reviewDB.getAllCards(),
+    reviewDB.getAllReviewLogsInRange(startMs, endMs),
+    reviewDB.getAllDailyStats(),
+  ]);
+
+  const normalized = allCards.map(normalizeCard);
+
+  // Filter daily stats to period
+  const startDate = new Date(startMs).toISOString().slice(0, 10);
+  const filteredDailyStats =
+    period.value === "all" ? dailyStats : dailyStats.filter((s) => s.date >= startDate);
+
+  // Card-based stats (always use all cards for current state)
+  cardCounts.value = computeCardCounts(normalized);
+  intervalDist.value = computeIntervalDistribution(normalized);
+  easeDist.value = computeEaseDistribution(normalized);
+  futureDue.value = computeFutureDue(normalized, 30);
+
+  // Review-log-based stats (filtered by period)
+  calendarData.value = computeCalendarHeatmap(logs);
+  hourlyData.value = computeReviewsByHour(logs);
+  answerButtons.value = computeAnswerButtons(logs);
+  trueRetention.value = computeTrueRetention(logs, normalized);
+  addedCardsData.value = computeAddedCards(normalized, startMs, endMs);
+
+  // Aggregate totals
+  totalReviews.value = filteredDailyStats.reduce(
+    (sum, s) => sum + s.newCount + s.reviewCount,
+    0,
+  );
+  totalTimeMs.value = filteredDailyStats.reduce((sum, s) => sum + s.totalTimeMs, 0);
+  streak.value = computeStudyStreak(dailyStats);
+
+  loading.value = false;
+}
+
+onMounted(loadStats);
+watch(period, loadStats);
+</script>
+
+<template>
+  <div class="stats-panel">
+    <div class="stats-header">
+      <h2 class="stats-title">Statistics</h2>
+      <StatsPeriodSelector v-model="period" />
+    </div>
+
+    <div v-if="loading" class="stats-loading">Loading statistics...</div>
+
+    <template v-else>
+      <StatsOverview
+        :total-reviews="totalReviews"
+        :streak="streak"
+        :card-counts="cardCounts"
+        :true-retention="trueRetention"
+        :total-time-ms="totalTimeMs"
+      />
+
+      <CalendarHeatmap :data="calendarData" :colors="colors" />
+
+      <div class="chart-grid">
+        <CardCountsChart :data="cardCounts" :colors="colors" />
+        <AnswerButtonsChart :data="answerButtons" :colors="colors" />
+      </div>
+
+      <FutureDueChart :data="futureDue" :colors="colors" />
+
+      <div class="chart-grid">
+        <IntervalChart :data="intervalDist" :colors="colors" />
+        <EaseChart :data="easeDist" :colors="colors" />
+      </div>
+
+      <div class="chart-grid">
+        <HourlyReviewChart :data="hourlyData" :colors="colors" />
+        <AddedCardsChart :data="addedCardsData" :colors="colors" />
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.stats-panel {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--spacing-6) var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-5);
+}
+
+.stats-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+}
+
+.stats-title {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-neutral-900);
+  margin: 0;
+}
+
+.stats-loading {
+  text-align: center;
+  padding: var(--spacing-12);
+  color: var(--color-neutral-500);
+  font-size: var(--font-size-sm);
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: var(--spacing-4);
+}
+</style>

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -13,6 +13,7 @@ const tabs: { id: AppView; label: string }[] = [
   { id: "review", label: "Review" },
   { id: "browse", label: "Browse" },
   { id: "create", label: "Create Deck" },
+  { id: "stats", label: "Stats" },
   { id: "sync", label: "Sync" },
 ];
 

--- a/src/components/stats/AddedCardsChart.vue
+++ b/src/components/stats/AddedCardsChart.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Bar } from "vue-chartjs";
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  type ChartData,
+  type ChartOptions,
+} from "chart.js";
+import type { DayCount } from "../../stats/types";
+import type { ChartColors } from "../../composables/useChartTheme";
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip);
+
+const props = defineProps<{ data: DayCount[]; colors: ChartColors }>();
+
+const chartData = computed<ChartData<"bar">>(() => {
+  const labels = props.data.map((d) => {
+    const date = new Date(d.date);
+    return `${date.getMonth() + 1}/${date.getDate()}`;
+  });
+
+  return {
+    labels,
+    datasets: [
+      {
+        data: props.data.map((d) => d.count),
+        backgroundColor: props.colors.success,
+        borderRadius: 2,
+      },
+    ],
+  };
+});
+
+const chartOptions = computed<ChartOptions<"bar">>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        title: (items) => {
+          const idx = items[0]?.dataIndex;
+          return idx != null ? props.data[idx].date : "";
+        },
+      },
+    },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: {
+        color: props.colors.textSecondary,
+        font: { size: 10 },
+        maxTicksLimit: 10,
+      },
+    },
+    y: {
+      grid: { color: props.colors.gridLine },
+      ticks: { color: props.colors.textSecondary },
+      beginAtZero: true,
+    },
+  },
+}));
+</script>
+
+<template>
+  <div class="chart-card">
+    <h3 class="chart-title">Cards Added</h3>
+    <div class="chart-container">
+      <Bar :data="chartData" :options="chartOptions" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chart-card {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+}
+
+.chart-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-neutral-900);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.chart-container {
+  position: relative;
+  height: 250px;
+}
+</style>

--- a/src/components/stats/AnswerButtonsChart.vue
+++ b/src/components/stats/AnswerButtonsChart.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Doughnut } from "vue-chartjs";
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+  type ChartData,
+  type ChartOptions,
+} from "chart.js";
+import type { AnswerButtonsData } from "../../stats/types";
+import type { ChartColors } from "../../composables/useChartTheme";
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+const props = defineProps<{ data: AnswerButtonsData; colors: ChartColors }>();
+
+const chartData = computed<ChartData<"doughnut">>(() => ({
+  labels: ["Again", "Hard", "Good", "Easy"],
+  datasets: [
+    {
+      data: [props.data.again, props.data.hard, props.data.good, props.data.easy],
+      backgroundColor: [
+        props.colors.again,
+        props.colors.hard,
+        props.colors.good,
+        props.colors.easy,
+      ],
+      borderWidth: 0,
+    },
+  ],
+}));
+
+const chartOptions = computed<ChartOptions<"doughnut">>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      position: "bottom",
+      labels: { color: props.colors.text, padding: 16 },
+    },
+  },
+}));
+</script>
+
+<template>
+  <div class="chart-card">
+    <h3 class="chart-title">Answer Buttons</h3>
+    <div class="chart-container">
+      <Doughnut :data="chartData" :options="chartOptions" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chart-card {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+}
+
+.chart-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-neutral-900);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.chart-container {
+  position: relative;
+  height: 250px;
+}
+</style>

--- a/src/components/stats/CalendarHeatmap.vue
+++ b/src/components/stats/CalendarHeatmap.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type { DayCount } from "../../stats/types";
+import type { ChartColors } from "../../composables/useChartTheme";
+
+const props = defineProps<{ data: DayCount[]; colors: ChartColors }>();
+
+const tooltipInfo = ref<{ text: string; x: number; y: number } | null>(null);
+
+const CELL_SIZE = 13;
+const CELL_GAP = 3;
+const TOTAL = CELL_SIZE + CELL_GAP;
+const WEEKS = 53;
+const LABEL_WIDTH = 28;
+
+const countMap = computed(() => {
+  const m = new Map<string, number>();
+  for (const d of props.data) m.set(d.date, d.count);
+  return m;
+});
+
+const maxCount = computed(() => {
+  let max = 0;
+  for (const d of props.data) if (d.count > max) max = d.count;
+  return max || 1;
+});
+
+function getColor(count: number): string {
+  if (count === 0) return props.colors.gridLine;
+  const ratio = count / maxCount.value;
+  if (ratio < 0.25) return props.colors.young;
+  if (ratio < 0.5) return props.colors.good;
+  if (ratio < 0.75) return props.colors.success;
+  return props.colors.mature;
+}
+
+interface CellInfo {
+  x: number;
+  y: number;
+  date: string;
+  count: number;
+  color: string;
+}
+
+const cells = computed<CellInfo[]>(() => {
+  const result: CellInfo[] = [];
+  const today = new Date();
+  const todayDay = today.getDay();
+
+  // Start from (WEEKS-1)*7 days ago, aligned to Sunday
+  const startOffset = (WEEKS - 1) * 7 + todayDay;
+  const startDate = new Date(today);
+  startDate.setDate(startDate.getDate() - startOffset);
+
+  for (let week = 0; week < WEEKS; week++) {
+    for (let day = 0; day < 7; day++) {
+      const d = new Date(startDate);
+      d.setDate(d.getDate() + week * 7 + day);
+      if (d > today) continue;
+
+      const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      const count = countMap.value.get(dateStr) ?? 0;
+
+      result.push({
+        x: LABEL_WIDTH + week * TOTAL,
+        y: day * TOTAL,
+        date: dateStr,
+        count,
+        color: getColor(count),
+      });
+    }
+  }
+
+  return result;
+});
+
+const dayLabels = ["", "Mon", "", "Wed", "", "Fri", ""];
+
+function handleMouseEnter(cell: CellInfo, event: MouseEvent) {
+  const rect = (event.target as SVGElement).getBoundingClientRect();
+  tooltipInfo.value = {
+    text: `${cell.date}: ${cell.count} review${cell.count !== 1 ? "s" : ""}`,
+    x: rect.left + rect.width / 2,
+    y: rect.top,
+  };
+}
+
+function handleMouseLeave() {
+  tooltipInfo.value = null;
+}
+</script>
+
+<template>
+  <div class="chart-card">
+    <h3 class="chart-title">Review Activity</h3>
+    <div class="heatmap-wrapper">
+      <svg
+        :width="LABEL_WIDTH + WEEKS * TOTAL"
+        :height="7 * TOTAL"
+        class="heatmap-svg"
+      >
+        <!-- Day labels -->
+        <text
+          v-for="(label, i) in dayLabels"
+          :key="'label-' + i"
+          :x="LABEL_WIDTH - 6"
+          :y="i * TOTAL + CELL_SIZE"
+          class="day-label"
+          text-anchor="end"
+        >
+          {{ label }}
+        </text>
+        <!-- Cells -->
+        <rect
+          v-for="(cell, i) in cells"
+          :key="i"
+          :x="cell.x"
+          :y="cell.y"
+          :width="CELL_SIZE"
+          :height="CELL_SIZE"
+          :fill="cell.color"
+          rx="2"
+          ry="2"
+          @mouseenter="handleMouseEnter(cell, $event)"
+          @mouseleave="handleMouseLeave"
+        />
+      </svg>
+    </div>
+    <!-- Tooltip -->
+    <Teleport to="body">
+      <div
+        v-if="tooltipInfo"
+        class="heatmap-tooltip"
+        :style="{ left: tooltipInfo.x + 'px', top: tooltipInfo.y - 8 + 'px' }"
+      >
+        {{ tooltipInfo.text }}
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped>
+.chart-card {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+}
+
+.chart-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-neutral-900);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.heatmap-wrapper {
+  overflow-x: auto;
+}
+
+.heatmap-svg {
+  display: block;
+}
+
+.day-label {
+  font-size: 10px;
+  fill: var(--color-neutral-500);
+}
+
+.heatmap-svg rect {
+  cursor: pointer;
+  transition: opacity 0.1s;
+}
+
+.heatmap-svg rect:hover {
+  opacity: 0.8;
+  stroke: var(--color-neutral-900);
+  stroke-width: 1;
+}
+</style>
+
+<style>
+.heatmap-tooltip {
+  position: fixed;
+  transform: translate(-50%, -100%);
+  background: var(--color-neutral-900);
+  color: var(--color-neutral-50);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 9999;
+}
+</style>

--- a/src/components/stats/CardCountsChart.vue
+++ b/src/components/stats/CardCountsChart.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Doughnut } from "vue-chartjs";
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+  type ChartData,
+  type ChartOptions,
+} from "chart.js";
+import type { CardCountsData } from "../../stats/types";
+import type { ChartColors } from "../../composables/useChartTheme";
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+const props = defineProps<{ data: CardCountsData; colors: ChartColors }>();
+
+const chartData = computed<ChartData<"doughnut">>(() => ({
+  labels: ["New", "Learning", "Young", "Mature"],
+  datasets: [
+    {
+      data: [props.data.new, props.data.learning, props.data.young, props.data.mature],
+      backgroundColor: [
+        props.colors.newCard,
+        props.colors.learning,
+        props.colors.young,
+        props.colors.mature,
+      ],
+      borderWidth: 0,
+    },
+  ],
+}));
+
+const chartOptions = computed<ChartOptions<"doughnut">>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      position: "bottom",
+      labels: { color: props.colors.text, padding: 16 },
+    },
+  },
+}));
+</script>
+
+<template>
+  <div class="chart-card">
+    <h3 class="chart-title">Card States</h3>
+    <div class="chart-container">
+      <Doughnut :data="chartData" :options="chartOptions" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chart-card {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+}
+
+.chart-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-neutral-900);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.chart-container {
+  position: relative;
+  height: 250px;
+}
+</style>

--- a/src/components/stats/EaseChart.vue
+++ b/src/components/stats/EaseChart.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Bar } from "vue-chartjs";
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  type ChartData,
+  type ChartOptions,
+} from "chart.js";
+import type { BucketData } from "../../stats/types";
+import type { ChartColors } from "../../composables/useChartTheme";
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip);
+
+const props = defineProps<{ data: BucketData[]; colors: ChartColors }>();
+
+const chartData = computed<ChartData<"bar">>(() => ({
+  labels: props.data.map((b) => b.label),
+  datasets: [
+    {
+      data: props.data.map((b) => b.count),
+      backgroundColor: props.colors.success,
+      borderRadius: 4,
+    },
+  ],
+}));
+
+const chartOptions = computed<ChartOptions<"bar">>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: { color: props.colors.textSecondary, font: { size: 11 } },
+    },
+    y: {
+      grid: { color: props.colors.gridLine },
+      ticks: { color: props.colors.textSecondary },
+      beginAtZero: true,
+    },
+  },
+}));
+</script>
+
+<template>
+  <div class="chart-card">
+    <h3 class="chart-title">Ease Factor Distribution</h3>
+    <div class="chart-container">
+      <Bar :data="chartData" :options="chartOptions" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chart-card {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+}
+
+.chart-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-neutral-900);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.chart-container {
+  position: relative;
+  height: 250px;
+}
+</style>

--- a/src/components/stats/FutureDueChart.vue
+++ b/src/components/stats/FutureDueChart.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Bar } from "vue-chartjs";
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  type ChartData,
+  type ChartOptions,
+} from "chart.js";
+import type { DayCount } from "../../stats/types";
+import type { ChartColors } from "../../composables/useChartTheme";
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip);
+
+const props = defineProps<{ data: DayCount[]; colors: ChartColors }>();
+
+const chartData = computed<ChartData<"bar">>(() => {
+  const labels = props.data.map((d) => {
+    const date = new Date(d.date);
+    return `${date.getMonth() + 1}/${date.getDate()}`;
+  });
+
+  return {
+    labels,
+    datasets: [
+      {
+        data: props.data.map((d) => d.count),
+        backgroundColor: props.colors.primary,
+        borderRadius: 2,
+      },
+    ],
+  };
+});
+
+const chartOptions = computed<ChartOptions<"bar">>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        title: (items) => {
+          const idx = items[0]?.dataIndex;
+          return idx != null ? props.data[idx].date : "";
+        },
+      },
+    },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: {
+        color: props.colors.textSecondary,
+        font: { size: 10 },
+        maxTicksLimit: 10,
+      },
+    },
+    y: {
+      grid: { color: props.colors.gridLine },
+      ticks: { color: props.colors.textSecondary },
+      beginAtZero: true,
+    },
+  },
+}));
+</script>
+
+<template>
+  <div class="chart-card">
+    <h3 class="chart-title">Future Due</h3>
+    <div class="chart-container">
+      <Bar :data="chartData" :options="chartOptions" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chart-card {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+}
+
+.chart-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-neutral-900);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.chart-container {
+  position: relative;
+  height: 250px;
+}
+</style>

--- a/src/components/stats/HourlyReviewChart.vue
+++ b/src/components/stats/HourlyReviewChart.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Bar } from "vue-chartjs";
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  type ChartData,
+  type ChartOptions,
+} from "chart.js";
+import type { BucketData } from "../../stats/types";
+import type { ChartColors } from "../../composables/useChartTheme";
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip);
+
+const props = defineProps<{ data: BucketData[]; colors: ChartColors }>();
+
+const chartData = computed<ChartData<"bar">>(() => ({
+  labels: props.data.map((b) => b.label),
+  datasets: [
+    {
+      data: props.data.map((b) => b.count),
+      backgroundColor: props.colors.warning,
+      borderRadius: 4,
+    },
+  ],
+}));
+
+const chartOptions = computed<ChartOptions<"bar">>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: {
+        color: props.colors.textSecondary,
+        font: { size: 10 },
+        maxTicksLimit: 12,
+      },
+    },
+    y: {
+      grid: { color: props.colors.gridLine },
+      ticks: { color: props.colors.textSecondary },
+      beginAtZero: true,
+    },
+  },
+}));
+</script>
+
+<template>
+  <div class="chart-card">
+    <h3 class="chart-title">Reviews by Hour of Day</h3>
+    <div class="chart-container">
+      <Bar :data="chartData" :options="chartOptions" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chart-card {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+}
+
+.chart-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-neutral-900);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.chart-container {
+  position: relative;
+  height: 250px;
+}
+</style>

--- a/src/components/stats/IntervalChart.vue
+++ b/src/components/stats/IntervalChart.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Bar } from "vue-chartjs";
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  type ChartData,
+  type ChartOptions,
+} from "chart.js";
+import type { BucketData } from "../../stats/types";
+import type { ChartColors } from "../../composables/useChartTheme";
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip);
+
+const props = defineProps<{ data: BucketData[]; colors: ChartColors }>();
+
+const chartData = computed<ChartData<"bar">>(() => ({
+  labels: props.data.map((b) => b.label),
+  datasets: [
+    {
+      data: props.data.map((b) => b.count),
+      backgroundColor: props.colors.primary,
+      borderRadius: 4,
+    },
+  ],
+}));
+
+const chartOptions = computed<ChartOptions<"bar">>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: { color: props.colors.textSecondary, font: { size: 11 } },
+    },
+    y: {
+      grid: { color: props.colors.gridLine },
+      ticks: { color: props.colors.textSecondary },
+      beginAtZero: true,
+    },
+  },
+}));
+</script>
+
+<template>
+  <div class="chart-card">
+    <h3 class="chart-title">Card Intervals</h3>
+    <div class="chart-container">
+      <Bar :data="chartData" :options="chartOptions" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chart-card {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+}
+
+.chart-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-neutral-900);
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.chart-container {
+  position: relative;
+  height: 250px;
+}
+</style>

--- a/src/components/stats/StatsOverview.vue
+++ b/src/components/stats/StatsOverview.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import type { CardCountsData, TrueRetentionData } from "../../stats/types";
+
+const props = defineProps<{
+  totalReviews: number;
+  streak: number;
+  cardCounts: CardCountsData;
+  trueRetention: TrueRetentionData;
+  totalTimeMs: number;
+}>();
+
+function formatTime(ms: number): string {
+  const hours = Math.floor(ms / 3_600_000);
+  const mins = Math.floor((ms % 3_600_000) / 60_000);
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+</script>
+
+<template>
+  <div class="overview-grid">
+    <div class="stat-card">
+      <div class="stat-value">{{ props.totalReviews.toLocaleString() }}</div>
+      <div class="stat-label">Total Reviews</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">{{ props.streak }}</div>
+      <div class="stat-label">Day Streak</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">
+        {{ props.trueRetention.total > 0 ? (props.trueRetention.retention * 100).toFixed(1) + "%" : "—" }}
+      </div>
+      <div class="stat-label">True Retention</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">{{ formatTime(props.totalTimeMs) }}</div>
+      <div class="stat-label">Study Time</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">{{ props.cardCounts.mature.toLocaleString() }}</div>
+      <div class="stat-label">Mature Cards</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-value">
+        {{
+          (props.cardCounts.new + props.cardCounts.learning + props.cardCounts.young + props.cardCounts.mature).toLocaleString()
+        }}
+      </div>
+      <div class="stat-label">Total Cards</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--spacing-3);
+}
+
+.stat-card {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+  text-align: center;
+}
+
+.stat-value {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-neutral-900);
+  line-height: 1.2;
+}
+
+.stat-label {
+  font-size: var(--font-size-xs);
+  color: var(--color-neutral-500);
+  margin-top: var(--spacing-1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+</style>

--- a/src/components/stats/StatsPeriodSelector.vue
+++ b/src/components/stats/StatsPeriodSelector.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import type { StatsPeriod } from "../../stats/types";
+
+const props = defineProps<{ modelValue: StatsPeriod }>();
+const emit = defineEmits<{ "update:modelValue": [value: StatsPeriod] }>();
+
+const periods: { value: StatsPeriod; label: string }[] = [
+  { value: "1m", label: "1 Month" },
+  { value: "3m", label: "3 Months" },
+  { value: "1y", label: "1 Year" },
+  { value: "all", label: "All Time" },
+];
+</script>
+
+<template>
+  <div class="period-selector">
+    <button
+      v-for="p in periods"
+      :key="p.value"
+      class="period-btn"
+      :class="{ 'period-btn--active': props.modelValue === p.value }"
+      @click="emit('update:modelValue', p.value)"
+    >
+      {{ p.label }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.period-selector {
+  display: flex;
+  gap: var(--spacing-1);
+  background: var(--color-neutral-100);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-0-5);
+}
+
+.period-btn {
+  padding: var(--spacing-1) var(--spacing-3);
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-neutral-600);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.period-btn:hover {
+  color: var(--color-neutral-900);
+}
+
+.period-btn--active {
+  background: var(--color-surface);
+  color: var(--color-neutral-900);
+  font-weight: var(--font-weight-medium);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+</style>

--- a/src/composables/useChartTheme.ts
+++ b/src/composables/useChartTheme.ts
@@ -1,0 +1,69 @@
+import { ref, onMounted, onUnmounted } from "vue";
+
+function getCssVar(name: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+export interface ChartColors {
+  primary: string;
+  success: string;
+  error: string;
+  warning: string;
+  text: string;
+  textSecondary: string;
+  gridLine: string;
+  surface: string;
+  // Answer button colors
+  again: string;
+  hard: string;
+  good: string;
+  easy: string;
+  // Card state colors
+  newCard: string;
+  learning: string;
+  young: string;
+  mature: string;
+}
+
+function readColors(): ChartColors {
+  return {
+    primary: getCssVar("--color-primary-500") || "#8b5cf6",
+    success: getCssVar("--color-success-500") || "#10b981",
+    error: getCssVar("--color-error-500") || "#f43f5e",
+    warning: getCssVar("--color-warning-500") || "#f59e0b",
+    text: getCssVar("--color-neutral-900") || "#18181b",
+    textSecondary: getCssVar("--color-neutral-500") || "#71717a",
+    gridLine: getCssVar("--color-neutral-200") || "#e4e4e7",
+    surface: getCssVar("--color-neutral-50") || "#fafafa",
+    again: getCssVar("--color-error-500") || "#f43f5e",
+    hard: getCssVar("--color-warning-500") || "#f59e0b",
+    good: getCssVar("--color-success-500") || "#10b981",
+    easy: getCssVar("--color-primary-400") || "#a78bfa",
+    newCard: getCssVar("--color-primary-400") || "#a78bfa",
+    learning: getCssVar("--color-warning-400") || "#fbbf24",
+    young: getCssVar("--color-success-400") || "#34d399",
+    mature: getCssVar("--color-success-700") || "#047857",
+  };
+}
+
+export function useChartTheme() {
+  const colors = ref<ChartColors>(readColors());
+  let observer: MutationObserver | null = null;
+
+  onMounted(() => {
+    colors.value = readColors();
+    observer = new MutationObserver(() => {
+      colors.value = readColors();
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+  });
+
+  onUnmounted(() => {
+    observer?.disconnect();
+  });
+
+  return { colors };
+}

--- a/src/scheduler/db.ts
+++ b/src/scheduler/db.ts
@@ -425,6 +425,29 @@ class ReviewDB {
   }
 
   /**
+   * Get all cards across all decks.
+   */
+  async getAllCards(): Promise<CardReviewState[]> {
+    return this.run(["cards"], "readonly", (tx) => tx.objectStore("cards").getAll());
+  }
+
+  /**
+   * Get all review logs within a timestamp range using the "date" index.
+   */
+  async getAllReviewLogsInRange(startMs: number, endMs: number): Promise<StoredReviewLog[]> {
+    return this.run(["reviewLogs"], "readonly", (tx) =>
+      tx.objectStore("reviewLogs").index("date").getAll(IDBKeyRange.bound(startMs, endMs)),
+    );
+  }
+
+  /**
+   * Get all daily stats entries.
+   */
+  async getAllDailyStats(): Promise<DailyStats[]> {
+    return this.run(["dailyStats"], "readonly", (tx) => tx.objectStore("dailyStats").getAll());
+  }
+
+  /**
    * Clear all review data (for testing or reset)
    */
   async clearAll(): Promise<void> {

--- a/src/stats/computeStats.ts
+++ b/src/stats/computeStats.ts
@@ -1,0 +1,204 @@
+import type { StoredReviewLog, DailyStats, Answer } from "../scheduler/types";
+import type {
+  NormalizedCardInfo,
+  BucketData,
+  DayCount,
+  AnswerButtonsData,
+  CardCountsData,
+  TrueRetentionData,
+} from "./types";
+
+const MS_PER_DAY = 86_400_000;
+
+function formatDate(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function normalizeRating(rating: Answer | number): Answer {
+  if (typeof rating === "string") return rating;
+  const map: Record<number, Answer> = { 1: "again", 2: "hard", 3: "good", 4: "easy" };
+  return map[rating] ?? "good";
+}
+
+// --- Card-based stats ---
+
+export function computeCardCounts(cards: NormalizedCardInfo[]): CardCountsData {
+  const counts: CardCountsData = { new: 0, learning: 0, young: 0, mature: 0 };
+  for (const card of cards) {
+    counts[card.phase]++;
+  }
+  return counts;
+}
+
+export function computeIntervalDistribution(cards: NormalizedCardInfo[]): BucketData[] {
+  // Only include cards with meaningful intervals (review/young/mature)
+  const intervals = cards
+    .filter((c) => c.phase !== "new" && c.phase !== "learning")
+    .map((c) => c.interval);
+
+  if (intervals.length === 0) return [];
+
+  // Create logarithmic-ish buckets: 0-1d, 1-3d, 3-7d, 7-14d, 14-30d, 1-3mo, 3-6mo, 6-12mo, 1y+
+  const buckets: [string, number, number][] = [
+    ["< 1d", 0, 1],
+    ["1-3d", 1, 3],
+    ["3-7d", 3, 7],
+    ["1-2w", 7, 14],
+    ["2w-1mo", 14, 30],
+    ["1-3mo", 30, 90],
+    ["3-6mo", 90, 180],
+    ["6-12mo", 180, 365],
+    ["1y+", 365, Infinity],
+  ];
+
+  return buckets.map(([label, min, max]) => ({
+    label,
+    count: intervals.filter((i) => i >= min && i < max).length,
+  }));
+}
+
+export function computeEaseDistribution(cards: NormalizedCardInfo[]): BucketData[] {
+  const eases = cards.filter((c) => c.reps > 0).map((c) => Math.round(c.easeFactor * 100));
+
+  if (eases.length === 0) return [];
+
+  // Buckets from 130% to 350%+ in steps of 20
+  const buckets: BucketData[] = [];
+  for (let start = 130; start <= 340; start += 20) {
+    const end = start + 20;
+    buckets.push({
+      label: `${start}%`,
+      count: eases.filter((e) => e >= start && e < end).length,
+    });
+  }
+  buckets.push({
+    label: "350%+",
+    count: eases.filter((e) => e >= 350).length,
+  });
+  return buckets;
+}
+
+export function computeFutureDue(cards: NormalizedCardInfo[], days: number = 30): DayCount[] {
+  const now = Date.now();
+  const result: DayCount[] = [];
+
+  for (let i = 0; i < days; i++) {
+    const dayStart = now + i * MS_PER_DAY;
+    const dayEnd = dayStart + MS_PER_DAY;
+    const date = formatDate(dayStart);
+    const count = cards.filter((c) => c.due >= dayStart && c.due < dayEnd).length;
+    result.push({ date, count });
+  }
+
+  return result;
+}
+
+export function computeAddedCards(
+  cards: NormalizedCardInfo[],
+  startMs: number,
+  endMs: number,
+): DayCount[] {
+  const days = new Map<string, number>();
+
+  // Initialize all days in range
+  for (let ts = startMs; ts < endMs; ts += MS_PER_DAY) {
+    days.set(formatDate(ts), 0);
+  }
+
+  for (const card of cards) {
+    if (card.createdAt >= startMs && card.createdAt < endMs) {
+      const date = formatDate(card.createdAt);
+      days.set(date, (days.get(date) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(days.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, count]) => ({ date, count }));
+}
+
+// --- Review-log-based stats ---
+
+export function computeCalendarHeatmap(logs: StoredReviewLog[]): DayCount[] {
+  const dayCounts = new Map<string, number>();
+  for (const log of logs) {
+    const date = formatDate(log.timestamp);
+    dayCounts.set(date, (dayCounts.get(date) ?? 0) + 1);
+  }
+
+  return Array.from(dayCounts.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, count]) => ({ date, count }));
+}
+
+export function computeReviewsByHour(logs: StoredReviewLog[]): BucketData[] {
+  const hours = Array.from({ length: 24 }, () => 0);
+  for (const log of logs) {
+    const h = new Date(log.timestamp).getHours();
+    hours[h] = (hours[h] ?? 0) + 1;
+  }
+  return hours.map((count, hour) => ({
+    label: `${hour}:00`,
+    count,
+  }));
+}
+
+export function computeAnswerButtons(logs: StoredReviewLog[]): AnswerButtonsData {
+  const data: AnswerButtonsData = { again: 0, hard: 0, good: 0, easy: 0 };
+  for (const log of logs) {
+    const rating = normalizeRating(log.rating);
+    data[rating]++;
+  }
+  return data;
+}
+
+export function computeTrueRetention(
+  logs: StoredReviewLog[],
+  cards: NormalizedCardInfo[],
+): TrueRetentionData {
+  // True retention: % of reviews on mature cards that were not "again"
+  const matureCardIds = new Set(cards.filter((c) => c.phase === "mature").map((c) => c.cardId));
+
+  let total = 0;
+  let correct = 0;
+
+  for (const log of logs) {
+    if (!matureCardIds.has(log.cardId)) continue;
+    total++;
+    if (normalizeRating(log.rating) !== "again") {
+      correct++;
+    }
+  }
+
+  return {
+    retention: total > 0 ? correct / total : 0,
+    total,
+    correct,
+  };
+}
+
+export function computeStudyStreak(dailyStats: DailyStats[]): number {
+  if (dailyStats.length === 0) return 0;
+
+  const dates = new Set(
+    dailyStats.filter((s) => s.newCount + s.reviewCount > 0).map((s) => s.date),
+  );
+
+  let streak = 0;
+  const now = new Date();
+
+  for (let i = 0; i < 365; i++) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    const dateStr = formatDate(d.getTime());
+    if (dates.has(dateStr)) {
+      streak++;
+    } else if (i > 0) {
+      // Allow today to be missing (not reviewed yet)
+      break;
+    }
+  }
+
+  return streak;
+}

--- a/src/stats/normalizeCard.ts
+++ b/src/stats/normalizeCard.ts
@@ -1,0 +1,51 @@
+import type { CardReviewState } from "../scheduler/types";
+import type { AnkiSM2CardState } from "../scheduler/anki-sm2-algorithm";
+import type { Card } from "ts-fsrs";
+import { State } from "ts-fsrs";
+import type { NormalizedCardInfo, CardPhaseGroup } from "./types";
+
+function getPhaseFromSM2(state: AnkiSM2CardState): CardPhaseGroup {
+  if (state.phase === "new") return "new";
+  if (state.phase === "learning" || state.phase === "relearning") return "learning";
+  return state.interval < 21 ? "young" : "mature";
+}
+
+function getPhaseFromFSRS(card: Card): CardPhaseGroup {
+  if (card.state === State.New) return "new";
+  if (card.state === State.Learning || card.state === State.Relearning) return "learning";
+  return card.scheduled_days < 21 ? "young" : "mature";
+}
+
+export function normalizeCard(card: CardReviewState): NormalizedCardInfo {
+  if (card.algorithm === "sm2") {
+    const sm2 = card.cardState as AnkiSM2CardState;
+    return {
+      cardId: card.cardId,
+      deckId: card.deckId,
+      algorithm: card.algorithm,
+      phase: getPhaseFromSM2(sm2),
+      interval: sm2.interval,
+      easeFactor: sm2.ease,
+      due: sm2.due,
+      lapses: sm2.lapses,
+      reps: sm2.reps,
+      createdAt: card.createdAt,
+    };
+  }
+
+  // FSRS
+  const fsrs = card.cardState as Card;
+  return {
+    cardId: card.cardId,
+    deckId: card.deckId,
+    algorithm: card.algorithm,
+    phase: getPhaseFromFSRS(fsrs),
+    interval: fsrs.scheduled_days,
+    // Map FSRS difficulty (1-10, lower=easier) to ease-like scale
+    easeFactor: (11 - fsrs.difficulty) / 2.5,
+    due: new Date(fsrs.due).getTime(),
+    lapses: fsrs.lapses,
+    reps: fsrs.reps,
+    createdAt: card.createdAt,
+  };
+}

--- a/src/stats/types.ts
+++ b/src/stats/types.ts
@@ -1,0 +1,52 @@
+import type { AlgorithmType } from "../scheduler/types";
+
+export type CardPhaseGroup = "new" | "learning" | "young" | "mature";
+
+export type StatsPeriod = "1m" | "3m" | "1y" | "all";
+
+export interface NormalizedCardInfo {
+  cardId: string;
+  deckId: string;
+  algorithm: AlgorithmType;
+  phase: CardPhaseGroup;
+  /** Current interval in days */
+  interval: number;
+  /** Ease factor (SM-2) or mapped difficulty (FSRS) */
+  easeFactor: number;
+  /** Due timestamp in ms */
+  due: number;
+  lapses: number;
+  reps: number;
+  /** Timestamp when card was first created */
+  createdAt: number;
+}
+
+export interface BucketData {
+  label: string;
+  count: number;
+}
+
+export interface DayCount {
+  date: string;
+  count: number;
+}
+
+export interface AnswerButtonsData {
+  again: number;
+  hard: number;
+  good: number;
+  easy: number;
+}
+
+export interface CardCountsData {
+  new: number;
+  learning: number;
+  young: number;
+  mature: number;
+}
+
+export interface TrueRetentionData {
+  retention: number;
+  total: number;
+  correct: number;
+}

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -48,7 +48,7 @@ function revokeOldMediaUrls() {
 }
 
 // View state
-export type AppView = "review" | "browse" | "create" | "sync" | "duplicates";
+export type AppView = "review" | "browse" | "create" | "sync" | "duplicates" | "stats";
 export const activeViewSig = ref<AppView>("review");
 export const reviewModeSig = ref<"deck-list" | "studying">("deck-list");
 


### PR DESCRIPTION
## Summary

Adds a new "Stats" tab with comprehensive study performance visualization. Closes #123.

- **Overview cards**: total reviews, day streak, true retention, study time, mature & total cards
- **Calendar heatmap**: GitHub-style SVG grid of daily review activity
- **Card states** & **answer buttons**: doughnut charts for card phase breakdown and rating usage
- **Future due**: bar chart forecasting cards due per day (next 30 days)
- **Interval & ease distributions**: histograms of card intervals and ease factors
- **Reviews by hour** & **cards added**: bar charts for study patterns and collection growth
- Period selector (1mo/3mo/1yr/all time) for filtering review-based stats
- Dark/light theme support via CSS variable integration
- Lazy-loaded via defineAsyncComponent to keep initial bundle size unchanged
- Handles both SM-2 and FSRS algorithms through a card normalization layer