### PR TITLE
feat: note type management – create, edit, convert, and delete notetypes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,7 @@ import {
   schedulerSettingsModalOpenSig,
   schedulerSettingsSig,
   flagSettingsModalOpenSig,
+  notetypeManagerOpenSig,
   selectedCardSig,
   selectedDeckIdSig,
   selectedTemplateSig,
@@ -40,6 +41,7 @@ import FindDuplicates from "./components/FindDuplicates.vue";
 import SyncPanel from "./components/SyncPanel.vue";
 import { defineAsyncComponent } from "vue";
 const StatsPanel = defineAsyncComponent(() => import("./components/StatsPanel.vue"));
+const NoteTypeManager = defineAsyncComponent(() => import("./components/NoteTypeManager.vue"));
 import CongratsScreen from "./components/CongratsScreen.vue";
 import SchedulerSettings from "./components/SchedulerSettings.vue";
 import FlagSettings from "./components/FlagSettings.vue";
@@ -486,6 +488,8 @@ onUnmounted(clearAutoAdvanceTimer);
   />
 
   <FlagSettings :is-open="flagSettingsModalOpenSig" @close="flagSettingsModalOpenSig = false" />
+
+  <NoteTypeManager :is-open="notetypeManagerOpenSig" @close="notetypeManagerOpenSig = false" />
 
   <Modal
     :is-open="deckInfoModalOpen"

--- a/src/ankiParser/anki21b/proto/index.ts
+++ b/src/ankiParser/anki21b/proto/index.ts
@@ -53,7 +53,7 @@ type Anki21bNotesTypeConfig = {
   targetDeckIdUnused: number;
 };
 
-function parseNotesTypeConfigProto(proto: Uint8Array): Anki21bNotesTypeConfig {
+export function parseNotesTypeConfigProto(proto: Uint8Array): Anki21bNotesTypeConfig {
   const root = getProtoRoot("notestype", notesTypeProto);
   const NotesTypeConfig = root.lookupType("NotesTypeConfig");
 
@@ -82,7 +82,7 @@ export function parseTemplatesProto(proto: Uint8Array): Anki21bTemplate {
   }) as Anki21bTemplate;
 }
 
-type Anki21bFieldConfig = {
+export type Anki21bFieldConfig = {
   sticky: boolean;
   rtl: boolean;
   fontName: string;
@@ -181,4 +181,65 @@ export function parseDeckConfigProto(proto: Uint8Array): Anki21bDeckConfig {
     longs: Number,
     defaults: true,
   }) as Anki21bDeckConfig;
+}
+
+// --- Protobuf encode functions ---
+
+export function encodeNotesTypeConfig(config: Partial<Anki21bNotesTypeConfig>): Uint8Array {
+  const root = getProtoRoot("notestype", notesTypeProto);
+  const NotesTypeConfig = root.lookupType("NotesTypeConfig");
+  const message = NotesTypeConfig.create({
+    kind: config.kind ?? 0,
+    sortFieldIdx: config.sortFieldIdx ?? 0,
+    css: config.css ?? "",
+    targetDeckIdUnused: config.targetDeckIdUnused ?? 0,
+    latexPre: config.latexPre ?? "",
+    latexPost: config.latexPost ?? "",
+    latexSvg: config.latexSvg ?? false,
+    reqs: config.reqs ?? [],
+    originalStockKind: config.originalStockKind ?? 0,
+    originalId: config.originalId ?? 0,
+    other: new Uint8Array(),
+  });
+  return NotesTypeConfig.encode(message).finish();
+}
+
+export function encodeFieldConfig(config: Partial<Anki21bFieldConfig>): Uint8Array {
+  const root = getProtoRoot("field", fieldConfigProto);
+  const FieldConfig = root.lookupType("FieldConfig");
+  return FieldConfig.encode({
+    sticky: config.sticky ?? false,
+    rtl: config.rtl ?? false,
+    fontName: config.fontName ?? "Arial",
+    fontSize: config.fontSize ?? 20,
+    description: config.description ?? "",
+    plainText: config.plainText ?? false,
+    collapsed: config.collapsed ?? false,
+    excludeFromSearch: config.excludeFromSearch ?? false,
+    preventDeletion: config.preventDeletion ?? false,
+    other: new Uint8Array(),
+  }).finish();
+}
+
+export function encodeTemplateConfig(config: {
+  qFormat: string;
+  aFormat: string;
+  qFormatBrowser?: string;
+  aFormatBrowser?: string;
+  targetDeckId?: number;
+  browserFontName?: string;
+  browserFontSize?: number;
+}): Uint8Array {
+  const root = getProtoRoot("templates", templatesProto);
+  const TemplateConfig = root.lookupType("TemplateConfig");
+  return TemplateConfig.encode({
+    qFormat: config.qFormat,
+    aFormat: config.aFormat,
+    qFormatBrowser: config.qFormatBrowser ?? "",
+    aFormatBrowser: config.aFormatBrowser ?? "",
+    targetDeckId: config.targetDeckId ?? 0,
+    browserFontName: config.browserFontName ?? "",
+    browserFontSize: config.browserFontSize ?? 0,
+    id: 0,
+  }).finish();
 }

--- a/src/components/NoteTypeManager.vue
+++ b/src/components/NoteTypeManager.vue
@@ -1,0 +1,751 @@
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import { Copy, Plus, Trash2 } from "lucide-vue-next";
+import Modal from "~/design-system/components/primitives/Modal.vue";
+import Button from "~/design-system/components/primitives/Button.vue";
+import FieldEditor, { type FieldEntry } from "./notetype/FieldEditor.vue";
+import TemplateEditor, { type TemplateEntry } from "./notetype/TemplateEditor.vue";
+import CssEditor from "./notetype/CssEditor.vue";
+import ConvertNotetypeModal, { type NotetypeInfo } from "./notetype/ConvertNotetypeModal.vue";
+import { createDatabase } from "~/utils/sql";
+import { getActiveSqliteBytes, withDbMutation, ankiDataSig } from "~/stores";
+import {
+  getAllNotetypes,
+  getFieldsForNotetype,
+  getTemplatesForNotetype,
+  getNotetypeUsageCounts,
+  createNotetype,
+  cloneNotetype,
+  renameNotetype,
+  updateNotetypeCss,
+  addField,
+  removeField,
+  renameField,
+  reorderFields,
+  addTemplate,
+  removeTemplate,
+  updateTemplate,
+  deleteNotetype,
+  convertNotes,
+  updateFieldConfig,
+} from "~/lib/notetypeOps";
+import {
+  parseNotesTypeConfigProto,
+  parseFieldConfigProto,
+  parseTemplatesProto,
+} from "~/ankiParser/anki21b/proto";
+import type { Anki21bFieldConfig } from "~/ankiParser/anki21b/proto";
+import { executeQueryAll } from "~/utils/sql";
+
+const props = defineProps<{
+  isOpen: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+type Tab = "fields" | "templates" | "css";
+const activeTab = ref<Tab>("fields");
+const selectedNtid = ref<string | null>(null);
+const searchQuery = ref("");
+const showNewDialog = ref(false);
+const newNotetypeName = ref("");
+const newNotetypeKind = ref(0);
+const convertModalOpen = ref(false);
+const editingName = ref(false);
+const nameInput = ref("");
+
+// Loaded data from SQLite
+interface LoadedNotetype {
+  id: string;
+  name: string;
+  kind: number;
+  css: string;
+  fields: FieldEntry[];
+  templates: TemplateEntry[];
+  noteCount: number;
+}
+
+const notetypes = ref<LoadedNotetype[]>([]);
+
+const filteredNotetypes = computed(() => {
+  const q = searchQuery.value.toLowerCase();
+  if (!q) return notetypes.value;
+  return notetypes.value.filter((nt) => nt.name.toLowerCase().includes(q));
+});
+
+const selectedNotetype = computed(() =>
+  notetypes.value.find((nt) => nt.id === selectedNtid.value) ?? null,
+);
+
+const allNotetypeInfos = computed<NotetypeInfo[]>(() =>
+  notetypes.value.map((nt) => ({
+    id: nt.id,
+    name: nt.name,
+    fields: nt.fields.map((f) => f.name),
+  })),
+);
+
+// Load notetypes from DB when modal opens
+watch(
+  () => props.isOpen,
+  async (open) => {
+    if (open) await loadNotetypes();
+  },
+  { immediate: true },
+);
+
+// Reload when ankiData changes (after mutations)
+watch(ankiDataSig, async () => {
+  if (props.isOpen) {
+    const prevId = selectedNtid.value;
+    await loadNotetypes();
+    // Restore selection if it still exists
+    if (prevId && notetypes.value.find((nt) => nt.id === prevId)) {
+      selectedNtid.value = prevId;
+    }
+  }
+});
+
+async function loadNotetypes() {
+  const bytes = getActiveSqliteBytes();
+  if (!bytes) {
+    notetypes.value = [];
+    return;
+  }
+
+  const db = await createDatabase(bytes);
+  try {
+    const ntRows = getAllNotetypes(db);
+    const usageCounts = getNotetypeUsageCounts(db);
+
+    notetypes.value = ntRows.map((row) => {
+      const config = parseNotesTypeConfigProto(row.config);
+      const fieldRows = getFieldsForNotetype(db, row.id);
+      const tmplRows = getTemplatesForNotetype(db, row.id);
+
+      return {
+        id: row.id,
+        name: row.name,
+        kind: config.kind,
+        css: config.css,
+        fields: fieldRows.map((f) => ({
+          ord: f.ord,
+          name: f.name,
+          config: parseFieldConfigProto(f.config),
+        })),
+        templates: tmplRows.map((t) => {
+          const tc = parseTemplatesProto(t.config);
+          return {
+            ord: t.ord,
+            name: t.name,
+            qfmt: tc.qFormat,
+            afmt: tc.aFormat,
+          };
+        }),
+        noteCount: usageCounts.get(row.id) ?? 0,
+      };
+    });
+
+    // Auto-select first if none selected
+    if (!selectedNtid.value && notetypes.value.length > 0) {
+      selectedNtid.value = notetypes.value[0]!.id;
+    }
+  } finally {
+    db.close();
+  }
+}
+
+// --- Mutation handlers ---
+
+async function handleRename(newName: string) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => renameNotetype(db, ntid, newName));
+}
+
+async function handleUpdateCss(css: string) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => updateNotetypeCss(db, ntid, css));
+}
+
+async function handleAddField(name: string, ord: number) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => addField(db, ntid, name, ord));
+}
+
+async function handleRemoveField(ord: number) {
+  if (!selectedNtid.value) return;
+  const nt = selectedNotetype.value;
+  if (nt && nt.fields.length <= 1) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => removeField(db, ntid, ord));
+}
+
+async function handleRenameField(ord: number, newName: string) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => renameField(db, ntid, ord, newName));
+}
+
+async function handleReorderFields(newOrdering: number[]) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => reorderFields(db, ntid, newOrdering));
+}
+
+async function handleUpdateFieldConfig(ord: number, updates: Partial<Anki21bFieldConfig>) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => updateFieldConfig(db, ntid, ord, updates));
+}
+
+async function handleUpdateTemplate(
+  ord: number,
+  updates: { name?: string; qfmt?: string; afmt?: string },
+) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) =>
+    updateTemplate(db, ntid, ord, {
+      name: updates.name,
+      qfmt: updates.qfmt,
+      afmt: updates.afmt,
+    }),
+  );
+}
+
+async function handleAddTemplate(tmpl: { name: string; qfmt: string; afmt: string }) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => addTemplate(db, ntid, tmpl));
+}
+
+async function handleRemoveTemplate(ord: number) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => removeTemplate(db, ntid, ord));
+}
+
+async function handleCreate() {
+  const name = newNotetypeName.value.trim();
+  if (!name) return;
+
+  let newId: string | null = null;
+  await withDbMutation((db) => {
+    newId = createNotetype(db, {
+      name,
+      kind: newNotetypeKind.value,
+      fields: [{ name: "Front" }, { name: "Back" }],
+      templates: [
+        {
+          name: "Card 1",
+          qfmt: "{{Front}}",
+          afmt: '{{FrontSide}}\n\n<hr id="answer">\n\n{{Back}}',
+        },
+      ],
+    });
+  });
+
+  showNewDialog.value = false;
+  newNotetypeName.value = "";
+  newNotetypeKind.value = 0;
+  if (newId) selectedNtid.value = newId;
+}
+
+async function handleClone() {
+  if (!selectedNtid.value || !selectedNotetype.value) return;
+  const ntid = selectedNtid.value;
+  const cloneName = `${selectedNotetype.value.name} (copy)`;
+  let newId: string | null = null;
+  await withDbMutation((db) => {
+    newId = cloneNotetype(db, ntid, cloneName);
+  });
+  if (newId) selectedNtid.value = newId;
+}
+
+async function handleDelete() {
+  if (!selectedNtid.value || !selectedNotetype.value) return;
+  if (selectedNotetype.value.noteCount > 0) return;
+  if (!confirm(`Delete note type "${selectedNotetype.value.name}"?`)) return;
+
+  const ntid = selectedNtid.value;
+  await withDbMutation((db) => deleteNotetype(db, ntid));
+  selectedNtid.value = notetypes.value[0]?.id ?? null;
+}
+
+async function handleConvert(targetNtid: string, fieldMapping: Record<string, string>) {
+  if (!selectedNtid.value) return;
+  const ntid = selectedNtid.value;
+
+  const bytes = getActiveSqliteBytes();
+  if (!bytes) return;
+
+  // Get note IDs for this notetype
+  const db = await createDatabase(bytes);
+  let noteIds: number[];
+  try {
+    noteIds = executeQueryAll<{ id: number }>(
+      db,
+      "SELECT id FROM notes WHERE mid=?",
+      [Number(ntid)] as unknown as Record<string, string>,
+    ).map((r) => r.id);
+  } finally {
+    db.close();
+  }
+
+  if (noteIds.length === 0) return;
+
+  await withDbMutation((db) => convertNotes(db, noteIds, targetNtid, fieldMapping));
+  convertModalOpen.value = false;
+}
+
+function startRename() {
+  if (!selectedNotetype.value) return;
+  editingName.value = true;
+  nameInput.value = selectedNotetype.value.name;
+}
+
+function commitRename() {
+  const trimmed = nameInput.value.trim();
+  if (trimmed && selectedNotetype.value && trimmed !== selectedNotetype.value.name) {
+    handleRename(trimmed);
+  }
+  editingName.value = false;
+}
+</script>
+
+<template>
+  <Modal :is-open="isOpen" title="Manage Note Types" size="xl" @close="emit('close')">
+    <div class="manager-layout">
+      <!-- Left sidebar -->
+      <div class="sidebar">
+        <input
+          v-model="searchQuery"
+          class="search-input"
+          placeholder="Search note types..."
+        />
+
+        <div class="notetype-list">
+          <button
+            v-for="nt in filteredNotetypes"
+            :key="nt.id"
+            :class="['notetype-item', { 'notetype-item--active': selectedNtid === nt.id }]"
+            @click="selectedNtid = nt.id"
+          >
+            <span class="notetype-name">{{ nt.name }}</span>
+            <span class="notetype-count">{{ nt.noteCount }} notes</span>
+          </button>
+          <div v-if="filteredNotetypes.length === 0" class="empty-list">
+            No note types found
+          </div>
+        </div>
+
+        <div class="sidebar-actions">
+          <Button size="sm" variant="secondary" @click="showNewDialog = true">
+            <template #iconLeft><Plus :size="14" /></template>
+            New
+          </Button>
+          <Button size="sm" variant="secondary" :disabled="!selectedNtid" @click="handleClone">
+            <template #iconLeft><Copy :size="14" /></template>
+            Clone
+          </Button>
+        </div>
+      </div>
+
+      <!-- Right panel -->
+      <div v-if="selectedNotetype" class="detail-panel">
+        <div class="detail-header">
+          <div class="header-left">
+            <template v-if="editingName">
+              <input
+                v-model="nameInput"
+                class="name-edit-input"
+                @keydown.enter="commitRename"
+                @keydown.escape="editingName = false"
+                @blur="commitRename"
+                autofocus
+              />
+            </template>
+            <template v-else>
+              <h3 class="notetype-title" @dblclick="startRename">
+                {{ selectedNotetype.name }}
+              </h3>
+            </template>
+            <span :class="['kind-badge', `kind-badge--${selectedNotetype.kind === 1 ? 'cloze' : 'normal'}`]">
+              {{ selectedNotetype.kind === 1 ? "Cloze" : "Normal" }}
+            </span>
+          </div>
+        </div>
+
+        <div class="tab-bar">
+          <button
+            :class="['detail-tab', { 'detail-tab--active': activeTab === 'fields' }]"
+            @click="activeTab = 'fields'"
+          >
+            Fields ({{ selectedNotetype.fields.length }})
+          </button>
+          <button
+            :class="['detail-tab', { 'detail-tab--active': activeTab === 'templates' }]"
+            @click="activeTab = 'templates'"
+          >
+            Templates ({{ selectedNotetype.templates.length }})
+          </button>
+          <button
+            :class="['detail-tab', { 'detail-tab--active': activeTab === 'css' }]"
+            @click="activeTab = 'css'"
+          >
+            CSS
+          </button>
+        </div>
+
+        <div class="tab-content">
+          <FieldEditor
+            v-if="activeTab === 'fields'"
+            :fields="selectedNotetype.fields"
+            @add-field="handleAddField"
+            @remove-field="handleRemoveField"
+            @rename-field="handleRenameField"
+            @reorder-fields="handleReorderFields"
+            @update-field-config="handleUpdateFieldConfig"
+          />
+          <TemplateEditor
+            v-if="activeTab === 'templates'"
+            :templates="selectedNotetype.templates"
+            :css="selectedNotetype.css"
+            :is-cloze="selectedNotetype.kind === 1"
+            @update-template="handleUpdateTemplate"
+            @add-template="handleAddTemplate"
+            @remove-template="handleRemoveTemplate"
+          />
+          <CssEditor
+            v-if="activeTab === 'css'"
+            :css="selectedNotetype.css"
+            @update-css="handleUpdateCss"
+          />
+        </div>
+
+        <div class="detail-footer">
+          <Button
+            v-if="selectedNotetype.noteCount > 0"
+            size="sm"
+            variant="secondary"
+            @click="convertModalOpen = true"
+          >
+            Convert {{ selectedNotetype.noteCount }} Notes...
+          </Button>
+          <Button
+            size="sm"
+            variant="danger"
+            :disabled="selectedNotetype.noteCount > 0"
+            :title="selectedNotetype.noteCount > 0 ? `Cannot delete: ${selectedNotetype.noteCount} note(s) use this type` : 'Delete note type'"
+            @click="handleDelete"
+          >
+            <template #iconLeft><Trash2 :size="14" /></template>
+            Delete
+          </Button>
+        </div>
+      </div>
+
+      <div v-else class="detail-panel detail-panel--empty">
+        <p v-if="notetypes.length === 0">
+          No note types available. Import a deck or create a new note type to get started.
+        </p>
+        <p v-else>Select a note type from the list.</p>
+      </div>
+    </div>
+
+    <!-- New notetype dialog -->
+    <Modal
+      :is-open="showNewDialog"
+      title="New Note Type"
+      size="sm"
+      @close="showNewDialog = false"
+    >
+      <div class="new-form">
+        <div class="form-group">
+          <label class="form-label">Name</label>
+          <input
+            v-model="newNotetypeName"
+            class="form-input"
+            placeholder="e.g., Basic, Vocabulary..."
+            @keydown.enter="handleCreate"
+          />
+        </div>
+        <div class="form-group">
+          <label class="form-label">Type</label>
+          <select v-model="newNotetypeKind" class="form-select">
+            <option :value="0">Normal</option>
+            <option :value="1">Cloze</option>
+          </select>
+        </div>
+        <p class="form-hint">
+          Creates a note type with Front and Back fields and one card template.
+        </p>
+      </div>
+      <template #footer>
+        <Button variant="ghost" @click="showNewDialog = false">Cancel</Button>
+        <Button :disabled="!newNotetypeName.trim()" @click="handleCreate">Create</Button>
+      </template>
+    </Modal>
+
+    <!-- Convert modal -->
+    <ConvertNotetypeModal
+      v-if="selectedNotetype"
+      :is-open="convertModalOpen"
+      :source-notetype="{
+        id: selectedNotetype.id,
+        name: selectedNotetype.name,
+        fields: selectedNotetype.fields.map((f) => f.name),
+      }"
+      :all-notetypes="allNotetypeInfos"
+      :note-count="selectedNotetype.noteCount"
+      @close="convertModalOpen = false"
+      @convert="handleConvert"
+    />
+  </Modal>
+</template>
+
+<style scoped>
+.manager-layout {
+  display: flex;
+  gap: var(--spacing-4);
+  min-height: 500px;
+  margin: calc(-1 * var(--spacing-8));
+  margin-top: calc(-1 * var(--spacing-4));
+}
+
+/* Sidebar */
+.sidebar {
+  width: 250px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  border-right: 1px solid var(--color-border);
+  padding: var(--spacing-3);
+}
+
+.search-input {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.search-input:focus {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -1px;
+}
+
+.notetype-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.notetype-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: var(--transition-colors);
+  width: 100%;
+  box-shadow: none;
+}
+
+.notetype-item:hover {
+  background: var(--color-surface-hover);
+}
+
+.notetype-item--active {
+  background: var(--color-surface-elevated);
+  outline: 1px solid var(--color-primary-500);
+}
+
+.notetype-name {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  word-break: break-word;
+}
+
+.notetype-count {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+}
+
+.empty-list {
+  padding: var(--spacing-4);
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+}
+
+.sidebar-actions {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+/* Detail panel */
+.detail-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  overflow-y: auto;
+  min-width: 0;
+}
+
+.detail-panel--empty {
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-tertiary);
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.notetype-title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  cursor: default;
+}
+
+.name-edit-input {
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.kind-badge {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+}
+
+.kind-badge--normal {
+  background: var(--color-primary-100, #e0e7ff);
+  color: var(--color-primary-700, #3730a3);
+}
+
+.kind-badge--cloze {
+  background: var(--color-warning-100, #fef3c7);
+  color: var(--color-warning-700, #92400e);
+}
+
+/* Tabs */
+.tab-bar {
+  display: flex;
+  gap: var(--spacing-1);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.detail-tab {
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: var(--transition-colors);
+  box-shadow: none;
+}
+
+.detail-tab:hover {
+  color: var(--color-text-primary);
+}
+
+.detail-tab--active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary-500);
+}
+
+.tab-content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.detail-footer {
+  display: flex;
+  gap: var(--spacing-2);
+  justify-content: flex-end;
+  padding-top: var(--spacing-3);
+  border-top: 1px solid var(--color-border);
+}
+
+/* New notetype form */
+.new-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.form-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.form-input {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.form-select {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.form-hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+}
+</style>

--- a/src/components/notetype/ConvertNotetypeModal.vue
+++ b/src/components/notetype/ConvertNotetypeModal.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import Modal from "~/design-system/components/primitives/Modal.vue";
+import Button from "~/design-system/components/primitives/Button.vue";
+
+export interface NotetypeInfo {
+  id: string;
+  name: string;
+  fields: string[];
+}
+
+const props = defineProps<{
+  isOpen: boolean;
+  sourceNotetype: NotetypeInfo;
+  allNotetypes: NotetypeInfo[];
+  noteCount: number;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  convert: [targetNtid: string, fieldMapping: Record<string, string>];
+}>();
+
+const targetNtid = ref("");
+const fieldMapping = ref<Record<string, string>>({});
+
+const targetNotetype = computed(() =>
+  props.allNotetypes.find((nt) => nt.id === targetNtid.value),
+);
+
+const availableTargets = computed(() =>
+  props.allNotetypes.filter((nt) => nt.id !== props.sourceNotetype.id),
+);
+
+// Reset mapping when target changes
+watch(targetNtid, () => {
+  const target = targetNotetype.value;
+  if (!target) {
+    fieldMapping.value = {};
+    return;
+  }
+  // Auto-map fields with matching names
+  const map: Record<string, string> = {};
+  for (const tf of target.fields) {
+    const match = props.sourceNotetype.fields.find(
+      (sf) => sf.toLowerCase() === tf.toLowerCase(),
+    );
+    if (match) map[tf] = match;
+  }
+  fieldMapping.value = map;
+});
+
+// Reset when opening
+watch(
+  () => props.isOpen,
+  (open) => {
+    if (open) {
+      targetNtid.value = "";
+      fieldMapping.value = {};
+    }
+  },
+);
+
+function handleConvert() {
+  if (!targetNtid.value) return;
+  emit("convert", targetNtid.value, { ...fieldMapping.value });
+}
+</script>
+
+<template>
+  <Modal :is-open="isOpen" title="Convert Note Type" size="md" @close="emit('close')">
+    <div class="convert-form">
+      <p class="convert-info">
+        Convert {{ noteCount }} note(s) from <strong>{{ sourceNotetype.name }}</strong> to another
+        note type. Map each target field to a source field.
+      </p>
+
+      <div class="form-group">
+        <label class="form-label">Target Note Type</label>
+        <select v-model="targetNtid" class="form-select">
+          <option value="" disabled>Select a note type...</option>
+          <option v-for="nt in availableTargets" :key="nt.id" :value="nt.id">
+            {{ nt.name }}
+          </option>
+        </select>
+      </div>
+
+      <div v-if="targetNotetype" class="mapping-section">
+        <label class="form-label">Field Mapping</label>
+        <div class="mapping-list">
+          <div v-for="targetField in targetNotetype.fields" :key="targetField" class="mapping-row">
+            <span class="mapping-target">{{ targetField }}</span>
+            <span class="mapping-arrow">&larr;</span>
+            <select
+              :value="fieldMapping[targetField] ?? ''"
+              class="form-select form-select--sm"
+              @change="fieldMapping[targetField] = ($event.target as HTMLSelectElement).value"
+            >
+              <option value="">(empty)</option>
+              <option
+                v-for="sf in sourceNotetype.fields"
+                :key="sf"
+                :value="sf"
+              >
+                {{ sf }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <Button variant="ghost" @click="emit('close')">Cancel</Button>
+      <Button :disabled="!targetNtid" @click="handleConvert">Convert</Button>
+    </template>
+  </Modal>
+</template>
+
+<style scoped>
+.convert-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.convert-info {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.form-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.form-select {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.form-select--sm {
+  padding: var(--spacing-1) var(--spacing-2);
+  flex: 1;
+}
+
+.mapping-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.mapping-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-elevated);
+}
+
+.mapping-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.mapping-target {
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+  min-width: 120px;
+}
+
+.mapping-arrow {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-lg);
+}
+</style>

--- a/src/components/notetype/CssEditor.vue
+++ b/src/components/notetype/CssEditor.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+defineProps<{
+  css: string;
+}>();
+
+const emit = defineEmits<{
+  updateCss: [css: string];
+}>();
+</script>
+
+<template>
+  <div class="css-editor">
+    <label class="css-label">Card Styling (CSS)</label>
+    <textarea
+      class="css-textarea"
+      :value="css"
+      @input="emit('updateCss', ($event.target as HTMLTextAreaElement).value)"
+      spellcheck="false"
+      placeholder="Enter CSS styles for cards..."
+    />
+  </div>
+</template>
+
+<style scoped>
+.css-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.css-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+}
+
+.css-textarea {
+  min-height: 300px;
+  padding: var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-family-mono, monospace);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  resize: vertical;
+  tab-size: 2;
+}
+
+.css-textarea:focus {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -1px;
+}
+</style>

--- a/src/components/notetype/FieldEditor.vue
+++ b/src/components/notetype/FieldEditor.vue
@@ -1,0 +1,374 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { GripVertical, Plus, Trash2, ChevronDown, ChevronRight } from "lucide-vue-next";
+import Button from "~/design-system/components/primitives/Button.vue";
+import type { Anki21bFieldConfig } from "~/ankiParser/anki21b/proto";
+
+export interface FieldEntry {
+  ord: number;
+  name: string;
+  config: Anki21bFieldConfig;
+}
+
+const props = defineProps<{
+  fields: FieldEntry[];
+}>();
+
+const emit = defineEmits<{
+  addField: [name: string, ord: number];
+  removeField: [ord: number];
+  renameField: [ord: number, newName: string];
+  reorderFields: [newOrdering: number[]];
+  updateFieldConfig: [ord: number, updates: Partial<Anki21bFieldConfig>];
+}>();
+
+const editingField = ref<number | null>(null);
+const editName = ref("");
+const expandedField = ref<number | null>(null);
+const newFieldName = ref("");
+const showAddField = ref(false);
+const dragIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
+
+function startRename(field: FieldEntry) {
+  editingField.value = field.ord;
+  editName.value = field.name;
+}
+
+function commitRename(ord: number) {
+  const trimmed = editName.value.trim();
+  if (trimmed && trimmed !== props.fields.find((f) => f.ord === ord)?.name) {
+    emit("renameField", ord, trimmed);
+  }
+  editingField.value = null;
+}
+
+function handleAdd() {
+  const name = newFieldName.value.trim();
+  if (!name) return;
+  emit("addField", name, props.fields.length);
+  newFieldName.value = "";
+  showAddField.value = false;
+}
+
+function toggleExpand(ord: number) {
+  expandedField.value = expandedField.value === ord ? null : ord;
+}
+
+function handleDragStart(idx: number) {
+  dragIndex.value = idx;
+}
+
+function handleDragOver(e: DragEvent, idx: number) {
+  e.preventDefault();
+  dragOverIndex.value = idx;
+}
+
+function handleDrop(idx: number) {
+  if (dragIndex.value === null || dragIndex.value === idx) {
+    dragIndex.value = null;
+    dragOverIndex.value = null;
+    return;
+  }
+  // Build new ordering
+  const ordering = props.fields.map((_, i) => i);
+  const [moved] = ordering.splice(dragIndex.value, 1);
+  ordering.splice(idx, 0, moved!);
+  emit("reorderFields", ordering);
+  dragIndex.value = null;
+  dragOverIndex.value = null;
+}
+
+function handleDragEnd() {
+  dragIndex.value = null;
+  dragOverIndex.value = null;
+}
+</script>
+
+<template>
+  <div class="field-editor">
+    <div class="field-list">
+      <div
+        v-for="(field, idx) in fields"
+        :key="field.ord"
+        :class="['field-item', { 'field-item--drag-over': dragOverIndex === idx }]"
+        draggable="true"
+        @dragstart="handleDragStart(idx)"
+        @dragover="(e) => handleDragOver(e, idx)"
+        @drop="handleDrop(idx)"
+        @dragend="handleDragEnd"
+      >
+        <div class="field-row">
+          <GripVertical :size="14" class="drag-handle" />
+          <span class="field-ord">{{ idx + 1 }}</span>
+
+          <template v-if="editingField === field.ord">
+            <input
+              v-model="editName"
+              class="field-name-input"
+              @keydown.enter="commitRename(field.ord)"
+              @keydown.escape="editingField = null"
+              @blur="commitRename(field.ord)"
+              autofocus
+            />
+          </template>
+          <template v-else>
+            <span class="field-name" @dblclick="startRename(field)">{{ field.name }}</span>
+          </template>
+
+          <div class="field-actions">
+            <button
+              class="icon-btn"
+              title="Toggle options"
+              @click="toggleExpand(field.ord)"
+            >
+              <ChevronDown v-if="expandedField === field.ord" :size="14" />
+              <ChevronRight v-else :size="14" />
+            </button>
+            <button
+              class="icon-btn icon-btn--danger"
+              title="Remove field"
+              :disabled="fields.length <= 1"
+              @click="emit('removeField', field.ord)"
+            >
+              <Trash2 :size="14" />
+            </button>
+          </div>
+        </div>
+
+        <div v-if="expandedField === field.ord" class="field-options">
+          <label class="option-row">
+            <input
+              type="checkbox"
+              :checked="field.config.rtl"
+              @change="emit('updateFieldConfig', field.ord, { rtl: !field.config.rtl })"
+            />
+            <span>Right-to-left</span>
+          </label>
+          <label class="option-row">
+            <input
+              type="checkbox"
+              :checked="field.config.sticky"
+              @change="emit('updateFieldConfig', field.ord, { sticky: !field.config.sticky })"
+            />
+            <span>Sticky (remember last input)</span>
+          </label>
+          <label class="option-row">
+            <input
+              type="checkbox"
+              :checked="field.config.plainText"
+              @change="emit('updateFieldConfig', field.ord, { plainText: !field.config.plainText })"
+            />
+            <span>Plain text (no HTML)</span>
+          </label>
+          <label class="option-row">
+            <input
+              type="checkbox"
+              :checked="field.config.excludeFromSearch"
+              @change="emit('updateFieldConfig', field.ord, { excludeFromSearch: !field.config.excludeFromSearch })"
+            />
+            <span>Exclude from search</span>
+          </label>
+          <div class="option-row">
+            <label>
+              Description
+              <input
+                type="text"
+                class="desc-input"
+                :value="field.config.description"
+                placeholder="Field description..."
+                @change="emit('updateFieldConfig', field.ord, { description: ($event.target as HTMLInputElement).value })"
+              />
+            </label>
+          </div>
+          <div class="option-row">
+            <label>
+              Font
+              <input
+                type="text"
+                class="desc-input"
+                :value="field.config.fontName"
+                @change="emit('updateFieldConfig', field.ord, { fontName: ($event.target as HTMLInputElement).value })"
+              />
+            </label>
+            <label>
+              Size
+              <input
+                type="number"
+                class="size-input"
+                :value="field.config.fontSize"
+                min="8"
+                max="72"
+                @change="emit('updateFieldConfig', field.ord, { fontSize: Number(($event.target as HTMLInputElement).value) })"
+              />
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="showAddField" class="add-field-form">
+      <input
+        v-model="newFieldName"
+        class="field-name-input"
+        placeholder="Field name..."
+        @keydown.enter="handleAdd"
+        @keydown.escape="showAddField = false"
+        autofocus
+      />
+      <Button size="sm" @click="handleAdd">Add</Button>
+      <Button size="sm" variant="ghost" @click="showAddField = false">Cancel</Button>
+    </div>
+
+    <Button v-else size="sm" variant="secondary" @click="showAddField = true">
+      <template #iconLeft><Plus :size="14" /></template>
+      Add Field
+    </Button>
+  </div>
+</template>
+
+<style scoped>
+.field-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.field-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.field-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  transition: var(--transition-colors);
+}
+
+.field-item--drag-over {
+  border-color: var(--color-primary-500);
+  background: var(--color-surface-elevated);
+}
+
+.field-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+}
+
+.drag-handle {
+  cursor: grab;
+  color: var(--color-text-tertiary);
+  flex-shrink: 0;
+}
+
+.field-ord {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+  min-width: 1.5em;
+  text-align: center;
+}
+
+.field-name {
+  flex: 1;
+  font-weight: var(--font-weight-medium);
+  cursor: default;
+}
+
+.field-name-input {
+  flex: 1;
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.field-actions {
+  display: flex;
+  gap: var(--spacing-1);
+  align-items: center;
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition-colors);
+  padding: 0;
+  box-shadow: none;
+}
+
+.icon-btn:hover:not(:disabled) {
+  background: var(--color-surface-hover);
+  color: var(--color-text-primary);
+}
+
+.icon-btn--danger:hover:not(:disabled) {
+  color: var(--color-error-500);
+}
+
+.icon-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.field-options {
+  padding: var(--spacing-2) var(--spacing-3) var(--spacing-3) var(--spacing-8);
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.option-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.option-row input[type="checkbox"] {
+  accent-color: var(--color-primary-500);
+}
+
+.desc-input {
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  flex: 1;
+  margin-left: var(--spacing-2);
+}
+
+.size-input {
+  width: 60px;
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  margin-left: var(--spacing-2);
+}
+
+.add-field-form {
+  display: flex;
+  gap: var(--spacing-2);
+  align-items: center;
+}
+</style>

--- a/src/components/notetype/TemplateEditor.vue
+++ b/src/components/notetype/TemplateEditor.vue
@@ -1,0 +1,336 @@
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import { Plus, Trash2 } from "lucide-vue-next";
+import Button from "~/design-system/components/primitives/Button.vue";
+
+export interface TemplateEntry {
+  ord: number;
+  name: string;
+  qfmt: string;
+  afmt: string;
+}
+
+const props = defineProps<{
+  templates: TemplateEntry[];
+  css: string;
+  isCloze: boolean;
+}>();
+
+const emit = defineEmits<{
+  updateTemplate: [ord: number, updates: { name?: string; qfmt?: string; afmt?: string }];
+  addTemplate: [template: { name: string; qfmt: string; afmt: string }];
+  removeTemplate: [ord: number];
+}>();
+
+const selectedOrd = ref(0);
+const editSide = ref<"front" | "back">("front");
+
+const selectedTemplate = computed(() =>
+  props.templates.find((t) => t.ord === selectedOrd.value) ?? props.templates[0],
+);
+
+// Reset selection if current template is removed
+watch(
+  () => props.templates,
+  (tmpls) => {
+    if (!tmpls.find((t) => t.ord === selectedOrd.value) && tmpls.length > 0) {
+      selectedOrd.value = tmpls[0]!.ord;
+    }
+  },
+);
+
+const editContent = computed({
+  get: () => {
+    if (!selectedTemplate.value) return "";
+    return editSide.value === "front" ? selectedTemplate.value.qfmt : selectedTemplate.value.afmt;
+  },
+  set: (val: string) => {
+    if (!selectedTemplate.value) return;
+    if (editSide.value === "front") {
+      emit("updateTemplate", selectedTemplate.value.ord, { qfmt: val });
+    } else {
+      emit("updateTemplate", selectedTemplate.value.ord, { afmt: val });
+    }
+  },
+});
+
+const editingName = ref(false);
+const nameInput = ref("");
+
+function startRenameTmpl() {
+  if (!selectedTemplate.value) return;
+  editingName.value = true;
+  nameInput.value = selectedTemplate.value.name;
+}
+
+function commitRenameTmpl() {
+  const trimmed = nameInput.value.trim();
+  if (trimmed && selectedTemplate.value && trimmed !== selectedTemplate.value.name) {
+    emit("updateTemplate", selectedTemplate.value.ord, { name: trimmed });
+  }
+  editingName.value = false;
+}
+
+function handleAddTemplate() {
+  const nextNum = props.templates.length + 1;
+  emit("addTemplate", {
+    name: `Card ${nextNum}`,
+    qfmt: "{{Front}}",
+    afmt: '{{FrontSide}}\n\n<hr id="answer">\n\n{{Back}}',
+  });
+}
+</script>
+
+<template>
+  <div class="template-editor">
+    <div class="template-selector">
+      <div class="template-tabs">
+        <button
+          v-for="tmpl in templates"
+          :key="tmpl.ord"
+          :class="['tmpl-tab', { 'tmpl-tab--active': selectedOrd === tmpl.ord }]"
+          @click="selectedOrd = tmpl.ord"
+          @dblclick="startRenameTmpl"
+        >
+          {{ tmpl.name }}
+        </button>
+        <button
+          v-if="!isCloze"
+          class="tmpl-tab tmpl-tab--add"
+          title="Add template"
+          @click="handleAddTemplate"
+        >
+          <Plus :size="14" />
+        </button>
+      </div>
+
+      <div class="template-actions">
+        <template v-if="editingName">
+          <input
+            v-model="nameInput"
+            class="tmpl-name-input"
+            @keydown.enter="commitRenameTmpl"
+            @keydown.escape="editingName = false"
+            @blur="commitRenameTmpl"
+            autofocus
+          />
+        </template>
+        <button
+          v-if="templates.length > 1 && !isCloze"
+          class="icon-btn icon-btn--danger"
+          title="Delete template"
+          @click="selectedTemplate && emit('removeTemplate', selectedTemplate.ord)"
+        >
+          <Trash2 :size="14" />
+        </button>
+      </div>
+    </div>
+
+    <div class="side-tabs">
+      <button
+        :class="['side-tab', { 'side-tab--active': editSide === 'front' }]"
+        @click="editSide = 'front'"
+      >
+        Front Template
+      </button>
+      <button
+        :class="['side-tab', { 'side-tab--active': editSide === 'back' }]"
+        @click="editSide = 'back'"
+      >
+        Back Template
+      </button>
+    </div>
+
+    <textarea
+      class="template-textarea"
+      :value="editContent"
+      @input="editContent = ($event.target as HTMLTextAreaElement).value"
+      spellcheck="false"
+      placeholder="Enter template HTML..."
+    />
+
+    <div class="template-help">
+      <details>
+        <summary>Template syntax help</summary>
+        <!-- v-pre prevents Vue from parsing mustache-like Anki template syntax -->
+        <div v-pre class="help-content">
+          <p><code>{{FieldName}}</code> — Insert field value</p>
+          <p><code>{{#FieldName}}...{{/FieldName}}</code> — Conditional (show if field is non-empty)</p>
+          <p><code>{{^FieldName}}...{{/FieldName}}</code> — Inverted conditional (show if field is empty)</p>
+          <p><code>{{FrontSide}}</code> — Insert front template content (back template only)</p>
+          <p><code>{{type:FieldName}}</code> — Type-in-the-answer input</p>
+          <p><code>{{cloze:FieldName}}</code> — Cloze deletion</p>
+          <p><code>{{hint:FieldName}}</code> — Hint (click to reveal)</p>
+        </div>
+      </details>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.template-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.template-selector {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.template-tabs {
+  display: flex;
+  gap: var(--spacing-1);
+  align-items: center;
+}
+
+.tmpl-tab {
+  padding: var(--spacing-1) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: var(--transition-colors);
+  box-shadow: none;
+}
+
+.tmpl-tab:hover {
+  background: var(--color-surface-hover);
+}
+
+.tmpl-tab--active {
+  color: var(--color-primary);
+  background: var(--color-surface-elevated);
+  border-color: var(--color-primary-500);
+}
+
+.tmpl-tab--add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-1);
+  width: 28px;
+  height: 28px;
+}
+
+.template-actions {
+  display: flex;
+  gap: var(--spacing-2);
+  align-items: center;
+}
+
+.tmpl-name-input {
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.side-tabs {
+  display: flex;
+  gap: var(--spacing-1);
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: var(--spacing-1);
+}
+
+.side-tab {
+  padding: var(--spacing-1) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: var(--transition-colors);
+  box-shadow: none;
+}
+
+.side-tab:hover {
+  color: var(--color-text-primary);
+}
+
+.side-tab--active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary-500);
+}
+
+.template-textarea {
+  min-height: 200px;
+  padding: var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-family-mono, monospace);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  resize: vertical;
+  tab-size: 2;
+}
+
+.template-textarea:focus {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -1px;
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition-colors);
+  padding: 0;
+  box-shadow: none;
+}
+
+.icon-btn:hover:not(:disabled) {
+  background: var(--color-surface-hover);
+}
+
+.icon-btn--danger:hover:not(:disabled) {
+  color: var(--color-error-500);
+}
+
+.template-help {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.template-help summary {
+  cursor: pointer;
+  user-select: none;
+}
+
+.help-content {
+  padding: var(--spacing-2) var(--spacing-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.help-content p {
+  margin: 0;
+}
+
+.help-content code {
+  font-family: var(--font-family-mono, monospace);
+  font-size: var(--font-size-xs);
+  background: var(--color-surface-elevated);
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+}
+</style>

--- a/src/composables/useCommands.ts
+++ b/src/composables/useCommands.ts
@@ -9,6 +9,7 @@ import {
   toggleSoundEffects,
   schedulerSettingsModalOpenSig,
   flagSettingsModalOpenSig,
+  notetypeManagerOpenSig,
   resetScheduler,
   currentReviewCardSig,
   reviewQueueSig,
@@ -43,6 +44,7 @@ import {
   Undo2,
   Redo2,
   Copy,
+  Layers,
 } from "lucide-vue-next";
 import { useTheme } from "../design-system/hooks/useTheme";
 import { getFlags, getFlagLabel } from "../lib/flags";
@@ -210,6 +212,16 @@ export function useCommands(options: UseCommandsOptions = {}) {
         group: "Tools",
         handler: () => {
           activeViewSig.value = "duplicates";
+        },
+      },
+      {
+        id: "manage-note-types",
+        title: "Manage Note Types",
+        description: "Create, edit, and manage note type definitions",
+        icon: icon(Layers),
+        group: "Tools",
+        handler: () => {
+          notetypeManagerOpenSig.value = true;
         },
       },
       {

--- a/src/lib/notetypeOps.ts
+++ b/src/lib/notetypeOps.ts
@@ -1,0 +1,504 @@
+import { type Database } from "sql.js";
+import { executeQueryAll } from "~/utils/sql";
+import {
+  encodeNotesTypeConfig,
+  encodeFieldConfig,
+  encodeTemplateConfig,
+  parseNotesTypeConfigProto,
+  parseFieldConfigProto,
+  parseTemplatesProto,
+  type Anki21bFieldConfig,
+} from "~/ankiParser/anki21b/proto";
+
+function now(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function generateId(): number {
+  // Anki uses millisecond timestamps with some randomness
+  return Date.now() * 1000 + Math.floor(Math.random() * 1000);
+}
+
+// --- Query helpers ---
+
+export function getNotetypeUsageCounts(db: Database): Map<string, number> {
+  const rows = executeQueryAll<{ mid: string; cnt: number }>(
+    db,
+    "SELECT cast(mid as text) as mid, COUNT(*) as cnt FROM notes GROUP BY mid",
+  );
+  return new Map(rows.map((r) => [r.mid, r.cnt]));
+}
+
+interface NotetypeRow {
+  id: string;
+  name: string;
+  config: Uint8Array;
+}
+
+export function getAllNotetypes(db: Database): NotetypeRow[] {
+  return executeQueryAll<NotetypeRow>(
+    db,
+    "SELECT cast(id as text) as id, name, config FROM notetypes",
+  );
+}
+
+interface FieldRow {
+  ntid: string;
+  ord: number;
+  name: string;
+  config: Uint8Array;
+}
+
+export function getFieldsForNotetype(db: Database, ntid: string): FieldRow[] {
+  return executeQueryAll<FieldRow>(
+    db,
+    "SELECT cast(ntid as text) as ntid, ord, name, config FROM fields WHERE ntid=? ORDER BY ord",
+    [ntid] as unknown as Record<string, string>,
+  ).sort((a, b) => a.ord - b.ord);
+}
+
+interface TemplateRow {
+  ntid: string;
+  ord: number;
+  name: string;
+  config: Uint8Array;
+}
+
+export function getTemplatesForNotetype(db: Database, ntid: string): TemplateRow[] {
+  return executeQueryAll<TemplateRow>(
+    db,
+    "SELECT cast(ntid as text) as ntid, ord, name, config FROM templates WHERE ntid=? ORDER BY ord",
+    [ntid] as unknown as Record<string, string>,
+  ).sort((a, b) => a.ord - b.ord);
+}
+
+// --- Mutations ---
+
+interface CreateNotetypeOptions {
+  name: string;
+  kind?: number; // 0=normal, 1=cloze
+  css?: string;
+  fields: { name: string; config?: Partial<Anki21bFieldConfig> }[];
+  templates: { name: string; qfmt: string; afmt: string }[];
+}
+
+export function createNotetype(db: Database, options: CreateNotetypeOptions): string {
+  const id = generateId();
+  const idStr = String(id);
+  const mtime = now();
+
+  const configBlob = encodeNotesTypeConfig({
+    kind: options.kind ?? 0,
+    css: options.css ?? ".card {\n  font-family: arial;\n  font-size: 20px;\n  text-align: center;\n  color: black;\n  background-color: white;\n}\n",
+  });
+
+  db.run("INSERT INTO notetypes (id, name, mtime_secs, usn, config) VALUES (?, ?, ?, -1, ?)", [
+    id,
+    options.name,
+    mtime,
+    configBlob,
+  ]);
+
+  for (let i = 0; i < options.fields.length; i++) {
+    const field = options.fields[i]!;
+    const fieldConfig = encodeFieldConfig(field.config ?? {});
+    db.run("INSERT INTO fields (ntid, ord, name, config) VALUES (?, ?, ?, ?)", [
+      id,
+      i,
+      field.name,
+      fieldConfig,
+    ]);
+  }
+
+  for (let i = 0; i < options.templates.length; i++) {
+    const tmpl = options.templates[i]!;
+    const tmplConfig = encodeTemplateConfig({
+      qFormat: tmpl.qfmt,
+      aFormat: tmpl.afmt,
+    });
+    db.run(
+      "INSERT INTO templates (ntid, ord, name, mtime_secs, usn, config) VALUES (?, ?, ?, ?, -1, ?)",
+      [id, i, tmpl.name, mtime, tmplConfig],
+    );
+  }
+
+  return idStr;
+}
+
+export function cloneNotetype(db: Database, sourceNtid: string, newName: string): string {
+  const newId = generateId();
+  const mtime = now();
+
+  // Copy notetype row
+  const rows = db.exec("SELECT config FROM notetypes WHERE id=?", [Number(sourceNtid)]);
+  const configBlob = rows[0]?.values[0]?.[0] as Uint8Array;
+  if (!configBlob) throw new Error(`Notetype ${sourceNtid} not found`);
+
+  db.run("INSERT INTO notetypes (id, name, mtime_secs, usn, config) VALUES (?, ?, ?, -1, ?)", [
+    newId,
+    newName,
+    mtime,
+    configBlob,
+  ]);
+
+  // Copy fields
+  const fields = getFieldsForNotetype(db, sourceNtid);
+  for (const field of fields) {
+    db.run("INSERT INTO fields (ntid, ord, name, config) VALUES (?, ?, ?, ?)", [
+      newId,
+      field.ord,
+      field.name,
+      field.config,
+    ]);
+  }
+
+  // Copy templates
+  const templates = getTemplatesForNotetype(db, sourceNtid);
+  for (const tmpl of templates) {
+    db.run(
+      "INSERT INTO templates (ntid, ord, name, mtime_secs, usn, config) VALUES (?, ?, ?, ?, -1, ?)",
+      [newId, tmpl.ord, tmpl.name, mtime, tmpl.config],
+    );
+  }
+
+  return String(newId);
+}
+
+export function renameNotetype(db: Database, ntid: string, newName: string): void {
+  db.run("UPDATE notetypes SET name=?, mtime_secs=?, usn=-1 WHERE id=?", [
+    newName,
+    now(),
+    Number(ntid),
+  ]);
+}
+
+export function updateNotetypeCss(db: Database, ntid: string, css: string): void {
+  const rows = db.exec("SELECT config FROM notetypes WHERE id=?", [Number(ntid)]);
+  const configBlob = rows[0]?.values[0]?.[0] as Uint8Array;
+  if (!configBlob) return;
+
+  const parsed = parseNotesTypeConfigProto(configBlob);
+  const newConfig = encodeNotesTypeConfig({ ...parsed, css });
+  db.run("UPDATE notetypes SET config=?, mtime_secs=?, usn=-1 WHERE id=?", [
+    newConfig,
+    now(),
+    Number(ntid),
+  ]);
+}
+
+export function addField(db: Database, ntid: string, fieldName: string, ord: number): void {
+  const mtime = now();
+  const ntidNum = Number(ntid);
+
+  // Shift existing fields at or after this ordinal
+  db.run("UPDATE fields SET ord = ord + 1 WHERE ntid=? AND ord >= ?", [ntidNum, ord]);
+
+  // Insert new field
+  const fieldConfig = encodeFieldConfig({});
+  db.run("INSERT INTO fields (ntid, ord, name, config) VALUES (?, ?, ?, ?)", [
+    ntidNum,
+    ord,
+    fieldName,
+    fieldConfig,
+  ]);
+
+  // Pad existing notes' flds with empty segment at the right position
+  const notes = executeQueryAll<{ id: number; flds: string }>(
+    db,
+    "SELECT id, flds FROM notes WHERE mid=?",
+    [ntidNum] as unknown as Record<string, string>,
+  );
+
+  for (const note of notes) {
+    const segments = note.flds.split("\x1f");
+    segments.splice(ord, 0, "");
+    db.run("UPDATE notes SET flds=?, mod=?, usn=-1 WHERE id=?", [
+      segments.join("\x1f"),
+      mtime,
+      note.id,
+    ]);
+  }
+
+  db.run("UPDATE notetypes SET mtime_secs=?, usn=-1 WHERE id=?", [mtime, ntidNum]);
+}
+
+export function removeField(db: Database, ntid: string, ord: number): void {
+  const mtime = now();
+  const ntidNum = Number(ntid);
+
+  // Delete the field
+  db.run("DELETE FROM fields WHERE ntid=? AND ord=?", [ntidNum, ord]);
+
+  // Shift subsequent fields down
+  db.run("UPDATE fields SET ord = ord - 1 WHERE ntid=? AND ord > ?", [ntidNum, ord]);
+
+  // Strip the segment from all notes using this notetype
+  const notes = executeQueryAll<{ id: number; flds: string }>(
+    db,
+    "SELECT id, flds FROM notes WHERE mid=?",
+    [ntidNum] as unknown as Record<string, string>,
+  );
+
+  for (const note of notes) {
+    const segments = note.flds.split("\x1f");
+    segments.splice(ord, 1);
+    db.run("UPDATE notes SET flds=?, mod=?, usn=-1 WHERE id=?", [
+      segments.join("\x1f"),
+      mtime,
+      note.id,
+    ]);
+  }
+
+  db.run("UPDATE notetypes SET mtime_secs=?, usn=-1 WHERE id=?", [mtime, ntidNum]);
+}
+
+export function renameField(db: Database, ntid: string, ord: number, newName: string): void {
+  db.run("UPDATE fields SET name=? WHERE ntid=? AND ord=?", [newName, Number(ntid), ord]);
+  db.run("UPDATE notetypes SET mtime_secs=?, usn=-1 WHERE id=?", [now(), Number(ntid)]);
+}
+
+export function reorderFields(db: Database, ntid: string, newOrdering: number[]): void {
+  const mtime = now();
+  const ntidNum = Number(ntid);
+
+  // newOrdering[newOrd] = oldOrd — e.g., [2, 0, 1] means: new position 0 gets old field 2
+  const fields = getFieldsForNotetype(db, ntid);
+
+  // Remap fields to temporary negative ords to avoid unique constraint conflicts
+  for (let newOrd = 0; newOrd < newOrdering.length; newOrd++) {
+    const oldOrd = newOrdering[newOrd]!;
+    db.run("UPDATE fields SET ord=? WHERE ntid=? AND ord=? AND name=?", [
+      -(newOrd + 1),
+      ntidNum,
+      oldOrd,
+      fields[oldOrd]!.name,
+    ]);
+  }
+  // Flip to positive
+  db.run("UPDATE fields SET ord = -(ord + 1) WHERE ntid=? AND ord < 0", [ntidNum]);
+
+  // Rearrange flds segments in all notes
+  const notes = executeQueryAll<{ id: number; flds: string }>(
+    db,
+    "SELECT id, flds FROM notes WHERE mid=?",
+    [ntidNum] as unknown as Record<string, string>,
+  );
+
+  for (const note of notes) {
+    const oldSegments = note.flds.split("\x1f");
+    const newSegments = newOrdering.map((oldOrd) => oldSegments[oldOrd] ?? "");
+    db.run("UPDATE notes SET flds=?, mod=?, usn=-1 WHERE id=?", [
+      newSegments.join("\x1f"),
+      mtime,
+      note.id,
+    ]);
+  }
+
+  db.run("UPDATE notetypes SET mtime_secs=?, usn=-1 WHERE id=?", [mtime, ntidNum]);
+}
+
+export function addTemplate(
+  db: Database,
+  ntid: string,
+  template: { name: string; qfmt: string; afmt: string },
+): void {
+  const mtime = now();
+  const ntidNum = Number(ntid);
+
+  // Determine next ordinal
+  const existing = getTemplatesForNotetype(db, ntid);
+  const ord = existing.length;
+
+  const tmplConfig = encodeTemplateConfig({
+    qFormat: template.qfmt,
+    aFormat: template.afmt,
+  });
+
+  db.run(
+    "INSERT INTO templates (ntid, ord, name, mtime_secs, usn, config) VALUES (?, ?, ?, ?, -1, ?)",
+    [ntidNum, ord, template.name, mtime, tmplConfig],
+  );
+
+  // Generate a card for each existing note of this notetype
+  const notes = executeQueryAll<{ id: number }>(
+    db,
+    "SELECT id FROM notes WHERE mid=?",
+    [ntidNum] as unknown as Record<string, string>,
+  );
+
+  for (const note of notes) {
+    const cardId = generateId();
+    // Get the deck ID from an existing card for this note, or default deck (1)
+    const existingCard = db.exec("SELECT did FROM cards WHERE nid=? LIMIT 1", [note.id]);
+    const did = existingCard[0]?.values[0]?.[0] ?? 1;
+    db.run(
+      "INSERT INTO cards (id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data) VALUES (?, ?, ?, ?, ?, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '')",
+      [cardId, note.id, did, ord, mtime],
+    );
+  }
+
+  db.run("UPDATE notetypes SET mtime_secs=?, usn=-1 WHERE id=?", [mtime, ntidNum]);
+}
+
+export function removeTemplate(db: Database, ntid: string, ord: number): void {
+  const mtime = now();
+  const ntidNum = Number(ntid);
+
+  // Delete template
+  db.run("DELETE FROM templates WHERE ntid=? AND ord=?", [ntidNum, ord]);
+
+  // Shift subsequent templates down
+  db.run("UPDATE templates SET ord = ord - 1 WHERE ntid=? AND ord > ?", [ntidNum, ord]);
+
+  // Delete corresponding cards
+  db.run("DELETE FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid=?) AND ord=?", [
+    ntidNum,
+    ord,
+  ]);
+
+  // Shift card ords down too
+  db.run(
+    "UPDATE cards SET ord = ord - 1 WHERE nid IN (SELECT id FROM notes WHERE mid=?) AND ord > ?",
+    [ntidNum, ord],
+  );
+
+  db.run("UPDATE notetypes SET mtime_secs=?, usn=-1 WHERE id=?", [mtime, ntidNum]);
+}
+
+export function updateTemplate(
+  db: Database,
+  ntid: string,
+  ord: number,
+  updates: { name?: string; qfmt?: string; afmt?: string },
+): void {
+  const mtime = now();
+  const ntidNum = Number(ntid);
+
+  if (updates.name != null) {
+    db.run("UPDATE templates SET name=? WHERE ntid=? AND ord=?", [updates.name, ntidNum, ord]);
+  }
+
+  if (updates.qfmt != null || updates.afmt != null) {
+    const rows = db.exec("SELECT config FROM templates WHERE ntid=? AND ord=?", [ntidNum, ord]);
+    const configBlob = rows[0]?.values[0]?.[0] as Uint8Array | undefined;
+    if (configBlob) {
+      const parsed = parseTemplatesProto(configBlob);
+      const newConfig = encodeTemplateConfig({
+        qFormat: updates.qfmt ?? parsed.qFormat,
+        aFormat: updates.afmt ?? parsed.aFormat,
+        qFormatBrowser: parsed.qFormatBrowser,
+        aFormatBrowser: parsed.aFormatBrowser,
+        targetDeckId: parsed.targetDeckId,
+        browserFontName: parsed.browserFontName,
+        browserFontSize: parsed.browserFontSize,
+      });
+      db.run("UPDATE templates SET config=?, mtime_secs=?, usn=-1 WHERE ntid=? AND ord=?", [
+        newConfig,
+        mtime,
+        ntidNum,
+        ord,
+      ]);
+    }
+  }
+
+  db.run("UPDATE notetypes SET mtime_secs=?, usn=-1 WHERE id=?", [mtime, ntidNum]);
+}
+
+export function deleteNotetype(db: Database, ntid: string): void {
+  const ntidNum = Number(ntid);
+
+  // Check for existing notes
+  const countRows = db.exec("SELECT COUNT(*) as cnt FROM notes WHERE mid=?", [ntidNum]);
+  const count = Number(countRows[0]?.values[0]?.[0] ?? 0);
+  if (count > 0) {
+    throw new Error(`Cannot delete notetype: ${count} note(s) still use it`);
+  }
+
+  db.run("DELETE FROM templates WHERE ntid=?", [ntidNum]);
+  db.run("DELETE FROM fields WHERE ntid=?", [ntidNum]);
+  db.run("DELETE FROM notetypes WHERE id=?", [ntidNum]);
+}
+
+export function convertNotes(
+  db: Database,
+  noteIds: number[],
+  targetNtid: string,
+  fieldMapping: Record<string, string>, // targetFieldName -> sourceFieldName
+): void {
+  if (noteIds.length === 0) return;
+
+  const mtime = now();
+  const targetNtidNum = Number(targetNtid);
+
+  // Get target notetype's fields and templates
+  const targetFields = getFieldsForNotetype(db, targetNtid);
+  const targetTemplates = getTemplatesForNotetype(db, targetNtid);
+
+  // Get source notetype's fields (from the first note)
+  const firstNote = db.exec("SELECT cast(mid as text) as mid FROM notes WHERE id=?", [
+    noteIds[0]!,
+  ]);
+  const sourceMid = String(firstNote[0]?.values[0]?.[0]);
+  const sourceFields = getFieldsForNotetype(db, sourceMid);
+  const sourceFieldNames = sourceFields.map((f) => f.name);
+
+  for (const noteId of noteIds) {
+    // Read current flds
+    const noteRow = db.exec("SELECT flds FROM notes WHERE id=?", [noteId]);
+    const flds = String(noteRow[0]?.values[0]?.[0] ?? "");
+    const sourceSegments = flds.split("\x1f");
+
+    // Build source values map
+    const sourceValues: Record<string, string> = {};
+    for (let i = 0; i < sourceFieldNames.length; i++) {
+      sourceValues[sourceFieldNames[i]!] = sourceSegments[i] ?? "";
+    }
+
+    // Remap to target fields
+    const newSegments = targetFields.map((tf) => {
+      const sourceFieldName = fieldMapping[tf.name];
+      return sourceFieldName ? (sourceValues[sourceFieldName] ?? "") : "";
+    });
+
+    const newFlds = newSegments.join("\x1f");
+    const sfld = (newSegments[0] ?? "").replace(/<[^>]*>/g, "").trim();
+
+    db.run("UPDATE notes SET mid=?, flds=?, sfld=?, mod=?, usn=-1 WHERE id=?", [
+      targetNtidNum,
+      newFlds,
+      sfld,
+      mtime,
+      noteId,
+    ]);
+
+    // Delete existing cards for this note
+    db.run("DELETE FROM cards WHERE nid=?", [noteId]);
+
+    // Create new cards — one per target template
+    for (let i = 0; i < targetTemplates.length; i++) {
+      const cardId = generateId();
+      // Use default deck
+      db.run(
+        "INSERT INTO cards (id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data) VALUES (?, ?, 1, ?, ?, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '')",
+        [cardId, noteId, i, mtime],
+      );
+    }
+  }
+}
+
+export function updateFieldConfig(
+  db: Database,
+  ntid: string,
+  ord: number,
+  updates: Partial<Anki21bFieldConfig>,
+): void {
+  const ntidNum = Number(ntid);
+  const rows = db.exec("SELECT config FROM fields WHERE ntid=? AND ord=?", [ntidNum, ord]);
+  const configBlob = rows[0]?.values[0]?.[0] as Uint8Array | undefined;
+  if (!configBlob) return;
+
+  const parsed = parseFieldConfigProto(configBlob);
+  const newConfig = encodeFieldConfig({ ...parsed, ...updates });
+  db.run("UPDATE fields SET config=? WHERE ntid=? AND ord=?", [newConfig, ntidNum, ord]);
+  db.run("UPDATE notetypes SET mtime_secs=?, usn=-1 WHERE id=?", [now(), ntidNum]);
+}

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -59,6 +59,12 @@ export const selectedDeckIdSig = ref<string | null>(null);
 const ankiCachePromise = caches.open("anki-cache");
 const sampleDeckIds = new Set(sampleDecks.map((deck) => deck.id));
 const activeDeckInputSig = shallowRef<DeckInput | null>(null);
+
+/** Returns the current SQLite deck bytes if available, or null. */
+export function getActiveSqliteBytes(): Uint8Array | null {
+  const input = activeDeckInputSig.value;
+  return input?.kind === "sqlite" ? input.bytes : null;
+}
 export const cachedFilesSig = ref<CachedFileEntry[]>(readCachedFiles());
 export const activeDeckSourceIdSig = ref<string | null>(null);
 
@@ -476,6 +482,7 @@ export const currentReviewCardSig = shallowRef<ReviewCard | null>(null);
 
 export const schedulerSettingsModalOpenSig = ref(false);
 export const flagSettingsModalOpenSig = ref(false);
+export const notetypeManagerOpenSig = ref(false);
 /** The deck ID whose settings are being edited in the modal */
 export const settingsTargetDeckIdSig = ref<string | null>(null);
 /** The deck tree node whose settings are being edited */
@@ -1355,6 +1362,33 @@ export async function updateNote(
 
     // Update in-place without triggering re-parse
     activeDeckInputSig.value = { ...input, bytes: newBytes };
+    markDataChanged();
+  } finally {
+    db.close();
+  }
+}
+
+// --- Notetype Management ---
+
+/**
+ * Open the DB from current deck input, run a mutation callback, then persist and re-parse.
+ * This is the standard pattern for all notetype (and other schema) mutations.
+ */
+export async function withDbMutation(mutate: (db: import("sql.js").Database) => void): Promise<void> {
+  const input = activeDeckInputSig.value;
+  if (input?.kind !== "sqlite") return;
+
+  const db = await createDatabase(input.bytes);
+  try {
+    mutate(db);
+
+    const newBytes = new Uint8Array(db.export());
+    const cache = await caches.open("anki-cache");
+    await cache.put("/sync/collection.sqlite", new Response(new Blob([newBytes as BlobPart])));
+
+    activeDeckInputSig.value = { ...input, bytes: newBytes };
+    const { getAnkiDataFromSqlite } = await import("./ankiParser");
+    ankiDataSig.value = await getAnkiDataFromSqlite(newBytes, input.mediaFiles);
     markDataChanged();
   } finally {
     db.close();


### PR DESCRIPTION
## Summary

Adds full notetype CRUD accessible via "Manage Note Types" in the command palette.

- **Create** new notetypes from scratch or clone existing ones
- **Edit** fields (add, remove, rename, reorder, config toggles)
- **Edit** card templates (front/back HTML) with syntax help
- **Edit** card CSS styling
- **Convert** notes between notetypes with field remapping UI
- **Delete** unused notetypes (blocked when notes exist)

Closes #121