### PR TITLE
test: add unit tests for untested pure-logic modules

### DIFF
--- a/src/ankiExporter/__tests__/csvJsonExport.test.ts
+++ b/src/ankiExporter/__tests__/csvJsonExport.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import { exportCards } from "../csvJsonExport";
+import type { AnkiData } from "../../ankiParser";
+
+function makeAnkiData(cards: AnkiData["cards"][number][] = []): AnkiData {
+  return {
+    deckName: "Test Deck",
+    cards,
+    decks: {},
+    media: [],
+    models: {},
+    tags: [],
+    dconf: {},
+    schedulerVersion: 2,
+  } as unknown as AnkiData;
+}
+
+function makeCard(overrides: Record<string, unknown> = {}): AnkiData["cards"][number] {
+  return {
+    deckName: "Test Deck",
+    guid: "abc123",
+    tags: ["tag1"],
+    values: { Front: "Question", Back: "Answer" },
+    templates: [{ name: "Card 1", front: "{{Front}}", back: "{{Back}}" }],
+    noteId: 1,
+    fieldNames: ["Front", "Back"],
+    modelName: "Basic",
+    ...overrides,
+  } as unknown as AnkiData["cards"][number];
+}
+
+describe("exportCards CSV", () => {
+  it("returns CSV with headers and data rows", () => {
+    const data = makeAnkiData([makeCard()]);
+    const result = exportCards(data, {
+      format: "csv",
+      scope: "all",
+      includeScheduling: false,
+      includeHtml: true,
+    });
+    expect(result.mimeType).toBe("text/csv;charset=utf-8");
+    expect(result.extension).toBe("csv");
+    const lines = result.content.split("\n");
+    expect(lines.length).toBe(2); // header + 1 row
+    expect(lines[0]).toContain("deck");
+    expect(lines[0]).toContain("tags");
+    expect(lines[0]).toContain("guid");
+    expect(lines[0]).toContain("Front");
+    expect(lines[0]).toContain("Back");
+  });
+
+  it("returns empty string for no cards", () => {
+    const result = exportCards(makeAnkiData([]), {
+      format: "csv",
+      scope: "all",
+      includeScheduling: false,
+      includeHtml: true,
+    });
+    expect(result.content).toBe("");
+  });
+
+  it("escapes commas in CSV fields", () => {
+    const card = makeCard({ values: { Front: "hello, world", Back: "ok" } });
+    const result = exportCards(makeAnkiData([card]), {
+      format: "csv",
+      scope: "all",
+      includeScheduling: false,
+      includeHtml: true,
+    });
+    expect(result.content).toContain('"hello, world"');
+  });
+
+  it("escapes quotes in CSV fields", () => {
+    const card = makeCard({ values: { Front: 'say "hi"', Back: "ok" } });
+    const result = exportCards(makeAnkiData([card]), {
+      format: "csv",
+      scope: "all",
+      includeScheduling: false,
+      includeHtml: true,
+    });
+    expect(result.content).toContain('"say ""hi"""');
+  });
+
+  it("strips HTML when includeHtml is false", () => {
+    const card = makeCard({ values: { Front: "<b>bold</b>", Back: "plain" } });
+    const result = exportCards(makeAnkiData([card]), {
+      format: "csv",
+      scope: "all",
+      includeScheduling: false,
+      includeHtml: false,
+    });
+    expect(result.content).toContain("bold");
+    expect(result.content).not.toContain("<b>");
+  });
+
+  it("strips sound tags when includeHtml is false", () => {
+    const card = makeCard({ values: { Front: "[sound:audio.mp3] word", Back: "ok" } });
+    const result = exportCards(makeAnkiData([card]), {
+      format: "csv",
+      scope: "all",
+      includeScheduling: false,
+      includeHtml: false,
+    });
+    expect(result.content).toContain("word");
+    expect(result.content).not.toContain("[sound:");
+  });
+
+  it("includes scheduling columns when requested", () => {
+    const card = makeCard({
+      scheduling: {
+        type: 2,
+        queue: 2,
+        due: 100,
+        ivl: 10,
+        easeFactor: 2500,
+        reps: 5,
+        lapses: 1,
+        typeName: "review",
+        queueName: "review",
+      },
+    } as Partial<AnkiData["cards"][number]>);
+    const result = exportCards(makeAnkiData([card]), {
+      format: "csv",
+      scope: "all",
+      includeScheduling: true,
+      includeHtml: true,
+    });
+    expect(result.content).toContain("scheduling_type");
+    expect(result.content).toContain("scheduling_interval");
+  });
+
+  it("filters by deck when scope is 'deck'", () => {
+    const card1 = makeCard({ deckName: "Deck A", values: { Front: "Q1", Back: "A1" } });
+    const card2 = makeCard({ deckName: "Deck B", values: { Front: "Q2", Back: "A2" } });
+    const result = exportCards(makeAnkiData([card1, card2]), {
+      format: "csv",
+      scope: "deck",
+      deckName: "Deck A",
+      includeScheduling: false,
+      includeHtml: true,
+    });
+    const lines = result.content.split("\n");
+    expect(lines).toHaveLength(2); // header + 1 matching card
+    expect(result.content).toContain("Q1");
+    expect(result.content).not.toContain("Q2");
+  });
+
+  it("includes subdeck cards when filtering by parent deck", () => {
+    const card1 = makeCard({ deckName: "Parent", values: { Front: "Q1", Back: "A1" } });
+    const card2 = makeCard({ deckName: "Parent::Child", values: { Front: "Q2", Back: "A2" } });
+    const result = exportCards(makeAnkiData([card1, card2]), {
+      format: "csv",
+      scope: "deck",
+      deckName: "Parent",
+      includeScheduling: false,
+      includeHtml: true,
+    });
+    const lines = result.content.split("\n");
+    expect(lines).toHaveLength(3); // header + 2 cards
+  });
+
+  it("respects csvColumns filter", () => {
+    const card = makeCard({ values: { Front: "Q", Back: "A", Extra: "E" } });
+    const result = exportCards(makeAnkiData([card]), {
+      format: "csv",
+      scope: "all",
+      includeScheduling: false,
+      includeHtml: true,
+      csvColumns: ["Front"],
+    });
+    const header = result.content.split("\n")[0]!;
+    expect(header).toContain("Front");
+    expect(header).not.toContain("Back");
+    expect(header).not.toContain("Extra");
+  });
+});
+
+describe("exportCards JSON", () => {
+  it("returns valid JSON", () => {
+    const data = makeAnkiData([makeCard()]);
+    const result = exportCards(data, {
+      format: "json",
+      scope: "all",
+      includeScheduling: false,
+      includeHtml: true,
+    });
+    expect(result.mimeType).toBe("application/json;charset=utf-8");
+    expect(result.extension).toBe("json");
+    const parsed = JSON.parse(result.content);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].Front).toBe("Question");
+  });
+
+  it("includes deck and tags in JSON output", () => {
+    const card = makeCard({ deckName: "My Deck", tags: ["t1", "t2"] });
+    const result = exportCards(makeAnkiData([card]), {
+      format: "json",
+      scope: "all",
+      includeScheduling: false,
+      includeHtml: true,
+    });
+    const parsed = JSON.parse(result.content);
+    expect(parsed[0].deck).toBe("My Deck");
+    expect(parsed[0].tags).toBe("t1 t2");
+  });
+});

--- a/src/scheduler/__tests__/anki-sm2-algorithm.test.ts
+++ b/src/scheduler/__tests__/anki-sm2-algorithm.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AnkiSM2Algorithm } from "../anki-sm2-algorithm";
+import type { AnkiSM2CardState, AnkiSM2ReviewLog } from "../anki-sm2-algorithm";
+import { DEFAULT_SM2_PARAMS } from "../types";
+import { MS_PER_DAY } from "~/utils/constants";
+
+describe("AnkiSM2Algorithm", () => {
+  let algo: AnkiSM2Algorithm;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T12:00:00Z"));
+    algo = new AnkiSM2Algorithm();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("createCard", () => {
+    it("creates a new card with default state", () => {
+      const card = algo.createCard();
+      expect(card.phase).toBe("new");
+      expect(card.step).toBe(0);
+      expect(card.ease).toBe(DEFAULT_SM2_PARAMS.startingEase);
+      expect(card.interval).toBe(0);
+      expect(card.lapses).toBe(0);
+      expect(card.reps).toBe(0);
+    });
+  });
+
+  describe("new card review", () => {
+    it("moves to learning phase on 'again'", () => {
+      const card = algo.createCard();
+      const result = algo.reviewCard(card, "again");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.phase).toBe("learning");
+      expect(newState.step).toBe(0);
+      expect(newState.reps).toBe(1);
+    });
+
+    it("moves to learning phase on 'good'", () => {
+      const card = algo.createCard();
+      const result = algo.reviewCard(card, "good");
+      const newState = result.cardState as AnkiSM2CardState;
+      // Good advances to next step (step 1 of [1, 10])
+      expect(newState.phase).toBe("learning");
+      expect(newState.step).toBe(1);
+    });
+
+    it("graduates immediately on 'easy'", () => {
+      const card = algo.createCard();
+      const result = algo.reviewCard(card, "easy");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.phase).toBe("review");
+      expect(newState.interval).toBe(DEFAULT_SM2_PARAMS.easyInterval);
+    });
+
+    it("graduates immediately when no learning steps", () => {
+      const noSteps = new AnkiSM2Algorithm({ learningSteps: [] });
+      const card = noSteps.createCard();
+      const result = noSteps.reviewCard(card, "good");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.phase).toBe("review");
+      expect(newState.interval).toBe(DEFAULT_SM2_PARAMS.graduatingInterval);
+    });
+  });
+
+  describe("learning card review", () => {
+    it("graduates on 'good' after final step", () => {
+      const card: AnkiSM2CardState = {
+        phase: "learning",
+        step: 1, // last step of default [1, 10]
+        ease: 2.5,
+        interval: 10 / (24 * 60), // 10 min in days
+        due: Date.now(),
+        lapses: 0,
+        reps: 1,
+      };
+      const result = algo.reviewCard(card, "good");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.phase).toBe("review");
+      expect(newState.interval).toBe(DEFAULT_SM2_PARAMS.graduatingInterval);
+    });
+
+    it("resets to step 0 on 'again'", () => {
+      const card: AnkiSM2CardState = {
+        phase: "learning",
+        step: 1,
+        ease: 2.5,
+        interval: 10 / (24 * 60),
+        due: Date.now(),
+        lapses: 0,
+        reps: 1,
+      };
+      const result = algo.reviewCard(card, "again");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.phase).toBe("learning");
+      expect(newState.step).toBe(0);
+    });
+
+    it("graduates on 'easy' from learning", () => {
+      const card: AnkiSM2CardState = {
+        phase: "learning",
+        step: 0,
+        ease: 2.5,
+        interval: 0,
+        due: Date.now(),
+        lapses: 0,
+        reps: 1,
+      };
+      const result = algo.reviewCard(card, "easy");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.phase).toBe("review");
+    });
+  });
+
+  describe("review card answers", () => {
+    function makeReviewCard(overrides: Partial<AnkiSM2CardState> = {}): AnkiSM2CardState {
+      return {
+        phase: "review",
+        step: 0,
+        ease: 2.5,
+        interval: 10,
+        due: Date.now(), // due now
+        lapses: 0,
+        reps: 5,
+        ...overrides,
+      };
+    }
+
+    it("decreases ease on 'again'", () => {
+      const card = makeReviewCard();
+      const result = algo.reviewCard(card, "again");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.ease).toBe(2.3);
+      expect(newState.lapses).toBe(1);
+    });
+
+    it("enters relearning on 'again' with relearning steps", () => {
+      const card = makeReviewCard();
+      const result = algo.reviewCard(card, "again");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.phase).toBe("relearning");
+    });
+
+    it("decreases ease on 'hard'", () => {
+      const card = makeReviewCard();
+      const result = algo.reviewCard(card, "hard");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.ease).toBe(2.35);
+      expect(newState.phase).toBe("review");
+    });
+
+    it("keeps ease on 'good'", () => {
+      const card = makeReviewCard();
+      const result = algo.reviewCard(card, "good");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.ease).toBe(2.5);
+    });
+
+    it("increases ease on 'easy'", () => {
+      const card = makeReviewCard();
+      const result = algo.reviewCard(card, "easy");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.ease).toBe(2.65);
+    });
+
+    it("enforces minimum ease of 1.3", () => {
+      const card = makeReviewCard({ ease: 1.3 });
+      const result = algo.reviewCard(card, "again");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.ease).toBe(1.3);
+    });
+
+    it("enforces good > hard interval ordering", () => {
+      const card = makeReviewCard({ interval: 10, ease: 2.5 });
+      const hard = algo.reviewCard(card, "hard").cardState as AnkiSM2CardState;
+      const good = algo.reviewCard(card, "good").cardState as AnkiSM2CardState;
+      expect(good.interval).toBeGreaterThanOrEqual(hard.interval);
+    });
+
+    it("enforces easy > good interval ordering", () => {
+      const card = makeReviewCard({ interval: 10, ease: 2.5 });
+      const good = algo.reviewCard(card, "good").cardState as AnkiSM2CardState;
+      const easy = algo.reviewCard(card, "easy").cardState as AnkiSM2CardState;
+      expect(easy.interval).toBeGreaterThanOrEqual(good.interval);
+    });
+
+    it("clamps interval to maximumInterval", () => {
+      const shortMax = new AnkiSM2Algorithm({ maximumInterval: 30 });
+      const card = makeReviewCard({ interval: 25, ease: 2.5 });
+      const result = shortMax.reviewCard(card, "easy");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.interval).toBeLessThanOrEqual(30);
+    });
+  });
+
+  describe("relearning", () => {
+    it("graduates from relearning on 'good' after final step", () => {
+      const card: AnkiSM2CardState = {
+        phase: "relearning",
+        step: 0, // only step in default [10]
+        ease: 2.3,
+        interval: 5, // saved review interval
+        due: Date.now(),
+        lapses: 1,
+        reps: 6,
+      };
+      const result = algo.reviewCard(card, "good");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.phase).toBe("review");
+      // Should use the saved interval, clamped to minLapseInterval
+      expect(newState.interval).toBeGreaterThanOrEqual(DEFAULT_SM2_PARAMS.minLapseInterval);
+    });
+
+    it("graduates from relearning on 'easy' without interval +1", () => {
+      const card: AnkiSM2CardState = {
+        phase: "relearning",
+        step: 0,
+        ease: 2.3,
+        interval: 5,
+        due: Date.now(),
+        lapses: 1,
+        reps: 6,
+      };
+      const result = algo.reviewCard(card, "easy");
+      const newState = result.cardState as AnkiSM2CardState;
+      expect(newState.phase).toBe("review");
+    });
+  });
+
+  describe("leech detection", () => {
+    it("marks card as leeched at leech threshold", () => {
+      const card: AnkiSM2CardState = {
+        phase: "review",
+        step: 0,
+        ease: 2.5,
+        interval: 10,
+        due: Date.now(),
+        lapses: 7, // one below default threshold of 8
+        reps: 20,
+      };
+      const result = algo.reviewCard(card, "again");
+      expect((result.reviewLog as AnkiSM2ReviewLog).leeched).toBe(true);
+    });
+
+    it("does not mark as leeched below threshold", () => {
+      const card: AnkiSM2CardState = {
+        phase: "review",
+        step: 0,
+        ease: 2.5,
+        interval: 10,
+        due: Date.now(),
+        lapses: 5,
+        reps: 15,
+      };
+      const result = algo.reviewCard(card, "again");
+      expect((result.reviewLog as AnkiSM2ReviewLog).leeched).toBe(false);
+    });
+  });
+
+  describe("getNextIntervals", () => {
+    it("returns dates for all four answers", () => {
+      const card = algo.createCard();
+      const intervals = algo.getNextIntervals(card);
+      expect(intervals.again).toBeInstanceOf(Date);
+      expect(intervals.hard).toBeInstanceOf(Date);
+      expect(intervals.good).toBeInstanceOf(Date);
+      expect(intervals.easy).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("getDueDate", () => {
+    it("returns the due date from card state", () => {
+      const card: AnkiSM2CardState = {
+        phase: "review",
+        step: 0,
+        ease: 2.5,
+        interval: 10,
+        due: Date.now() + MS_PER_DAY,
+        lapses: 0,
+        reps: 5,
+      };
+      const due = algo.getDueDate(card);
+      expect(due.getTime()).toBe(card.due);
+    });
+  });
+
+  describe("getDisplayInfo", () => {
+    it("returns card state details", () => {
+      const card: AnkiSM2CardState = {
+        phase: "review",
+        step: 0,
+        ease: 2.5,
+        interval: 10,
+        due: Date.now(),
+        lapses: 2,
+        reps: 15,
+      };
+      const info = algo.getDisplayInfo(card);
+      expect(info.ease).toBe(2.5);
+      expect(info.interval).toBe(10);
+      expect(info.repetitions).toBe(15);
+      expect(info.state).toBe("review");
+      expect(info.lapses).toBe(2);
+    });
+  });
+
+  describe("isInLearning", () => {
+    it("returns true for learning phase", () => {
+      expect(algo.isInLearning({ phase: "learning" } as AnkiSM2CardState)).toBe(true);
+    });
+
+    it("returns true for relearning phase", () => {
+      expect(algo.isInLearning({ phase: "relearning" } as AnkiSM2CardState)).toBe(true);
+    });
+
+    it("returns false for review phase", () => {
+      expect(algo.isInLearning({ phase: "review" } as AnkiSM2CardState)).toBe(false);
+    });
+
+    it("returns false for new phase", () => {
+      expect(algo.isInLearning({ phase: "new" } as AnkiSM2CardState)).toBe(false);
+    });
+  });
+});

--- a/src/stats/__tests__/computeStats.test.ts
+++ b/src/stats/__tests__/computeStats.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeCardCounts,
+  computeIntervalDistribution,
+  computeEaseDistribution,
+  computeAnswerButtons,
+  computeReviewsByHour,
+  computeCalendarHeatmap,
+  computeTrueRetention,
+  computeStudyStreak,
+  computeAddedCards,
+} from "../computeStats";
+import type { NormalizedCardInfo } from "../types";
+import type { StoredReviewLog, DailyStats } from "../../scheduler/types";
+
+function makeCard(overrides: Partial<NormalizedCardInfo> = {}): NormalizedCardInfo {
+  return {
+    cardId: "1",
+    deckId: "1",
+    algorithm: "sm2",
+    phase: "young",
+    interval: 5,
+    easeFactor: 2.5,
+    due: Date.now(),
+    lapses: 0,
+    reps: 1,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeLog(overrides: Partial<StoredReviewLog> = {}): StoredReviewLog {
+  return {
+    cardId: "1",
+    timestamp: Date.now(),
+    rating: "good",
+    reviewLog: {} as StoredReviewLog["reviewLog"],
+    ...overrides,
+  };
+}
+
+describe("computeCardCounts", () => {
+  it("counts cards by phase", () => {
+    const cards = [
+      makeCard({ phase: "new" }),
+      makeCard({ phase: "new" }),
+      makeCard({ phase: "learning" }),
+      makeCard({ phase: "young" }),
+      makeCard({ phase: "mature" }),
+      makeCard({ phase: "mature" }),
+    ];
+    expect(computeCardCounts(cards)).toEqual({
+      new: 2,
+      learning: 1,
+      young: 1,
+      mature: 2,
+    });
+  });
+
+  it("returns all zeros for empty array", () => {
+    expect(computeCardCounts([])).toEqual({ new: 0, learning: 0, young: 0, mature: 0 });
+  });
+});
+
+describe("computeIntervalDistribution", () => {
+  it("returns empty for no cards", () => {
+    expect(computeIntervalDistribution([])).toEqual([]);
+  });
+
+  it("excludes new and learning cards", () => {
+    const cards = [makeCard({ phase: "new" }), makeCard({ phase: "learning" })];
+    expect(computeIntervalDistribution(cards)).toEqual([]);
+  });
+
+  it("distributes intervals into buckets", () => {
+    const cards = [
+      makeCard({ phase: "young", interval: 0.5 }),
+      makeCard({ phase: "young", interval: 2 }),
+      makeCard({ phase: "young", interval: 5 }),
+      makeCard({ phase: "mature", interval: 100 }),
+      makeCard({ phase: "mature", interval: 400 }),
+    ];
+    const buckets = computeIntervalDistribution(cards);
+    expect(buckets.length).toBe(9);
+
+    // < 1d bucket
+    expect(buckets[0]!.label).toBe("< 1d");
+    expect(buckets[0]!.count).toBe(1);
+
+    // 1-3d bucket
+    expect(buckets[1]!.label).toBe("1-3d");
+    expect(buckets[1]!.count).toBe(1);
+
+    // 3-7d bucket
+    expect(buckets[2]!.label).toBe("3-7d");
+    expect(buckets[2]!.count).toBe(1);
+
+    // 3-6mo bucket (90-180)
+    expect(buckets[6]!.label).toBe("3-6mo");
+    expect(buckets[6]!.count).toBe(1);
+
+    // 1y+ bucket
+    expect(buckets[8]!.label).toBe("1y+");
+    expect(buckets[8]!.count).toBe(1);
+  });
+});
+
+describe("computeEaseDistribution", () => {
+  it("returns empty for no cards", () => {
+    expect(computeEaseDistribution([])).toEqual([]);
+  });
+
+  it("excludes cards with 0 reps", () => {
+    const cards = [makeCard({ reps: 0 })];
+    expect(computeEaseDistribution(cards)).toEqual([]);
+  });
+
+  it("distributes ease factors into buckets", () => {
+    const cards = [
+      makeCard({ easeFactor: 2.5, reps: 5 }), // 250%
+      makeCard({ easeFactor: 1.3, reps: 3 }), // 130%
+    ];
+    const buckets = computeEaseDistribution(cards);
+    expect(buckets.length).toBeGreaterThan(0);
+    // 250% falls in 250-270 bucket
+    const bucket250 = buckets.find((b) => b.label === "250%");
+    expect(bucket250!.count).toBe(1);
+    // 130% falls in 130-150 bucket
+    const bucket130 = buckets.find((b) => b.label === "130%");
+    expect(bucket130!.count).toBe(1);
+  });
+});
+
+describe("computeAnswerButtons", () => {
+  it("counts each answer type", () => {
+    const logs = [
+      makeLog({ rating: "again" }),
+      makeLog({ rating: "good" }),
+      makeLog({ rating: "good" }),
+      makeLog({ rating: "easy" }),
+      makeLog({ rating: "hard" }),
+    ];
+    expect(computeAnswerButtons(logs)).toEqual({ again: 1, hard: 1, good: 2, easy: 1 });
+  });
+
+  it("normalizes numeric ratings", () => {
+    const logs = [makeLog({ rating: 1 }), makeLog({ rating: 3 }), makeLog({ rating: 4 })];
+    expect(computeAnswerButtons(logs)).toEqual({ again: 1, hard: 0, good: 1, easy: 1 });
+  });
+
+  it("returns all zeros for empty logs", () => {
+    expect(computeAnswerButtons([])).toEqual({ again: 0, hard: 0, good: 0, easy: 0 });
+  });
+});
+
+describe("computeReviewsByHour", () => {
+  it("returns 24 buckets", () => {
+    const buckets = computeReviewsByHour([]);
+    expect(buckets).toHaveLength(24);
+    expect(buckets[0]!.label).toBe("0:00");
+    expect(buckets[23]!.label).toBe("23:00");
+  });
+
+  it("counts reviews in their hour bucket", () => {
+    const noon = new Date();
+    noon.setHours(12, 30, 0, 0);
+    const logs = [makeLog({ timestamp: noon.getTime() }), makeLog({ timestamp: noon.getTime() })];
+    const buckets = computeReviewsByHour(logs);
+    expect(buckets[12]!.count).toBe(2);
+  });
+});
+
+describe("computeCalendarHeatmap", () => {
+  it("returns empty for no logs", () => {
+    expect(computeCalendarHeatmap([])).toEqual([]);
+  });
+
+  it("groups reviews by date", () => {
+    const day1 = new Date("2024-01-15T10:00:00").getTime();
+    const day1b = new Date("2024-01-15T14:00:00").getTime();
+    const day2 = new Date("2024-01-16T10:00:00").getTime();
+    const logs = [
+      makeLog({ timestamp: day1 }),
+      makeLog({ timestamp: day1b }),
+      makeLog({ timestamp: day2 }),
+    ];
+    const heatmap = computeCalendarHeatmap(logs);
+    expect(heatmap).toHaveLength(2);
+    expect(heatmap[0]!.count).toBe(2);
+    expect(heatmap[1]!.count).toBe(1);
+  });
+});
+
+describe("computeTrueRetention", () => {
+  it("returns 0 retention for no mature cards", () => {
+    const result = computeTrueRetention([makeLog()], [makeCard({ phase: "young" })]);
+    expect(result).toEqual({ retention: 0, total: 0, correct: 0 });
+  });
+
+  it("calculates retention from mature card reviews", () => {
+    const cards = [makeCard({ cardId: "1", phase: "mature" })];
+    const logs = [
+      makeLog({ cardId: "1", rating: "good" }),
+      makeLog({ cardId: "1", rating: "easy" }),
+      makeLog({ cardId: "1", rating: "again" }),
+    ];
+    const result = computeTrueRetention(logs, cards);
+    expect(result.total).toBe(3);
+    expect(result.correct).toBe(2);
+    expect(result.retention).toBeCloseTo(2 / 3);
+  });
+
+  it("returns 0 for no reviews", () => {
+    const result = computeTrueRetention([], [makeCard({ phase: "mature" })]);
+    expect(result).toEqual({ retention: 0, total: 0, correct: 0 });
+  });
+});
+
+describe("computeStudyStreak", () => {
+  it("returns 0 for empty stats", () => {
+    expect(computeStudyStreak([])).toBe(0);
+  });
+
+  it("counts consecutive days from today", () => {
+    const today = new Date();
+    const stats: DailyStats[] = [];
+    for (let i = 0; i < 5; i++) {
+      const d = new Date(today);
+      d.setDate(d.getDate() - i);
+      const date = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      stats.push({ date, newCount: 1, reviewCount: 5, totalTimeMs: 60000 });
+    }
+    expect(computeStudyStreak(stats)).toBe(5);
+  });
+
+  it("allows today to be missing (not yet reviewed)", () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const date = `${yesterday.getFullYear()}-${String(yesterday.getMonth() + 1).padStart(2, "0")}-${String(yesterday.getDate()).padStart(2, "0")}`;
+    const stats: DailyStats[] = [{ date, newCount: 1, reviewCount: 5, totalTimeMs: 60000 }];
+    expect(computeStudyStreak(stats)).toBe(1);
+  });
+
+  it("skips days with 0 reviews", () => {
+    const today = new Date();
+    const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+    const stats: DailyStats[] = [{ date, newCount: 0, reviewCount: 0, totalTimeMs: 0 }];
+    expect(computeStudyStreak(stats)).toBe(0);
+  });
+});
+
+describe("computeAddedCards", () => {
+  it("returns empty for no cards in range", () => {
+    const MS_PER_DAY = 86_400_000;
+    const start = Date.now() - MS_PER_DAY;
+    const end = Date.now();
+    const result = computeAddedCards([], start, end);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.count).toBe(0);
+  });
+
+  it("counts cards created within the range", () => {
+    const MS_PER_DAY = 86_400_000;
+    const now = Date.now();
+    const start = now - 2 * MS_PER_DAY;
+    const end = now;
+    const cards = [
+      makeCard({ createdAt: now - 1.5 * MS_PER_DAY }),
+      makeCard({ createdAt: now - 0.5 * MS_PER_DAY }),
+      makeCard({ createdAt: now - 0.2 * MS_PER_DAY }),
+    ];
+    const result = computeAddedCards(cards, start, end);
+    const totalAdded = result.reduce((sum, d) => sum + d.count, 0);
+    expect(totalAdded).toBe(3);
+  });
+
+  it("excludes cards outside the range", () => {
+    const MS_PER_DAY = 86_400_000;
+    const now = Date.now();
+    const start = now - MS_PER_DAY;
+    const end = now;
+    const cards = [makeCard({ createdAt: now - 3 * MS_PER_DAY })];
+    const result = computeAddedCards(cards, start, end);
+    const totalAdded = result.reduce((sum, d) => sum + d.count, 0);
+    expect(totalAdded).toBe(0);
+  });
+});

--- a/src/stats/__tests__/normalizeCard.test.ts
+++ b/src/stats/__tests__/normalizeCard.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { normalizeCard } from "../normalizeCard";
+import type { CardReviewState } from "../../scheduler/types";
+import type { AnkiSM2CardState } from "../../scheduler/anki-sm2-algorithm";
+import { State, type Card } from "ts-fsrs";
+
+function makeSM2Card(overrides: Partial<AnkiSM2CardState> = {}): CardReviewState {
+  const cardState: AnkiSM2CardState = {
+    phase: "review",
+    step: 0,
+    ease: 2.5,
+    interval: 10,
+    due: Date.now(),
+    lapses: 0,
+    reps: 5,
+    ...overrides,
+  };
+  return {
+    cardId: "1",
+    deckId: "deck1",
+    algorithm: "sm2",
+    cardState,
+    createdAt: Date.now() - 86400000,
+    lastReviewed: Date.now(),
+  };
+}
+
+function makeFSRSCard(overrides: Partial<Card> = {}): CardReviewState {
+  const cardState: Card = {
+    due: new Date(),
+    stability: 5,
+    difficulty: 5,
+    elapsed_days: 0,
+    scheduled_days: 10,
+    reps: 5,
+    lapses: 0,
+    learning_steps: 0,
+    state: State.Review,
+    last_review: new Date(),
+    ...overrides,
+  };
+  return {
+    cardId: "2",
+    deckId: "deck1",
+    algorithm: "fsrs",
+    cardState,
+    createdAt: Date.now() - 86400000,
+    lastReviewed: Date.now(),
+  };
+}
+
+describe("normalizeCard SM2", () => {
+  it("classifies new cards", () => {
+    const result = normalizeCard(makeSM2Card({ phase: "new" }));
+    expect(result.phase).toBe("new");
+  });
+
+  it("classifies learning cards", () => {
+    const result = normalizeCard(makeSM2Card({ phase: "learning" }));
+    expect(result.phase).toBe("learning");
+  });
+
+  it("classifies relearning cards as learning", () => {
+    const result = normalizeCard(makeSM2Card({ phase: "relearning" }));
+    expect(result.phase).toBe("learning");
+  });
+
+  it("classifies short-interval review cards as young", () => {
+    const result = normalizeCard(makeSM2Card({ phase: "review", interval: 10 }));
+    expect(result.phase).toBe("young");
+  });
+
+  it("classifies long-interval review cards as mature", () => {
+    const result = normalizeCard(makeSM2Card({ phase: "review", interval: 30 }));
+    expect(result.phase).toBe("mature");
+  });
+
+  it("uses interval=21 as the young/mature boundary", () => {
+    expect(normalizeCard(makeSM2Card({ phase: "review", interval: 20 })).phase).toBe("young");
+    expect(normalizeCard(makeSM2Card({ phase: "review", interval: 21 })).phase).toBe("mature");
+  });
+
+  it("maps SM2 fields correctly", () => {
+    const result = normalizeCard(makeSM2Card({ ease: 2.3, interval: 15, lapses: 2, reps: 10 }));
+    expect(result.easeFactor).toBe(2.3);
+    expect(result.interval).toBe(15);
+    expect(result.lapses).toBe(2);
+    expect(result.reps).toBe(10);
+  });
+});
+
+describe("normalizeCard FSRS", () => {
+  it("classifies new FSRS cards", () => {
+    const result = normalizeCard(makeFSRSCard({ state: State.New }));
+    expect(result.phase).toBe("new");
+  });
+
+  it("classifies learning FSRS cards", () => {
+    const result = normalizeCard(makeFSRSCard({ state: State.Learning }));
+    expect(result.phase).toBe("learning");
+  });
+
+  it("classifies relearning FSRS cards as learning", () => {
+    const result = normalizeCard(makeFSRSCard({ state: State.Relearning }));
+    expect(result.phase).toBe("learning");
+  });
+
+  it("classifies short-interval FSRS review cards as young", () => {
+    const result = normalizeCard(makeFSRSCard({ state: State.Review, scheduled_days: 10 }));
+    expect(result.phase).toBe("young");
+  });
+
+  it("classifies long-interval FSRS review cards as mature", () => {
+    const result = normalizeCard(makeFSRSCard({ state: State.Review, scheduled_days: 30 }));
+    expect(result.phase).toBe("mature");
+  });
+
+  it("maps FSRS difficulty to ease-like scale", () => {
+    // difficulty=1 (easiest) → (11-1)/2.5 = 4.0
+    const easy = normalizeCard(makeFSRSCard({ difficulty: 1 }));
+    expect(easy.easeFactor).toBe(4.0);
+
+    // difficulty=10 (hardest) → (11-10)/2.5 = 0.4
+    const hard = normalizeCard(makeFSRSCard({ difficulty: 10 }));
+    expect(hard.easeFactor).toBeCloseTo(0.4);
+  });
+
+  it("uses scheduled_days as interval", () => {
+    const result = normalizeCard(makeFSRSCard({ scheduled_days: 42 }));
+    expect(result.interval).toBe(42);
+  });
+});

--- a/src/utils/__tests__/constants.test.ts
+++ b/src/utils/__tests__/constants.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { isZstdCompressed, stringHash } from "../constants";
+
+describe("isZstdCompressed", () => {
+  it("detects zstd magic bytes", () => {
+    const bytes = new Uint8Array([0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x01]);
+    expect(isZstdCompressed(bytes)).toBe(true);
+  });
+
+  it("returns false for non-zstd data", () => {
+    const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // ZIP magic
+    expect(isZstdCompressed(bytes)).toBe(false);
+  });
+
+  it("returns false for too-short data", () => {
+    const bytes = new Uint8Array([0x28, 0xb5, 0x2f]);
+    expect(isZstdCompressed(bytes)).toBe(false);
+  });
+
+  it("returns false for empty data", () => {
+    expect(isZstdCompressed(new Uint8Array([]))).toBe(false);
+  });
+});
+
+describe("stringHash", () => {
+  it("returns a number for any string", () => {
+    expect(typeof stringHash("hello")).toBe("number");
+  });
+
+  it("returns same hash for same input", () => {
+    expect(stringHash("test")).toBe(stringHash("test"));
+  });
+
+  it("returns different hashes for different inputs", () => {
+    expect(stringHash("abc")).not.toBe(stringHash("def"));
+  });
+
+  it("handles empty string", () => {
+    expect(typeof stringHash("")).toBe("number");
+  });
+
+  it("handles unicode", () => {
+    const hash = stringHash("日本語テスト");
+    expect(typeof hash).toBe("number");
+    expect(hash).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns unsigned 32-bit integer", () => {
+    const hash = stringHash("some random string");
+    expect(hash).toBeGreaterThanOrEqual(0);
+    expect(hash).toBeLessThanOrEqual(0xffffffff);
+  });
+});

--- a/src/utils/__tests__/csvParser.test.ts
+++ b/src/utils/__tests__/csvParser.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { parseCsv, detectDelimiter, resolveDelimiter } from "../csvParser";
+
+describe("resolveDelimiter", () => {
+  it("resolves named delimiters", () => {
+    expect(resolveDelimiter("comma", "")).toBe(",");
+    expect(resolveDelimiter("tab", "")).toBe("\t");
+    expect(resolveDelimiter("semicolon", "")).toBe(";");
+    expect(resolveDelimiter("pipe", "")).toBe("|");
+  });
+
+  it("returns custom delimiter when name is 'custom'", () => {
+    expect(resolveDelimiter("custom", "~")).toBe("~");
+  });
+
+  it("falls back to comma when custom is empty", () => {
+    expect(resolveDelimiter("custom", "")).toBe(",");
+  });
+});
+
+describe("parseCsv", () => {
+  it("parses simple comma-separated rows", () => {
+    const result = parseCsv("a,b,c\n1,2,3", ",");
+    expect(result).toEqual([
+      ["a", "b", "c"],
+      ["1", "2", "3"],
+    ]);
+  });
+
+  it("handles quoted fields", () => {
+    const result = parseCsv('"hello, world",b,c', ",");
+    expect(result).toEqual([["hello, world", "b", "c"]]);
+  });
+
+  it("handles escaped double quotes inside quoted fields", () => {
+    const result = parseCsv('"say ""hi""",b', ",");
+    expect(result).toEqual([['say "hi"', "b"]]);
+  });
+
+  it("handles newlines inside quoted fields", () => {
+    const result = parseCsv('"line1\nline2",b\nc,d', ",");
+    expect(result).toEqual([
+      ["line1\nline2", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("handles tab delimiter", () => {
+    const result = parseCsv("a\tb\tc", "\t");
+    expect(result).toEqual([["a", "b", "c"]]);
+  });
+
+  it("normalizes CRLF line endings", () => {
+    const result = parseCsv("a,b\r\nc,d", ",");
+    expect(result).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("skips empty lines", () => {
+    const result = parseCsv("a,b\n\nc,d\n", ",");
+    expect(result).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("handles single-column data", () => {
+    const result = parseCsv("a\nb\nc", ",");
+    expect(result).toEqual([["a"], ["b"], ["c"]]);
+  });
+
+  it("handles empty quoted field", () => {
+    const result = parseCsv('"",b,c', ",");
+    expect(result).toEqual([["", "b", "c"]]);
+  });
+});
+
+describe("detectDelimiter", () => {
+  it("detects tab delimiter", () => {
+    expect(detectDelimiter("a\tb\tc\n1\t2\t3")).toBe("tab");
+  });
+
+  it("detects comma delimiter", () => {
+    expect(detectDelimiter("a,b,c\n1,2,3")).toBe("comma");
+  });
+
+  it("detects semicolon delimiter", () => {
+    expect(detectDelimiter("a;b;c\n1;2;3")).toBe("semicolon");
+  });
+
+  it("detects pipe delimiter", () => {
+    expect(detectDelimiter("a|b|c\n1|2|3")).toBe("pipe");
+  });
+
+  it("returns comma for empty input", () => {
+    expect(detectDelimiter("")).toBe("comma");
+  });
+
+  it("prefers consistent delimiters over higher field counts", () => {
+    // Tab gives consistent 3 fields, comma only appears in some lines
+    const input = "a\tb\tc\n1\t2\t3\n4\t5\t6";
+    expect(detectDelimiter(input)).toBe("tab");
+  });
+});

--- a/src/utils/__tests__/sanitize.test.ts
+++ b/src/utils/__tests__/sanitize.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHtmlForPreview } from "../sanitize";
+
+describe("sanitizeHtmlForPreview", () => {
+  it("removes script tags and their content", () => {
+    expect(sanitizeHtmlForPreview('<p>ok</p><script>alert("xss")</script>')).toBe("<p>ok</p>");
+  });
+
+  it("removes style tags and their content", () => {
+    expect(sanitizeHtmlForPreview("<style>.card { color: red; }</style><p>text</p>")).toBe(
+      "<p>text</p>",
+    );
+  });
+
+  it("removes event handler attributes", () => {
+    expect(sanitizeHtmlForPreview('<div onclick="evil()">text</div>')).toBe("<div>text</div>");
+  });
+
+  it("removes onmouseover attributes", () => {
+    expect(sanitizeHtmlForPreview('<span onmouseover="bad()">hi</span>')).toBe("<span>hi</span>");
+  });
+
+  it("removes audio-container divs", () => {
+    const html = '<div class="audio-container"><audio src="x.mp3"></audio></div><p>text</p>';
+    expect(sanitizeHtmlForPreview(html)).toBe("<p>text</p>");
+  });
+
+  it("preserves safe HTML", () => {
+    const html = "<b>bold</b> <i>italic</i> <a href='#'>link</a>";
+    expect(sanitizeHtmlForPreview(html)).toBe(html);
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeHtmlForPreview("")).toBe("");
+  });
+
+  it("handles multiple event handlers on one element", () => {
+    const html = '<div onclick="a()" onload="b()">text</div>';
+    expect(sanitizeHtmlForPreview(html)).toBe("<div>text</div>");
+  });
+});

--- a/src/utils/__tests__/tagTree.test.ts
+++ b/src/utils/__tests__/tagTree.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { buildTagTree } from "../tagTree";
+
+describe("buildTagTree", () => {
+  it("returns empty array for no tags", () => {
+    expect(buildTagTree([], new Map())).toEqual([]);
+  });
+
+  it("builds flat list for tags without hierarchy", () => {
+    const tree = buildTagTree(["math", "science"], new Map());
+    expect(tree).toHaveLength(2);
+    expect(tree.map((n) => n.name).sort()).toEqual(["math", "science"]);
+    expect(tree.every((n) => n.children.length === 0)).toBe(true);
+  });
+
+  it("builds nested tree from hierarchical tags", () => {
+    const tree = buildTagTree(["lang::french", "lang::spanish"], new Map());
+    expect(tree).toHaveLength(1);
+    expect(tree[0]!.name).toBe("lang");
+    expect(tree[0]!.fullPath).toBe("lang");
+    expect(tree[0]!.children).toHaveLength(2);
+    expect(tree[0]!.children.map((c) => c.name).sort()).toEqual(["french", "spanish"]);
+  });
+
+  it("creates intermediate parent nodes", () => {
+    const tree = buildTagTree(["a::b::c"], new Map());
+    expect(tree).toHaveLength(1);
+    expect(tree[0]!.name).toBe("a");
+    expect(tree[0]!.children).toHaveLength(1);
+    expect(tree[0]!.children[0]!.name).toBe("b");
+    expect(tree[0]!.children[0]!.children).toHaveLength(1);
+    expect(tree[0]!.children[0]!.children[0]!.name).toBe("c");
+  });
+
+  it("assigns note counts from the count map", () => {
+    const counts = new Map([
+      ["lang", 5],
+      ["lang::french", 3],
+    ]);
+    const tree = buildTagTree(["lang", "lang::french"], counts);
+    expect(tree[0]!.noteCount).toBe(5);
+    expect(tree[0]!.children[0]!.noteCount).toBe(3);
+  });
+
+  it("defaults noteCount to 0 for tags not in the count map", () => {
+    const tree = buildTagTree(["misc"], new Map());
+    expect(tree[0]!.noteCount).toBe(0);
+  });
+
+  it("sorts root nodes alphabetically", () => {
+    const tree = buildTagTree(["zebra", "apple", "mango"], new Map());
+    expect(tree.map((n) => n.name)).toEqual(["apple", "mango", "zebra"]);
+  });
+
+  it("initializes expanded to false", () => {
+    const tree = buildTagTree(["tag1"], new Map());
+    expect(tree[0]!.expanded).toBe(false);
+  });
+
+  it("deduplicates parent nodes from multiple children", () => {
+    const tree = buildTagTree(["a::x", "a::y", "a::z"], new Map());
+    expect(tree).toHaveLength(1);
+    expect(tree[0]!.children).toHaveLength(3);
+  });
+});

--- a/src/utils/__tests__/templateParser.test.ts
+++ b/src/utils/__tests__/templateParser.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { renderTemplateString, parseClozeNodes, isClozeNode } from "../templateParser";
+
+describe("renderTemplateString", () => {
+  it("renders plain text without any template tags", () => {
+    const result = renderTemplateString({
+      templateString: "Hello world",
+      renderField: () => "",
+      shouldRenderConditional: () => false,
+    });
+    expect(result).toBe("Hello world");
+  });
+
+  it("substitutes field references", () => {
+    const result = renderTemplateString({
+      templateString: "{{Front}} - {{Back}}",
+      renderField: (ref) => (ref === "Front" ? "Question" : "Answer"),
+      shouldRenderConditional: () => false,
+    });
+    expect(result).toBe("Question - Answer");
+  });
+
+  it("renders positive conditional when field is non-empty", () => {
+    const result = renderTemplateString({
+      templateString: "{{#Extra}}Has extra: {{Extra}}{{/Extra}}",
+      renderField: (ref) => (ref === "Extra" ? "details" : ""),
+      shouldRenderConditional: (field) => field === "Extra",
+    });
+    expect(result).toBe("Has extra: details");
+  });
+
+  it("hides positive conditional when field is empty", () => {
+    const result = renderTemplateString({
+      templateString: "Before{{#Extra}} extra content{{/Extra}} After",
+      renderField: () => "",
+      shouldRenderConditional: () => false,
+    });
+    expect(result).toBe("Before After");
+  });
+
+  it("renders negative conditional when field is empty", () => {
+    const result = renderTemplateString({
+      templateString: "{{^Hint}}No hint{{/Hint}}",
+      renderField: () => "",
+      shouldRenderConditional: () => false,
+    });
+    expect(result).toBe("No hint");
+  });
+
+  it("hides negative conditional when field is non-empty", () => {
+    const result = renderTemplateString({
+      templateString: "{{^Hint}}No hint{{/Hint}}",
+      renderField: () => "",
+      shouldRenderConditional: () => true,
+    });
+    expect(result).toBe("");
+  });
+
+  it("handles nested conditionals", () => {
+    const result = renderTemplateString({
+      templateString: "{{#A}}outer{{#B}}inner{{/B}}{{/A}}",
+      renderField: () => "",
+      shouldRenderConditional: () => true,
+    });
+    expect(result).toBe("outerinner");
+  });
+
+  it("throws on mismatched closing tag", () => {
+    expect(() =>
+      renderTemplateString({
+        templateString: "{{#A}}content{{/B}}",
+        renderField: () => "",
+        shouldRenderConditional: () => true,
+      }),
+    ).toThrow("{{/B}}");
+  });
+
+  it("renders open-ended conditional without closing tag gracefully", () => {
+    // The parser does not throw on unclosed conditionals at end of string —
+    // it treats remaining content as the conditional body
+    const result = renderTemplateString({
+      templateString: "{{#A}}content",
+      renderField: () => "",
+      shouldRenderConditional: () => true,
+    });
+    expect(result).toBe("content");
+  });
+
+  it("throws on orphan closing tag", () => {
+    expect(() =>
+      renderTemplateString({
+        templateString: "content{{/A}}",
+        renderField: () => "",
+        shouldRenderConditional: () => false,
+      }),
+    ).toThrow();
+  });
+
+  it("handles unclosed double braces as text", () => {
+    const result = renderTemplateString({
+      templateString: "hello {{ no close",
+      renderField: () => "",
+      shouldRenderConditional: () => false,
+    });
+    expect(result).toBe("hello {{ no close");
+  });
+});
+
+describe("parseClozeNodes", () => {
+  it("parses simple cloze deletion", () => {
+    const nodes = parseClozeNodes("{{c1::answer}}");
+    expect(nodes).toEqual([{ type: "cloze", ordinal: 1, answer: "answer", hint: null }]);
+  });
+
+  it("parses cloze with hint", () => {
+    const nodes = parseClozeNodes("{{c1::answer::hint text}}");
+    expect(nodes).toEqual([{ type: "cloze", ordinal: 1, answer: "answer", hint: "hint text" }]);
+  });
+
+  it("parses text before and after cloze", () => {
+    const nodes = parseClozeNodes("before {{c1::word}} after");
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0]).toEqual({ type: "text", value: "before " });
+    expect(nodes[1]).toEqual({ type: "cloze", ordinal: 1, answer: "word", hint: null });
+    expect(nodes[2]).toEqual({ type: "text", value: " after" });
+  });
+
+  it("parses multiple cloze deletions", () => {
+    const nodes = parseClozeNodes("{{c1::one}} and {{c2::two}}");
+    const clozes = nodes.filter(isClozeNode);
+    expect(clozes).toHaveLength(2);
+    expect(clozes[0]!.ordinal).toBe(1);
+    expect(clozes[1]!.ordinal).toBe(2);
+  });
+
+  it("handles multi-digit ordinals", () => {
+    const nodes = parseClozeNodes("{{c12::answer}}");
+    const clozes = nodes.filter(isClozeNode);
+    expect(clozes[0]!.ordinal).toBe(12);
+  });
+
+  it("treats invalid cloze syntax as text", () => {
+    const nodes = parseClozeNodes("{{cX::answer}}");
+    // No valid cloze nodes
+    const clozes = nodes.filter(isClozeNode);
+    expect(clozes).toHaveLength(0);
+  });
+
+  it("handles unclosed cloze as text", () => {
+    const nodes = parseClozeNodes("{{c1::no close");
+    const clozes = nodes.filter(isClozeNode);
+    expect(clozes).toHaveLength(0);
+  });
+
+  it("returns single text node for plain text", () => {
+    const nodes = parseClozeNodes("just plain text");
+    expect(nodes).toEqual([{ type: "text", value: "just plain text" }]);
+  });
+
+  it("returns empty array for empty string", () => {
+    const nodes = parseClozeNodes("");
+    expect(nodes).toEqual([]);
+  });
+});
+
+describe("isClozeNode", () => {
+  it("returns true for cloze nodes", () => {
+    expect(isClozeNode({ type: "cloze", ordinal: 1, answer: "x", hint: null })).toBe(true);
+  });
+
+  it("returns false for text nodes", () => {
+    expect(isClozeNode({ type: "text", value: "x" })).toBe(false);
+  });
+});


### PR DESCRIPTION
Add 146 unit tests across 9 new test files covering previously untested modules:

- **csvParser**: CSV parsing, delimiter detection/resolution
- **templateParser**: Anki template rendering, cloze deletion parsing
- **tagTree**: hierarchical tag tree building
- **sanitize**: HTML sanitization for previews
- **constants**: zstd detection, string hashing
- **computeStats**: card counts, distributions, retention, streaks, heatmaps
- **normalizeCard**: SM2/FSRS card normalization and phase classification
- **anki-sm2-algorithm**: SM-2 scheduling (all phases, ease, leech detection)
- **csvJsonExport**: CSV/JSON export with filtering, HTML stripping, escaping