### PR TITLE
feat: database integrity check & repair tool

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,6 +43,7 @@ import { defineAsyncComponent } from "vue";
 const StatsPanel = defineAsyncComponent(() => import("./components/StatsPanel.vue"));
 const NoteTypeManager = defineAsyncComponent(() => import("./components/NoteTypeManager.vue"));
 const BackupPanel = defineAsyncComponent(() => import("./components/BackupPanel.vue"));
+const DatabaseCheckPanel = defineAsyncComponent(() => import("./components/DatabaseCheckPanel.vue"));
 import CongratsScreen from "./components/CongratsScreen.vue";
 import SchedulerSettings from "./components/SchedulerSettings.vue";
 import FlagSettings from "./components/FlagSettings.vue";
@@ -444,6 +445,9 @@ onUnmounted(clearAutoAdvanceTimer);
 
   <!-- BACKUP VIEW -->
   <BackupPanel v-else-if="activeViewSig === 'backup'" />
+
+  <!-- DATABASE CHECK VIEW -->
+  <DatabaseCheckPanel v-else-if="activeViewSig === 'check-db'" />
 
   <!-- REVIEW VIEW: deck list or studying -->
   <FileLibrary v-else-if="reviewModeSig === 'deck-list'" />

--- a/src/components/DatabaseCheckPanel.vue
+++ b/src/components/DatabaseCheckPanel.vue
@@ -1,0 +1,595 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import {
+  ankiDataSig,
+  activeViewSig,
+  getActiveSqliteBytes,
+} from "../stores";
+import { createDatabase } from "../utils/sql";
+import {
+  checkDatabaseIntegrity,
+  applyFix,
+  type IntegrityIssue,
+  type IssueSeverity,
+} from "../utils/integrityCheck";
+import { withDbMutation } from "../stores";
+import Button from "../design-system/components/primitives/Button.vue";
+import Modal from "../design-system/components/primitives/Modal.vue";
+
+const issues = ref<IntegrityIssue[]>([]);
+const hasChecked = ref(false);
+const isChecking = ref(false);
+const expandedIssues = ref(new Set<string>());
+
+// Fix confirmation
+const confirmFix = ref<IntegrityIssue | null>(null);
+const isFixing = ref(false);
+const fixResult = ref<{ type: string; count: number } | null>(null);
+
+const severityOrder: Record<IssueSeverity, number> = { error: 0, warning: 1, info: 2 };
+
+function severityLabel(s: IssueSeverity): string {
+  return s === "error" ? "Error" : s === "warning" ? "Warning" : "Info";
+}
+
+function severityColor(s: IssueSeverity): string {
+  return s === "error"
+    ? "var(--color-danger, #ef4444)"
+    : s === "warning"
+      ? "var(--color-warning, #f59e0b)"
+      : "var(--color-primary)";
+}
+
+function toggleIssue(type: string) {
+  const next = new Set(expandedIssues.value);
+  if (next.has(type)) {
+    next.delete(type);
+  } else {
+    next.add(type);
+  }
+  expandedIssues.value = next;
+}
+
+async function runCheck() {
+  const bytes = getActiveSqliteBytes();
+  if (!bytes) return;
+
+  isChecking.value = true;
+  hasChecked.value = false;
+  fixResult.value = null;
+
+  // Use rAF to let UI update
+  requestAnimationFrame(async () => {
+    try {
+      const db = await createDatabase(bytes);
+      try {
+        const results = checkDatabaseIntegrity(db);
+        results.sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+        issues.value = results;
+      } finally {
+        db.close();
+      }
+    } catch (err) {
+      console.error("Integrity check failed:", err);
+      issues.value = [];
+    }
+
+    hasChecked.value = true;
+    isChecking.value = false;
+
+    // Auto-expand first few
+    const initial = new Set<string>();
+    for (let i = 0; i < Math.min(3, issues.value.length); i++) {
+      initial.add(issues.value[i]!.type);
+    }
+    expandedIssues.value = initial;
+  });
+}
+
+function handleFix(issue: IntegrityIssue) {
+  confirmFix.value = issue;
+}
+
+async function confirmRepair() {
+  const issue = confirmFix.value;
+  if (!issue) return;
+
+  isFixing.value = true;
+
+  try {
+    let fixedCount = 0;
+    await withDbMutation((db) => {
+      fixedCount = applyFix(db, issue.type);
+    });
+
+    fixResult.value = { type: issue.title, count: fixedCount };
+    confirmFix.value = null;
+
+    // Re-run the check to update results
+    await runCheckDirect();
+  } catch (err) {
+    console.error("Repair failed:", err);
+  } finally {
+    isFixing.value = false;
+  }
+}
+
+/** Run check without the rAF delay (used after a fix). */
+async function runCheckDirect() {
+  const bytes = getActiveSqliteBytes();
+  if (!bytes) return;
+
+  try {
+    const db = await createDatabase(bytes);
+    try {
+      const results = checkDatabaseIntegrity(db);
+      results.sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+      issues.value = results;
+    } finally {
+      db.close();
+    }
+  } catch {
+    // keep existing results
+  }
+  hasChecked.value = true;
+}
+
+function goBack() {
+  activeViewSig.value = "browse";
+}
+
+const errorCount = () => issues.value.filter((i) => i.severity === "error").length;
+const warningCount = () => issues.value.filter((i) => i.severity === "warning").length;
+
+// Reset when data changes
+watch(ankiDataSig, () => {
+  issues.value = [];
+  hasChecked.value = false;
+  fixResult.value = null;
+});
+</script>
+
+<template>
+  <main class="db-check">
+    <div class="db-check__container">
+      <div class="db-check__header">
+        <div class="db-check__title-row">
+          <button class="db-check__back-btn" @click="goBack" title="Back to Browse">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+          </button>
+          <h1 class="db-check__title">Database Check</h1>
+        </div>
+        <p class="db-check__subtitle">
+          Verify collection integrity and repair common issues.
+        </p>
+      </div>
+
+      <!-- Action bar -->
+      <div class="db-check__actions">
+        <Button
+          variant="primary"
+          size="md"
+          :loading="isChecking"
+          :disabled="!ankiDataSig || !getActiveSqliteBytes()"
+          @click="runCheck"
+        >
+          {{ hasChecked ? 'Re-run Check' : 'Check Database' }}
+        </Button>
+
+        <div v-if="fixResult" class="db-check__fix-toast">
+          Fixed {{ fixResult.count }} item{{ fixResult.count !== 1 ? 's' : '' }}
+          ({{ fixResult.type }})
+        </div>
+      </div>
+
+      <!-- Results -->
+      <div v-if="hasChecked" class="db-check__results">
+        <!-- Summary -->
+        <div v-if="issues.length === 0" class="db-check__pass">
+          <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
+          <p>No issues found. Your collection looks healthy!</p>
+        </div>
+
+        <template v-else>
+          <div class="db-check__summary">
+            <span v-if="errorCount() > 0" class="db-check__summary-badge db-check__summary-badge--error">
+              {{ errorCount() }} error{{ errorCount() !== 1 ? 's' : '' }}
+            </span>
+            <span v-if="warningCount() > 0" class="db-check__summary-badge db-check__summary-badge--warning">
+              {{ warningCount() }} warning{{ warningCount() !== 1 ? 's' : '' }}
+            </span>
+            <span class="db-check__summary-total">
+              {{ issues.length }} issue{{ issues.length !== 1 ? 's' : '' }} found
+            </span>
+          </div>
+
+          <!-- Issue groups -->
+          <div
+            v-for="issue in issues"
+            :key="issue.type"
+            class="db-check__issue"
+          >
+            <button
+              class="db-check__issue-header"
+              @click="toggleIssue(issue.type)"
+            >
+              <svg
+                :class="['db-check__chevron', { 'db-check__chevron--open': expandedIssues.has(issue.type) }]"
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="m9 18 6-6-6-6"/>
+              </svg>
+
+              <span
+                class="db-check__severity-dot"
+                :style="{ background: severityColor(issue.severity) }"
+                :title="severityLabel(issue.severity)"
+              />
+
+              <span class="db-check__issue-title">{{ issue.title }}</span>
+
+              <span class="db-check__issue-count">
+                {{ issue.count }} item{{ issue.count !== 1 ? 's' : '' }}
+              </span>
+
+              <span class="db-check__severity-tag" :data-severity="issue.severity">
+                {{ severityLabel(issue.severity) }}
+              </span>
+            </button>
+
+            <div
+              v-if="expandedIssues.has(issue.type)"
+              class="db-check__issue-body"
+            >
+              <p class="db-check__issue-desc">{{ issue.description }}</p>
+
+              <ul class="db-check__details">
+                <li v-for="(detail, idx) in issue.details" :key="idx">
+                  {{ detail }}
+                </li>
+                <li v-if="issue.count > issue.details.length" class="db-check__details-more">
+                  ...and {{ issue.count - issue.details.length }} more
+                </li>
+              </ul>
+
+              <div v-if="issue.fixable" class="db-check__issue-fix">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  @click.stop="handleFix(issue)"
+                >
+                  Fix {{ issue.title }}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- No deck loaded -->
+      <div v-else-if="!ankiDataSig || !getActiveSqliteBytes()" class="db-check__empty">
+        <p>No synced collection loaded. Import or sync a collection first.</p>
+      </div>
+    </div>
+
+    <!-- Fix confirmation modal -->
+    <Modal
+      :is-open="!!confirmFix"
+      :title="`Fix: ${confirmFix?.title ?? ''}`"
+      size="sm"
+      @close="confirmFix = null"
+    >
+      <div v-if="confirmFix" class="db-check__confirm">
+        <p>{{ confirmFix.description }}</p>
+        <p>
+          This will automatically fix <strong>{{ confirmFix.count }}</strong>
+          item{{ confirmFix.count !== 1 ? 's' : '' }}. This cannot be undone.
+        </p>
+      </div>
+      <template #footer>
+        <Button variant="secondary" size="sm" @click="confirmFix = null">Cancel</Button>
+        <Button variant="primary" size="sm" :loading="isFixing" @click="confirmRepair">
+          Apply Fix
+        </Button>
+      </template>
+    </Modal>
+  </main>
+</template>
+
+<style scoped>
+.db-check {
+  min-height: calc(100vh - 44px);
+  padding: var(--spacing-6) var(--spacing-4);
+}
+
+.db-check__container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.db-check__header {
+  margin-bottom: var(--spacing-6);
+}
+
+.db-check__title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.db-check__back-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-1);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition-colors);
+  box-shadow: none;
+}
+
+.db-check__back-btn:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover);
+}
+
+.db-check__back-btn:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+  box-shadow: var(--shadow-focus-ring);
+}
+
+.db-check__title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.db-check__subtitle {
+  margin: var(--spacing-1) 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+/* Actions */
+.db-check__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+}
+
+.db-check__fix-toast {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-success, #22c55e);
+}
+
+/* Results */
+.db-check__results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.db-check__pass {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-8);
+  color: var(--color-success, #22c55e);
+  text-align: center;
+}
+
+.db-check__pass p {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.db-check__summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-2);
+}
+
+.db-check__summary-badge {
+  padding: var(--spacing-0-5) var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  border-radius: var(--radius-full);
+}
+
+.db-check__summary-badge--error {
+  color: var(--color-danger, #ef4444);
+  background: color-mix(in srgb, var(--color-danger, #ef4444) 12%, transparent);
+}
+
+.db-check__summary-badge--warning {
+  color: var(--color-warning, #f59e0b);
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 12%, transparent);
+}
+
+.db-check__summary-total {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+}
+
+.db-check__empty {
+  text-align: center;
+  padding: var(--spacing-8);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+/* Issue cards */
+.db-check__issue {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.db-check__issue-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  width: 100%;
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-surface-elevated);
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  transition: var(--transition-colors);
+  box-shadow: none;
+}
+
+.db-check__issue-header:hover {
+  background: var(--color-surface-hover);
+}
+
+.db-check__issue-header:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -2px;
+  box-shadow: var(--shadow-focus-ring);
+}
+
+.db-check__chevron {
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+  color: var(--color-text-tertiary);
+}
+
+.db-check__chevron--open {
+  transform: rotate(90deg);
+}
+
+.db-check__severity-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+}
+
+.db-check__issue-title {
+  flex: 1;
+  min-width: 0;
+  font-weight: var(--font-weight-medium);
+}
+
+.db-check__issue-count {
+  flex-shrink: 0;
+  padding: var(--spacing-0-5) var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  background: var(--color-surface);
+  border-radius: var(--radius-full);
+}
+
+.db-check__severity-tag {
+  flex-shrink: 0;
+  padding: var(--spacing-0-5) var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  border-radius: var(--radius-full);
+}
+
+.db-check__severity-tag[data-severity="error"] {
+  color: var(--color-danger, #ef4444);
+  background: color-mix(in srgb, var(--color-danger, #ef4444) 12%, transparent);
+}
+
+.db-check__severity-tag[data-severity="warning"] {
+  color: var(--color-warning, #f59e0b);
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 12%, transparent);
+}
+
+.db-check__severity-tag[data-severity="info"] {
+  color: var(--color-primary);
+  background: var(--color-primary-50);
+}
+
+/* Issue body */
+.db-check__issue-body {
+  border-top: 1px solid var(--color-border);
+  padding: var(--spacing-4);
+}
+
+.db-check__issue-desc {
+  margin: 0 0 var(--spacing-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+}
+
+.db-check__details {
+  margin: 0 0 var(--spacing-3);
+  padding: var(--spacing-3);
+  list-style: none;
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-family-mono);
+  color: var(--color-text-secondary);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.db-check__details li {
+  padding: var(--spacing-0-5) 0;
+}
+
+.db-check__details li + li {
+  border-top: 1px solid var(--color-border);
+}
+
+.db-check__details-more {
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}
+
+.db-check__issue-fix {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Confirm modal */
+.db-check__confirm p {
+  margin: 0 0 var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  line-height: var(--line-height-relaxed);
+}
+
+.db-check__confirm p:last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 600px) {
+  .db-check__issue-header {
+    flex-wrap: wrap;
+  }
+
+  .db-check__severity-tag {
+    order: -1;
+    margin-left: auto;
+  }
+}
+</style>

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -43,7 +43,7 @@ async function handleRedo() {
       <button
         v-for="tab in tabs"
         :key="tab.id"
-        :class="['tab', { 'tab--active': activeViewSig === tab.id || (tab.id === 'browse' && activeViewSig === 'duplicates') }]"
+        :class="['tab', { 'tab--active': activeViewSig === tab.id || (tab.id === 'browse' && (activeViewSig === 'duplicates' || activeViewSig === 'check-db')) }]"
         @click="handleTabClick(tab.id)"
       >
         {{ tab.label }}

--- a/src/composables/useCommands.ts
+++ b/src/composables/useCommands.ts
@@ -45,6 +45,7 @@ import {
   Redo2,
   Copy,
   Layers,
+  ShieldCheck,
 } from "lucide-vue-next";
 import { useTheme } from "../design-system/hooks/useTheme";
 import { getFlags, getFlagLabel } from "../lib/flags";
@@ -222,6 +223,16 @@ export function useCommands(options: UseCommandsOptions = {}) {
         group: "Tools",
         handler: () => {
           notetypeManagerOpenSig.value = true;
+        },
+      },
+      {
+        id: "check-database",
+        title: "Check Database",
+        description: "Verify collection integrity and repair common issues",
+        icon: icon(ShieldCheck),
+        group: "Tools",
+        handler: () => {
+          activeViewSig.value = "check-db";
         },
       },
       {

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -48,7 +48,7 @@ function revokeOldMediaUrls() {
 }
 
 // View state
-export type AppView = "review" | "browse" | "create" | "sync" | "duplicates" | "stats" | "backup";
+export type AppView = "review" | "browse" | "create" | "sync" | "duplicates" | "stats" | "backup" | "check-db";
 export const activeViewSig = ref<AppView>("review");
 export const reviewModeSig = ref<"deck-list" | "studying">("deck-list");
 

--- a/src/utils/integrityCheck.ts
+++ b/src/utils/integrityCheck.ts
@@ -1,0 +1,413 @@
+import { type Database } from "sql.js";
+import { executeQueryAll } from "./sql";
+
+export type IssueSeverity = "error" | "warning" | "info";
+
+export type IssueType =
+  | "orphaned-cards"
+  | "orphaned-notes"
+  | "missing-notetype"
+  | "missing-deck"
+  | "field-count-mismatch"
+  | "invalid-scheduling"
+  | "duplicate-note-ids"
+  | "duplicate-card-ids"
+  | "duplicate-guids";
+
+export type IntegrityIssue = {
+  type: IssueType;
+  severity: IssueSeverity;
+  title: string;
+  description: string;
+  count: number;
+  details: string[];
+  fixable: boolean;
+};
+
+type NoteRow = { id: number; mid: number; flds: string; guid: string };
+type CardRow = { id: number; nid: number; did: number; type: number; queue: number; due: number; ivl: number; odid: number };
+
+function tableExists(db: Database, name: string): boolean {
+  const rows = executeQueryAll<{ name: string }>(
+    db,
+    `SELECT name FROM sqlite_master WHERE type='table' AND name='${name}'`,
+  );
+  return rows.length > 0;
+}
+
+/**
+ * Detect the database format and return appropriate table info.
+ */
+function isAnki21b(db: Database): boolean {
+  return tableExists(db, "notetypes");
+}
+
+/**
+ * Get all notetype IDs and their field counts from the database.
+ */
+function getNotetypeFieldCounts(db: Database): Map<number, number> {
+  const result = new Map<number, number>();
+
+  if (isAnki21b(db)) {
+    // anki21b: fields table with ntid
+    const rows = executeQueryAll<{ ntid: number; cnt: number }>(
+      db,
+      "SELECT ntid, COUNT(*) as cnt FROM fields GROUP BY ntid",
+    );
+    for (const row of rows) {
+      result.set(row.ntid, row.cnt);
+    }
+  } else {
+    // anki2: models stored as JSON in col table
+    try {
+      const col = executeQueryAll<{ models: string }>(db, "SELECT models FROM col");
+      if (col.length > 0 && col[0]!.models) {
+        const models = JSON.parse(col[0]!.models) as Record<string, { flds: unknown[] }>;
+        for (const [id, model] of Object.entries(models)) {
+          result.set(Number(id), model.flds?.length ?? 0);
+        }
+      }
+    } catch {
+      // If parsing fails, return empty
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get all valid deck IDs from the database.
+ */
+function getDeckIds(db: Database): Set<number> {
+  if (isAnki21b(db)) {
+    const rows = executeQueryAll<{ id: number }>(db, "SELECT id FROM decks");
+    return new Set(rows.map((r) => r.id));
+  } else {
+    try {
+      const col = executeQueryAll<{ decks: string }>(db, "SELECT decks FROM col");
+      if (col.length > 0 && col[0]!.decks) {
+        const decks = JSON.parse(col[0]!.decks) as Record<string, unknown>;
+        return new Set(Object.keys(decks).map(Number));
+      }
+    } catch {
+      // fallthrough
+    }
+    return new Set();
+  }
+}
+
+/**
+ * Get all valid notetype IDs from the database.
+ */
+function getNotetypeIds(db: Database): Set<number> {
+  if (isAnki21b(db)) {
+    const rows = executeQueryAll<{ id: number }>(db, "SELECT id FROM notetypes");
+    return new Set(rows.map((r) => r.id));
+  } else {
+    try {
+      const col = executeQueryAll<{ models: string }>(db, "SELECT models FROM col");
+      if (col.length > 0 && col[0]!.models) {
+        const models = JSON.parse(col[0]!.models) as Record<string, unknown>;
+        return new Set(Object.keys(models).map(Number));
+      }
+    } catch {
+      // fallthrough
+    }
+    return new Set();
+  }
+}
+
+/**
+ * Run all integrity checks against the database and return issues found.
+ */
+export function checkDatabaseIntegrity(db: Database): IntegrityIssue[] {
+  const issues: IntegrityIssue[] = [];
+
+  const notes = executeQueryAll<NoteRow>(db, "SELECT id, mid, flds, guid FROM notes");
+  const cards = executeQueryAll<CardRow>(
+    db,
+    "SELECT id, nid, did, type, queue, due, ivl, odid FROM cards",
+  );
+
+  const noteIdSet = new Set(notes.map((n) => n.id));
+  const cardNoteIds = new Set(cards.map((c) => c.nid));
+  const deckIds = getDeckIds(db);
+  const notetypeIds = getNotetypeIds(db);
+  const notetypeFieldCounts = getNotetypeFieldCounts(db);
+
+  // 1. Orphaned cards (cards whose note doesn't exist)
+  const orphanedCards = cards.filter((c) => !noteIdSet.has(c.nid));
+  if (orphanedCards.length > 0) {
+    issues.push({
+      type: "orphaned-cards",
+      severity: "error",
+      title: "Orphaned Cards",
+      description: "Cards that reference notes which no longer exist. These cards cannot be studied.",
+      count: orphanedCards.length,
+      details: orphanedCards.slice(0, 20).map((c) => `Card ${c.id} → missing note ${c.nid}`),
+      fixable: true,
+    });
+  }
+
+  // 2. Orphaned notes (notes with no cards)
+  const orphanedNotes = notes.filter((n) => !cardNoteIds.has(n.id));
+  if (orphanedNotes.length > 0) {
+    issues.push({
+      type: "orphaned-notes",
+      severity: "warning",
+      title: "Notes Without Cards",
+      description: "Notes that have no associated cards. They take up space but cannot be studied.",
+      count: orphanedNotes.length,
+      details: orphanedNotes.slice(0, 20).map((n) => `Note ${n.id} (guid: ${n.guid})`),
+      fixable: true,
+    });
+  }
+
+  // 3. Missing notetypes
+  const missingNotetypes = new Map<number, number>();
+  for (const note of notes) {
+    if (!notetypeIds.has(note.mid)) {
+      missingNotetypes.set(note.mid, (missingNotetypes.get(note.mid) ?? 0) + 1);
+    }
+  }
+  if (missingNotetypes.size > 0) {
+    const total = Array.from(missingNotetypes.values()).reduce((a, b) => a + b, 0);
+    issues.push({
+      type: "missing-notetype",
+      severity: "error",
+      title: "Missing Note Types",
+      description: "Notes reference note types that don't exist in the database.",
+      count: total,
+      details: Array.from(missingNotetypes.entries()).map(
+        ([mid, cnt]) => `Notetype ${mid}: ${cnt} note${cnt !== 1 ? "s" : ""} affected`,
+      ),
+      fixable: false,
+    });
+  }
+
+  // 4. Missing decks
+  const missingDecks = new Map<number, number>();
+  for (const card of cards) {
+    const effectiveDid = card.odid !== 0 ? card.odid : card.did;
+    if (!deckIds.has(effectiveDid)) {
+      missingDecks.set(effectiveDid, (missingDecks.get(effectiveDid) ?? 0) + 1);
+    }
+  }
+  if (missingDecks.size > 0) {
+    const total = Array.from(missingDecks.values()).reduce((a, b) => a + b, 0);
+    issues.push({
+      type: "missing-deck",
+      severity: "error",
+      title: "Missing Decks",
+      description: "Cards reference decks that don't exist in the database.",
+      count: total,
+      details: Array.from(missingDecks.entries()).map(
+        ([did, cnt]) => `Deck ${did}: ${cnt} card${cnt !== 1 ? "s" : ""} affected`,
+      ),
+      fixable: true,
+    });
+  }
+
+  // 5. Field count mismatches
+  const fieldMismatches: { noteId: number; expected: number; actual: number }[] = [];
+  for (const note of notes) {
+    const expectedCount = notetypeFieldCounts.get(note.mid);
+    if (expectedCount === undefined) continue; // already caught by missing notetype check
+    const actualCount = note.flds.split("\x1f").length;
+    if (actualCount !== expectedCount) {
+      fieldMismatches.push({ noteId: note.id, expected: expectedCount, actual: actualCount });
+    }
+  }
+  if (fieldMismatches.length > 0) {
+    issues.push({
+      type: "field-count-mismatch",
+      severity: "warning",
+      title: "Field Count Mismatches",
+      description: "Notes whose field count doesn't match their note type definition.",
+      count: fieldMismatches.length,
+      details: fieldMismatches.slice(0, 20).map(
+        (m) => `Note ${m.noteId}: expected ${m.expected} fields, has ${m.actual}`,
+      ),
+      fixable: false,
+    });
+  }
+
+  // 6. Invalid scheduling data
+  const invalidScheduling: { cardId: number; reason: string }[] = [];
+  for (const card of cards) {
+    if (card.ivl < 0 && card.type === 2) {
+      invalidScheduling.push({ cardId: card.id, reason: "negative interval on review card" });
+    }
+    if (card.type < 0 || card.type > 3) {
+      invalidScheduling.push({ cardId: card.id, reason: `invalid type ${card.type}` });
+    }
+    if (card.queue < -3 || card.queue > 4) {
+      invalidScheduling.push({ cardId: card.id, reason: `invalid queue ${card.queue}` });
+    }
+  }
+  if (invalidScheduling.length > 0) {
+    issues.push({
+      type: "invalid-scheduling",
+      severity: "warning",
+      title: "Invalid Scheduling Data",
+      description: "Cards with impossible scheduling values (negative intervals, invalid types/queues).",
+      count: invalidScheduling.length,
+      details: invalidScheduling.slice(0, 20).map(
+        (s) => `Card ${s.cardId}: ${s.reason}`,
+      ),
+      fixable: true,
+    });
+  }
+
+  // 7. Duplicate note IDs
+  const noteIdCounts = new Map<number, number>();
+  for (const note of notes) {
+    noteIdCounts.set(note.id, (noteIdCounts.get(note.id) ?? 0) + 1);
+  }
+  const dupNoteIds = Array.from(noteIdCounts.entries()).filter(([, cnt]) => cnt > 1);
+  if (dupNoteIds.length > 0) {
+    issues.push({
+      type: "duplicate-note-ids",
+      severity: "error",
+      title: "Duplicate Note IDs",
+      description: "Multiple notes share the same ID, which can cause data corruption.",
+      count: dupNoteIds.reduce((a, [, cnt]) => a + cnt, 0),
+      details: dupNoteIds.map(([id, cnt]) => `Note ID ${id}: ${cnt} occurrences`),
+      fixable: false,
+    });
+  }
+
+  // 8. Duplicate card IDs
+  const cardIdCounts = new Map<number, number>();
+  for (const card of cards) {
+    cardIdCounts.set(card.id, (cardIdCounts.get(card.id) ?? 0) + 1);
+  }
+  const dupCardIds = Array.from(cardIdCounts.entries()).filter(([, cnt]) => cnt > 1);
+  if (dupCardIds.length > 0) {
+    issues.push({
+      type: "duplicate-card-ids",
+      severity: "error",
+      title: "Duplicate Card IDs",
+      description: "Multiple cards share the same ID, which can cause data corruption.",
+      count: dupCardIds.reduce((a, [, cnt]) => a + cnt, 0),
+      details: dupCardIds.map(([id, cnt]) => `Card ID ${id}: ${cnt} occurrences`),
+      fixable: false,
+    });
+  }
+
+  // 9. Duplicate GUIDs
+  const guidCounts = new Map<string, number>();
+  for (const note of notes) {
+    guidCounts.set(note.guid, (guidCounts.get(note.guid) ?? 0) + 1);
+  }
+  const dupGuids = Array.from(guidCounts.entries()).filter(([, cnt]) => cnt > 1);
+  if (dupGuids.length > 0) {
+    issues.push({
+      type: "duplicate-guids",
+      severity: "warning",
+      title: "Duplicate Note GUIDs",
+      description: "Multiple notes share the same GUID. This can cause sync conflicts.",
+      count: dupGuids.reduce((a, [, cnt]) => a + cnt, 0),
+      details: dupGuids.slice(0, 20).map(([guid, cnt]) => `GUID "${guid}": ${cnt} occurrences`),
+      fixable: false,
+    });
+  }
+
+  return issues;
+}
+
+/**
+ * Fix orphaned cards by deleting cards whose notes don't exist.
+ */
+function fixOrphanedCards(db: Database): number {
+  const notes = executeQueryAll<{ id: number }>(db, "SELECT id FROM notes");
+  const noteIdSet = new Set(notes.map((n) => n.id));
+  const cards = executeQueryAll<{ id: number; nid: number }>(db, "SELECT id, nid FROM cards");
+  const orphanedIds = cards.filter((c) => !noteIdSet.has(c.nid)).map((c) => c.id);
+
+  if (orphanedIds.length === 0) return 0;
+  db.run(`DELETE FROM cards WHERE id IN (${orphanedIds.join(",")})`);
+  return orphanedIds.length;
+}
+
+/**
+ * Fix orphaned notes by deleting notes that have no cards.
+ */
+function fixOrphanedNotes(db: Database): number {
+  const notes = executeQueryAll<{ id: number }>(db, "SELECT id FROM notes");
+  const cards = executeQueryAll<{ nid: number }>(db, "SELECT DISTINCT nid FROM cards");
+  const cardNoteIds = new Set(cards.map((c) => c.nid));
+  const orphanedIds = notes.filter((n) => !cardNoteIds.has(n.id)).map((n) => n.id);
+
+  if (orphanedIds.length === 0) return 0;
+  db.run(`DELETE FROM notes WHERE id IN (${orphanedIds.join(",")})`);
+  return orphanedIds.length;
+}
+
+/**
+ * Fix cards referencing missing decks by moving them to the default deck (id=1).
+ */
+function fixMissingDecks(db: Database): number {
+  const deckIds = getDeckIds(db);
+  const cards = executeQueryAll<CardRow>(
+    db,
+    "SELECT id, nid, did, type, queue, due, ivl, odid FROM cards",
+  );
+
+  let fixed = 0;
+  for (const card of cards) {
+    const effectiveDid = card.odid !== 0 ? card.odid : card.did;
+    if (!deckIds.has(effectiveDid)) {
+      if (card.odid !== 0) {
+        db.run(`UPDATE cards SET odid = 0, did = 1 WHERE id = ${card.id}`);
+      } else {
+        db.run(`UPDATE cards SET did = 1 WHERE id = ${card.id}`);
+      }
+      fixed++;
+    }
+  }
+  return fixed;
+}
+
+/**
+ * Fix invalid scheduling by resetting affected cards to new card state.
+ */
+function fixInvalidScheduling(db: Database): number {
+  const cards = executeQueryAll<CardRow>(
+    db,
+    "SELECT id, nid, did, type, queue, due, ivl, odid FROM cards",
+  );
+
+  let fixed = 0;
+  for (const card of cards) {
+    const hasNegativeIvl = card.ivl < 0 && card.type === 2;
+    const hasInvalidType = card.type < 0 || card.type > 3;
+    const hasInvalidQueue = card.queue < -3 || card.queue > 4;
+
+    if (hasNegativeIvl || hasInvalidType || hasInvalidQueue) {
+      db.run(
+        `UPDATE cards SET type = 0, queue = 0, due = 0, ivl = 0, factor = 0, reps = 0, lapses = 0 WHERE id = ${card.id}`,
+      );
+      fixed++;
+    }
+  }
+  return fixed;
+}
+
+/**
+ * Apply a specific fix based on issue type. Returns number of items fixed.
+ */
+export function applyFix(db: Database, issueType: IssueType): number {
+  switch (issueType) {
+    case "orphaned-cards":
+      return fixOrphanedCards(db);
+    case "orphaned-notes":
+      return fixOrphanedNotes(db);
+    case "missing-deck":
+      return fixMissingDecks(db);
+    case "invalid-scheduling":
+      return fixInvalidScheduling(db);
+    default:
+      return 0;
+  }
+}


### PR DESCRIPTION
## Summary

- Add database integrity check tool with 9 checks: orphaned cards/notes, missing notetypes/decks, field count mismatches, invalid scheduling, duplicate IDs/GUIDs
- Auto-fix support for orphaned cards, orphaned notes, missing decks, and invalid scheduling
- Accessible via command palette ("Check Database" under Tools)

Closes #115