### PR TITLE
feat: filtered / custom study decks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,9 @@ import {
   selectedTemplateSig,
   templatesSig,
   updateDueCardsAfterReview,
+  activeFilteredDeckIdSig,
+  activeFilteredDeckSig,
+  emptyFilteredDeck,
 } from "./stores";
 import StatusBar from "./components/StatusBar.vue";
 import FileLibrary from "./components/FileLibrary.vue";
@@ -352,37 +355,49 @@ async function handleChooseAnswer(answer: Answer) {
     const queue = reviewQueueSig.value;
 
     if (reviewCard && queue) {
-      // Capture previous state for undo
-      const previousState = JSON.parse(JSON.stringify(reviewCard.reviewState));
-      const wasNew = reviewCard.isNew;
-      const today = new Date();
-      const rolloverHour = 4; // Default rollover hour
-      if (today.getHours() < rolloverHour) today.setDate(today.getDate() - 1);
-      const dailyStatsDate = today.toISOString().split("T")[0]!;
+      // Check if we're in cram mode (filtered deck with reschedule=false)
+      const filteredDeck = activeFilteredDeckSig.value;
+      const isCramMode = filteredDeck && !filteredDeck.reschedule;
 
-      const reviewTimeMs = Date.now() - reviewStartTime.value;
-      const reviewLogTimestamp = Date.now();
-      const updatedState = await queue.processReview(reviewCard, answer, reviewTimeMs);
+      if (isCramMode) {
+        // Cram mode: don't persist scheduling changes
+        // Just remove the card from the queue and move on
+        updateDueCardsAfterReview(reviewCard.cardId, reviewCard.reviewState);
+        moveToNextReviewCard();
+      } else {
+        // Normal mode: process review with scheduling
+        // Capture previous state for undo
+        const previousState = JSON.parse(JSON.stringify(reviewCard.reviewState));
+        const wasNew = reviewCard.isNew;
+        const today = new Date();
+        const rolloverHour = 4; // Default rollover hour
+        if (today.getHours() < rolloverHour) today.setDate(today.getDate() - 1);
+        const dailyStatsDate = today.toISOString().split("T")[0]!;
 
-      // Record undo entry
-      const answerLabel = answer.charAt(0).toUpperCase() + answer.slice(1);
-      pushUndo({
-        type: "review",
-        description: `Answer ${answerLabel}`,
-        undoData: {
-          cardId: reviewCard.cardId,
-          previousState,
-          newState: JSON.parse(JSON.stringify(updatedState)),
-          reviewLogTimestamp,
-          wasNew,
-          dailyStatsDate,
-          reviewTimeMs,
-        },
-      });
+        const reviewTimeMs = Date.now() - reviewStartTime.value;
+        const reviewLogTimestamp = Date.now();
+        const updatedState = await queue.processReview(reviewCard, answer, reviewTimeMs);
 
-      updateDueCardsAfterReview(reviewCard.cardId, updatedState);
-      moveToNextReviewCard();
-      markDataChanged();
+        // Record undo entry
+        const answerLabel = answer.charAt(0).toUpperCase() + answer.slice(1);
+        pushUndo({
+          type: "review",
+          description: `Answer ${answerLabel}`,
+          undoData: {
+            cardId: reviewCard.cardId,
+            previousState,
+            newState: JSON.parse(JSON.stringify(updatedState)),
+            reviewLogTimestamp,
+            wasNew,
+            dailyStatsDate,
+            reviewTimeMs,
+          },
+        });
+
+        updateDueCardsAfterReview(reviewCard.cardId, updatedState);
+        moveToNextReviewCard();
+        markDataChanged();
+      }
     }
   } else {
     moveToNextCard();
@@ -455,7 +470,19 @@ onUnmounted(clearAutoAdvanceTimer);
   <main v-else>
     <div class="layout-center-column">
       <template v-if="renderedCard">
-        <div v-if="selectedDeckName" class="deck-header">
+        <div v-if="activeFilteredDeckSig" class="filtered-deck-header">
+          <span class="filtered-deck-name">
+            <svg class="filtered-deck-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+            </svg>
+            {{ activeFilteredDeckSig.name }}
+            <span v-if="!activeFilteredDeckSig.reschedule" class="cram-badge">Cram</span>
+          </span>
+          <button class="filtered-deck-close" @click="emptyFilteredDeck(activeFilteredDeckSig.id); reviewModeSig = 'deck-list'">
+            &times;
+          </button>
+        </div>
+        <div v-else-if="selectedDeckName" class="deck-header">
           <Tooltip :text="selectedDeckDescription ?? 'No description'">
             <button class="deck-info-btn" @click="deckInfoModalOpen = true">
               <Info :size="16" />
@@ -643,6 +670,62 @@ main {
   gap: var(--spacing-1-5);
   color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
+}
+
+.filtered-deck-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-2);
+}
+
+.filtered-deck-name {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1-5);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.filtered-deck-icon {
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.cram-badge {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-warning, #f59e0b);
+  background: var(--color-warning-alpha, rgba(245, 158, 11, 0.1));
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.filtered-deck-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: var(--font-size-lg);
+  color: var(--color-text-tertiary);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  box-shadow: none;
+}
+
+.filtered-deck-close:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover);
 }
 
 .no-deck-message {

--- a/src/components/CardBrowser.vue
+++ b/src/components/CardBrowser.vue
@@ -26,6 +26,15 @@ import { reviewDB } from "../scheduler/db";
 import { QUEUE_USER_BURIED, QUEUE_SUSPENDED } from "../lib/syncWrite";
 import { markDataChanged } from "../lib/autoSync";
 import { triggerRef } from "vue";
+import {
+  parseSearch as _parseSearch,
+  matchExpr as _matchExpr,
+  IS_VALUES,
+  QUALIFIERS,
+  type SearchLeaf,
+  type SearchExpr,
+  type SearchableCard,
+} from "../search/engine";
 
 type ViewMode = "cards" | "notes";
 const viewMode = ref<ViewMode>("notes");
@@ -329,220 +338,15 @@ const allNoteTypes = computed(() => {
   return Array.from(names).sort();
 });
 
-// ── Search parsing ──
+// ── Search parsing (delegated to src/search/engine.ts) ──
 
-type SearchLeaf =
-  | { type: "text"; value: string }
-  | { type: "deck"; value: string }
-  | { type: "tag"; value: string }
-  | { type: "is"; value: string }
-  | { type: "flag"; value: number }
-  | { type: "card"; value: string }
-  | { type: "note"; value: string }
-  | { type: "prop"; prop: string; op: ">" | "<" | ">=" | "<=" | "=" | "!="; value: number }
-  | { type: "added"; days: number }
-  | { type: "edited"; days: number }
-  | { type: "rated"; days: number };
-
-type SearchExpr =
-  | SearchLeaf
-  | { type: "negate"; inner: SearchExpr }
-  | { type: "and"; left: SearchExpr; right: SearchExpr }
-  | { type: "or"; left: SearchExpr; right: SearchExpr };
-
-const IS_VALUES = ["new", "learn", "review", "due", "suspended", "buried"] as const;
 const FLAG_VALUES = computed(() => [
   { value: 0, label: "none" },
   ...getFlags().map((f) => ({ value: f.flag, label: f.label.toLowerCase() })),
 ]);
 
-const QUALIFIERS = [
-  "deck:", "tag:", "is:", "flag:", "card:", "note:",
-  "prop:", "added:", "edited:", "rated:",
-] as const;
-
-// ── Lexer ──
-
-type LexToken =
-  | { kind: "term"; value: SearchExpr }
-  | { kind: "or" }
-  | { kind: "lparen" }
-  | { kind: "rparen" };
-
-function parseQualifiedTerm(word: string): SearchLeaf {
-  const colonIdx = word.indexOf(":");
-  if (colonIdx === -1) return { type: "text", value: word };
-
-  const qualifier = word.slice(0, colonIdx).toLowerCase();
-  const val = word.slice(colonIdx + 1);
-
-  switch (qualifier) {
-    case "deck":
-      return { type: "deck", value: val };
-    case "tag":
-      return { type: "tag", value: val };
-    case "is":
-      return { type: "is", value: val.toLowerCase() };
-    case "flag": {
-      const parsed = parseInt(val, 10);
-      if (!isNaN(parsed)) return { type: "flag", value: parsed };
-      const m = FLAG_VALUES.value.find((f) => f.label.toLowerCase() === val.toLowerCase());
-      return { type: "flag", value: m?.value ?? 0 };
-    }
-    case "card":
-      return { type: "card", value: val };
-    case "note":
-      return { type: "note", value: val };
-    case "prop": {
-      const opMatch = val.match(/^(ease|ivl|due|reps|lapses)(>=|<=|!=|>|<|=)(.+)$/);
-      if (!opMatch) return { type: "text", value: word };
-      const num = parseFloat(opMatch[3]!);
-      if (isNaN(num)) return { type: "text", value: word };
-      return {
-        type: "prop",
-        prop: opMatch[1]!,
-        op: opMatch[2]! as SearchLeaf & { type: "prop" } extends { op: infer O } ? O : never,
-        value: num,
-      };
-    }
-    case "added":
-      return { type: "added", days: parseInt(val, 10) || 1 };
-    case "edited":
-      return { type: "edited", days: parseInt(val, 10) || 1 };
-    case "rated":
-      return { type: "rated", days: parseInt(val, 10) || 1 };
-    default:
-      return { type: "text", value: word };
-  }
-}
-
-function lex(query: string): LexToken[] {
-  const tokens: LexToken[] = [];
-  let i = 0;
-  const len = query.length;
-
-  while (i < len) {
-    const ch = query[i]!;
-    if (ch === " " || ch === "\t") {
-      i++;
-      continue;
-    }
-    if (ch === "(") {
-      tokens.push({ kind: "lparen" });
-      i++;
-      continue;
-    }
-    if (ch === ")") {
-      tokens.push({ kind: "rparen" });
-      i++;
-      continue;
-    }
-
-    // Check for OR keyword
-    if (
-      (ch === "O" || ch === "o") &&
-      i + 1 < len &&
-      (query[i + 1] === "R" || query[i + 1] === "r") &&
-      (i + 2 >= len || " ()\t".includes(query[i + 2]!))
-    ) {
-      tokens.push({ kind: "or" });
-      i += 2;
-      continue;
-    }
-
-    // Parse a term (possibly negated)
-    const negate = ch === "-" && i + 1 < len && query[i + 1] !== " ";
-    if (negate) i++;
-
-    let leaf: SearchLeaf;
-    if (i < len && query[i] === '"') {
-      // Quoted string
-      i++;
-      const start = i;
-      while (i < len && query[i] !== '"') i++;
-      leaf = { type: "text", value: query.slice(start, i) };
-      if (i < len) i++; // skip closing quote
-    } else {
-      // Unquoted word — but qualifier values may contain quoted portions (e.g. deck:"My Deck")
-      const start = i;
-      while (i < len && !" ()\t".includes(query[i]!)) {
-        if (query[i] === '"') {
-          // scan to closing quote
-          i++;
-          while (i < len && query[i] !== '"') i++;
-          if (i < len) i++; // skip closing quote
-        } else {
-          i++;
-        }
-      }
-      const word = query.slice(start, i);
-      // Strip quotes from qualifier values: deck:"My Deck" → deck:My Deck
-      const stripped = word.replace(/"/g, "");
-      leaf = parseQualifiedTerm(stripped);
-    }
-
-    tokens.push({ kind: "term", value: negate ? { type: "negate", inner: leaf } : leaf });
-  }
-
-  return tokens;
-}
-
-// ── Recursive descent parser ──
-// Grammar:
-//   expr    = andExpr (OR andExpr)*
-//   andExpr = unary unary*          (implicit AND)
-//   unary   = LPAREN expr RPAREN | term
-
-function parseSearch(query: string): SearchExpr | null {
-  const lexTokens = lex(query);
-  if (lexTokens.length === 0) return null;
-
-  let pos = 0;
-
-  function peek(): LexToken | undefined {
-    return lexTokens[pos];
-  }
-  function advance(): LexToken {
-    return lexTokens[pos++]!;
-  }
-
-  function parseExpr(): SearchExpr {
-    let left = parseAndExpr();
-    while (peek()?.kind === "or") {
-      advance();
-      const right = parseAndExpr();
-      left = { type: "or", left, right };
-    }
-    return left;
-  }
-
-  function parseAndExpr(): SearchExpr {
-    let left = parseUnary();
-    while (peek() && peek()!.kind !== "or" && peek()!.kind !== "rparen") {
-      const right = parseUnary();
-      left = { type: "and", left, right };
-    }
-    return left;
-  }
-
-  function parseUnary(): SearchExpr {
-    const tok = peek();
-    if (tok?.kind === "lparen") {
-      advance();
-      const expr = parseExpr();
-      if (peek()?.kind === "rparen") advance();
-      return expr;
-    }
-    if (tok?.kind === "term") {
-      advance();
-      return tok.value;
-    }
-    // Fallback for unexpected tokens
-    advance();
-    return { type: "text", value: "" };
-  }
-
-  return parseExpr();
+function parseSearch(query: string) {
+  return _parseSearch(query);
 }
 
 // ── Autocomplete ──
@@ -954,147 +758,52 @@ function formatInterval(ivl: number, unit: string): string {
   return `${(ivl / 365).toFixed(1)}y`;
 }
 
-// ── Filtering ──
+// ── Filtering (delegated to search engine, with Row adapter) ──
 
-function compareNumeric(actual: number, op: string, target: number): boolean {
-  switch (op) {
-    case ">":
-      return actual > target;
-    case "<":
-      return actual < target;
-    case ">=":
-      return actual >= target;
-    case "<=":
-      return actual <= target;
-    case "=":
-      return actual === target;
-    case "!=":
-      return actual !== target;
-    default:
-      return false;
+function rowToSearchable(row: Row): SearchableCard {
+  if (row.kind === "card") {
+    return {
+      fields: row.fields,
+      deck: row.deck,
+      tags: row.tags,
+      templateName: row.templateName,
+      queueName: row.queueName,
+      flags: row.flags,
+      rawEase: row.rawEase,
+      rawIvl: row.rawIvl,
+      rawDue: row.rawDue,
+      rawDueType: row.rawDueType,
+      cardCreatedMs: row.cardCreatedMs,
+      noteModSec: row.noteModSec,
+      cardModSec: row.cardModSec,
+      reps: row.reps,
+      lapses: row.lapses,
+    };
   }
-}
-
-function getDueDaysFromNow(row: CardRow): number | null {
-  if (row.rawDueType === "position") return null;
-  if (row.rawDueType === "timestamp") {
-    return (row.rawDue - Date.now() / 1000) / 86400;
-  }
-  // dayOffset or dayLearningOffset: due is days since collection creation
-  const data = ankiDataSig.value;
-  if (!data) return null;
-  const todayDay = Math.floor((Date.now() / 1000 - data.collectionCreationTime) / 86400);
-  return row.rawDue - todayDay;
-}
-
-function matchProp(row: Row, expr: SearchLeaf & { type: "prop" }): boolean {
-  if (row.kind === "note") return false;
-  let actual: number | null;
-  switch (expr.prop) {
-    case "ease":
-      actual = row.rawEase;
-      break;
-    case "ivl":
-      actual = row.rawIvl;
-      break;
-    case "due":
-      actual = getDueDaysFromNow(row);
-      break;
-    case "reps":
-      actual = row.reps;
-      break;
-    case "lapses":
-      actual = row.lapses;
-      break;
-    default:
-      return false;
-  }
-  if (actual == null) return false;
-  return compareNumeric(actual, expr.op, expr.value);
-}
-
-function matchDateRange(row: Row, field: "added" | "edited" | "rated", days: number): boolean {
-  const cutoffMs = Date.now() - days * 86400_000;
-  switch (field) {
-    case "added":
-      return row.cardCreatedMs > 0 && row.cardCreatedMs >= cutoffMs;
-    case "edited":
-      return row.noteModSec > 0 && row.noteModSec * 1000 >= cutoffMs;
-    case "rated": {
-      if (row.kind === "note") return false;
-      return row.cardModSec > 0 && row.cardModSec * 1000 >= cutoffMs;
-    }
-  }
+  // NoteRow — card-specific fields default to zero/empty since note rows can't match card filters
+  return {
+    fields: row.fields,
+    deck: row.deck,
+    tags: row.tags,
+    templateName: "",
+    templateNames: row.templateNames,
+    queueName: "",
+    flags: 0,
+    rawEase: null,
+    rawIvl: 0,
+    rawDue: 0,
+    rawDueType: "position",
+    cardCreatedMs: row.cardCreatedMs,
+    noteModSec: row.noteModSec,
+    cardModSec: 0,
+    reps: 0,
+    lapses: 0,
+  };
 }
 
 function matchExpr(row: Row, expr: SearchExpr): boolean {
-  switch (expr.type) {
-    case "negate":
-      return !matchExpr(row, expr.inner);
-    case "and":
-      return matchExpr(row, expr.left) && matchExpr(row, expr.right);
-    case "or":
-      return matchExpr(row, expr.left) || matchExpr(row, expr.right);
-    case "text": {
-      const q = expr.value.toLowerCase();
-      if (!q) return true;
-      for (const v of Object.values(row.fields)) {
-        if (v.toLowerCase().includes(q)) return true;
-      }
-      if (row.deck.toLowerCase().includes(q)) return true;
-      if (row.tags.some((t) => t.toLowerCase().includes(q))) return true;
-      if (row.kind === "card" && row.templateName.toLowerCase().includes(q)) return true;
-      if (row.kind === "note" && row.templateNames.toLowerCase().includes(q)) return true;
-      return false;
-    }
-    case "deck": {
-      const v = expr.value.toLowerCase();
-      const deck = row.deck.toLowerCase();
-      return deck === v || deck.startsWith(v + "::");
-    }
-    case "tag": {
-      const v = expr.value.toLowerCase();
-      return row.tags.some((t) => t.toLowerCase() === v || t.toLowerCase().startsWith(v + "::"));
-    }
-    case "is": {
-      if (row.kind === "note") return false;
-      const q = row.queueName;
-      switch (expr.value) {
-        case "new":
-          return q === "new";
-        case "learn":
-          return q === "learning" || q === "dayLearning";
-        case "review":
-          return q === "review";
-        case "due":
-          return q === "review" || q === "learning" || q === "dayLearning";
-        case "suspended":
-          return q === "suspended";
-        case "buried":
-          return q === "userBuried" || q === "schedulerBuried";
-        default:
-          return false;
-      }
-    }
-    case "flag": {
-      if (row.kind === "note") return false;
-      return row.flags === expr.value;
-    }
-    case "card":
-    case "note": {
-      const v = expr.value.toLowerCase();
-      if (row.kind === "card") return row.templateName.toLowerCase().includes(v);
-      return row.templateNames.toLowerCase().includes(v);
-    }
-    case "prop":
-      return matchProp(row, expr);
-    case "added":
-      return matchDateRange(row, "added", expr.days);
-    case "edited":
-      return matchDateRange(row, "edited", expr.days);
-    case "rated":
-      return matchDateRange(row, "rated", expr.days);
-  }
+  const collectionTime = ankiDataSig.value?.collectionCreationTime ?? 0;
+  return _matchExpr(rowToSearchable(row), expr, collectionTime);
 }
 
 /** Filtered + sorted rows */

--- a/src/components/CongratsScreen.vue
+++ b/src/components/CongratsScreen.vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import {
   reviewQueueSig,
   fullQueueSig,
   reviewModeSig,
+  activeFilteredDeckIdSig,
+  activeFilteredDeckSig,
+  emptyFilteredDeck,
+  rebuildFilteredDeck,
+  createFilteredDeck,
 } from "../stores";
 import { Button } from "../design-system";
+import CustomStudyModal from "./CustomStudyModal.vue";
+import FilteredDeckModal from "./FilteredDeckModal.vue";
 
 const stats = computed(() => {
   const queue = reviewQueueSig.value;
@@ -46,6 +53,28 @@ const reviewed = computed(() => {
   if (!stats.value) return 0;
   return stats.value.newCount + stats.value.reviewCount;
 });
+
+const isFilteredDeck = computed(() => activeFilteredDeckIdSig.value !== null);
+const filteredDeck = computed(() => activeFilteredDeckSig.value);
+
+const customStudyOpen = ref(false);
+const filteredDeckModalOpen = ref(false);
+const filteredDeckPreset = ref<{ name: string; query: string; reschedule: boolean } | null>(null);
+
+function handleCustomStudyCreate(preset: { name: string; query: string; reschedule: boolean }) {
+  filteredDeckPreset.value = preset;
+  filteredDeckModalOpen.value = true;
+}
+
+function handleEmptyDeck() {
+  const id = activeFilteredDeckIdSig.value;
+  if (id) emptyFilteredDeck(id);
+}
+
+function handleRebuild() {
+  const id = activeFilteredDeckIdSig.value;
+  if (id) rebuildFilteredDeck(id);
+}
 </script>
 
 <template>
@@ -70,11 +99,38 @@ const reviewed = computed(() => {
       </dl>
 
       <div class="congrats-actions">
+        <template v-if="isFilteredDeck">
+          <Button variant="secondary" @click="handleRebuild">
+            Rebuild Deck
+          </Button>
+          <Button variant="secondary" @click="handleEmptyDeck">
+            Empty Deck
+          </Button>
+        </template>
+        <template v-else>
+          <Button variant="secondary" @click="customStudyOpen = true">
+            Custom Study
+          </Button>
+        </template>
         <Button variant="secondary" @click="reviewModeSig = 'deck-list'">
           Back to Decks
         </Button>
       </div>
     </div>
+
+    <CustomStudyModal
+      :is-open="customStudyOpen"
+      @close="customStudyOpen = false"
+      @create-filtered="handleCustomStudyCreate"
+    />
+
+    <FilteredDeckModal
+      :is-open="filteredDeckModalOpen"
+      :initial-name="filteredDeckPreset?.name"
+      :initial-query="filteredDeckPreset?.query"
+      :initial-reschedule="filteredDeckPreset?.reschedule"
+      @close="filteredDeckModalOpen = false"
+    />
   </div>
 </template>
 

--- a/src/components/CustomStudyModal.vue
+++ b/src/components/CustomStudyModal.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { Button, Modal } from "../design-system";
+import { ankiDataSig, selectedDeckIdSig } from "../stores";
+
+const props = defineProps<{
+  isOpen: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "close"): void;
+  (e: "create-filtered", payload: {
+    name: string;
+    query: string;
+    reschedule: boolean;
+  }): void;
+}>();
+
+const currentDeckName = computed(() => {
+  const data = ankiDataSig.value;
+  const deckId = selectedDeckIdSig.value;
+  if (!data || !deckId) return null;
+  return data.decks[deckId]?.name ?? null;
+});
+
+const deckFilter = computed(() => {
+  const name = currentDeckName.value;
+  if (!name) return "";
+  return name.includes(" ") ? `deck:"${name}"` : `deck:${name}`;
+});
+
+type Preset = {
+  label: string;
+  description: string;
+  getQuery: () => string;
+  reschedule: boolean;
+};
+
+const reviewAheadDays = ref(1);
+
+const presets = computed<Preset[]>(() => {
+  const df = deckFilter.value;
+  const ahead = reviewAheadDays.value;
+  return [
+    {
+      label: "Review forgotten cards",
+      description: "Study cards you answered Again on recently",
+      getQuery: () => df ? `rated:7:1 ${df}` : "rated:7:1",
+      reschedule: true,
+    },
+    {
+      label: "Review ahead",
+      description: `Preview cards due in the next ${ahead} day${ahead === 1 ? "" : "s"}`,
+      getQuery: () => {
+        const base = `prop:due>0 prop:due<=${ahead}`;
+        return df ? `${base} ${df}` : base;
+      },
+      reschedule: false,
+    },
+    {
+      label: "Preview new cards",
+      description: "Study new cards without affecting scheduling",
+      getQuery: () => df ? `is:new ${df}` : "is:new",
+      reschedule: false,
+    },
+    {
+      label: "Study by state: due",
+      description: "Review all cards that are currently due",
+      getQuery: () => df ? `is:due ${df}` : "is:due",
+      reschedule: true,
+    },
+    {
+      label: "Cram all cards",
+      description: "Study all cards in the deck without rescheduling",
+      getQuery: () => df || "*",
+      reschedule: false,
+    },
+  ];
+});
+
+function selectPreset(preset: Preset) {
+  const dn = currentDeckName.value ?? "Filtered";
+  emit("create-filtered", {
+    name: `${preset.label} – ${dn}`,
+    query: preset.getQuery(),
+    reschedule: preset.reschedule,
+  });
+  emit("close");
+}
+</script>
+
+<template>
+  <Modal :is-open="isOpen" title="Custom Study" size="sm" @close="emit('close')">
+    <div class="custom-study">
+      <p v-if="currentDeckName" class="deck-context">
+        Deck: <strong>{{ currentDeckName }}</strong>
+      </p>
+
+      <div class="preset-list">
+        <button
+          v-for="(preset, i) in presets"
+          :key="i"
+          class="preset-btn"
+          @click="selectPreset(preset)"
+        >
+          <span class="preset-label">{{ preset.label }}</span>
+          <span class="preset-desc">{{ preset.description }}</span>
+        </button>
+      </div>
+
+      <div v-if="presets.some((p) => p.label.includes('ahead'))" class="ahead-config">
+        <label class="ahead-label">
+          Review ahead days:
+          <input
+            v-model.number="reviewAheadDays"
+            type="number"
+            min="1"
+            max="30"
+            class="ahead-input"
+          />
+        </label>
+      </div>
+
+      <div class="custom-study-footer">
+        <Button variant="secondary" @click="emit('close')">Cancel</Button>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<style scoped>
+.custom-study {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.deck-context {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.preset-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.preset-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-1);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+  transition: var(--transition-colors);
+  font-family: inherit;
+  width: 100%;
+}
+
+.preset-btn:hover {
+  background: var(--color-surface-hover);
+  border-color: var(--color-border-hover);
+}
+
+.preset-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.preset-desc {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+}
+
+.ahead-config {
+  padding: var(--spacing-2) 0;
+}
+
+.ahead-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.ahead-input {
+  width: 60px;
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+}
+
+.custom-study-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+</style>

--- a/src/components/FileLibrary.vue
+++ b/src/components/FileLibrary.vue
@@ -19,8 +19,15 @@ import {
   adoptSampleDeck,
   removeAdoptedSample,
   SAMPLE_COLLECTION_ID,
+  filteredDecksSig,
+  studyFilteredDeck,
+  rebuildFilteredDeck,
+  deleteFilteredDeck,
+  countFilteredDeckCards,
+  ankiDataSig,
 } from "../stores";
 import type { DeckTreeNode } from "../types";
+import FilteredDeckModal from "./FilteredDeckModal.vue";
 
 const fileInput = ref<HTMLInputElement>();
 
@@ -96,6 +103,21 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
   // Compute the card count for this deck to match the storage key used by initializeReviewQueue
   openDeckSettings(`deck-${node.cardCount}`, node);
 }
+
+// Filtered decks
+const filteredDeckModalOpen = ref(false);
+
+const filteredDecksWithCounts = computed(() =>
+  filteredDecksSig.value.map((d) => ({
+    ...d,
+    matchCount: countFilteredDeckCards(d.query),
+  })),
+);
+
+function handleDeleteFiltered(id: string, event: Event) {
+  event.stopPropagation();
+  deleteFilteredDeck(id);
+}
 </script>
 
 <template>
@@ -111,6 +133,55 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
       />
       <Button variant="primary" size="sm" @click="fileInput?.click()"> Add File </Button>
     </div>
+
+    <!-- Filtered Decks -->
+    <section v-if="ankiDataSig && filteredDecksWithCounts.length > 0" class="library-section">
+      <div class="section-header">
+        <h3 class="section-title">Filtered Decks</h3>
+        <span class="section-count">{{ filteredDecksWithCounts.length }}</span>
+      </div>
+      <div class="file-grid">
+        <div
+          v-for="fd in filteredDecksWithCounts"
+          :key="fd.id"
+          class="file-card file-card--filtered"
+          @click="studyFilteredDeck(fd.id)"
+        >
+          <div class="file-info">
+            <span class="file-name">
+              <svg class="filtered-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+              </svg>
+              {{ fd.name }}
+            </span>
+            <span class="file-meta">{{ fd.matchCount }} card{{ fd.matchCount === 1 ? "" : "s" }} · {{ fd.reschedule ? "Normal" : "Cram" }}</span>
+          </div>
+          <div class="filtered-actions">
+            <button
+              class="filtered-action-btn"
+              title="Rebuild"
+              @click.stop="rebuildFilteredDeck(fd.id)"
+            >&#8635;</button>
+            <button
+              class="delete-btn"
+              title="Delete"
+              @click.stop="handleDeleteFiltered(fd.id, $event)"
+            >&times;</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div v-if="ankiDataSig" class="create-filtered-row">
+      <Button variant="secondary" size="sm" @click="filteredDeckModalOpen = true">
+        Create Filtered Deck
+      </Button>
+    </div>
+
+    <FilteredDeckModal
+      :is-open="filteredDeckModalOpen"
+      @close="filteredDeckModalOpen = false"
+    />
 
     <section
       v-if="(syncActiveSig || isSampleCollectionActive) && deckInfoSig"
@@ -608,5 +679,52 @@ function handleOpenSettings(node: DeckTreeNode, event: Event) {
   outline: 2px solid var(--color-primary);
   outline-offset: -2px;
   color: var(--color-text-primary);
+}
+
+/* Filtered decks */
+.create-filtered-row {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--spacing-4);
+  margin-bottom: var(--spacing-2);
+}
+
+.file-card--filtered {
+  border-left: 3px solid var(--color-primary);
+}
+
+.filtered-icon {
+  vertical-align: -2px;
+  margin-right: var(--spacing-1);
+  color: var(--color-primary);
+}
+
+.filtered-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  flex-shrink: 0;
+}
+
+.filtered-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  font-size: var(--font-size-lg);
+  color: var(--color-text-tertiary);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition-colors);
+  box-shadow: none;
+}
+
+.filtered-action-btn:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover);
 }
 </style>

--- a/src/components/FilteredDeckModal.vue
+++ b/src/components/FilteredDeckModal.vue
@@ -1,0 +1,222 @@
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import { Button, Modal } from "../design-system";
+import {
+  ankiDataSig,
+  countFilteredDeckCards,
+  createFilteredDeck,
+} from "../stores";
+import type { FilteredDeckSortOrder } from "../scheduler/types";
+
+const props = defineProps<{
+  isOpen: boolean;
+  /** Pre-fill the query (from custom study presets) */
+  initialQuery?: string;
+  /** Pre-fill the deck name */
+  initialName?: string;
+  /** Pre-fill reschedule mode */
+  initialReschedule?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "close"): void;
+}>();
+
+const name = ref("Filtered Deck 1");
+const query = ref("");
+const limit = ref(100);
+const sortOrder = ref<FilteredDeckSortOrder>("random");
+const reschedule = ref(true);
+const creating = ref(false);
+
+watch(
+  () => props.isOpen,
+  (open) => {
+    if (open) {
+      name.value = props.initialName ?? "Filtered Deck 1";
+      query.value = props.initialQuery ?? "";
+      limit.value = 100;
+      sortOrder.value = "random";
+      reschedule.value = props.initialReschedule ?? true;
+      creating.value = false;
+    }
+  },
+);
+
+const previewCount = computed(() => {
+  if (!query.value.trim()) return ankiDataSig.value?.cards.length ?? 0;
+  return countFilteredDeckCards(query.value);
+});
+
+const effectiveCount = computed(() => Math.min(previewCount.value, limit.value));
+
+const canCreate = computed(
+  () => name.value.trim() && query.value.trim() && effectiveCount.value > 0 && !creating.value,
+);
+
+async function handleCreate() {
+  if (!canCreate.value) return;
+  creating.value = true;
+  try {
+    await createFilteredDeck({
+      name: name.value.trim(),
+      query: query.value.trim(),
+      limit: limit.value,
+      sortOrder: sortOrder.value,
+      reschedule: reschedule.value,
+    });
+    emit("close");
+  } finally {
+    creating.value = false;
+  }
+}
+
+const SORT_OPTIONS: { value: FilteredDeckSortOrder; label: string }[] = [
+  { value: "random", label: "Random" },
+  { value: "orderAdded", label: "Order added" },
+  { value: "orderDue", label: "Order due" },
+  { value: "intervalAsc", label: "Interval (ascending)" },
+  { value: "intervalDesc", label: "Interval (descending)" },
+  { value: "easeAsc", label: "Ease (ascending)" },
+  { value: "easeDesc", label: "Ease (descending)" },
+  { value: "lapsesDesc", label: "Lapses (most first)" },
+];
+</script>
+
+<template>
+  <Modal :is-open="isOpen" title="Create Filtered Deck" size="md" @close="emit('close')">
+    <div class="filtered-form">
+      <label class="field">
+        <span class="field-label">Name</span>
+        <input v-model="name" type="text" class="field-input" placeholder="Filtered Deck 1" />
+      </label>
+
+      <label class="field">
+        <span class="field-label">Search query</span>
+        <input
+          v-model="query"
+          type="text"
+          class="field-input"
+          placeholder='e.g. is:due deck:Biology'
+          @keydown.enter.prevent="handleCreate"
+        />
+        <span class="field-hint">
+          {{ previewCount }} matching card{{ previewCount === 1 ? "" : "s" }}
+        </span>
+      </label>
+
+      <div class="field-row">
+        <label class="field field--half">
+          <span class="field-label">Limit</span>
+          <input v-model.number="limit" type="number" min="1" max="9999" class="field-input" />
+        </label>
+
+        <label class="field field--half">
+          <span class="field-label">Sort order</span>
+          <select v-model="sortOrder" class="field-input">
+            <option v-for="opt in SORT_OPTIONS" :key="opt.value" :value="opt.value">
+              {{ opt.label }}
+            </option>
+          </select>
+        </label>
+      </div>
+
+      <label class="field field--checkbox">
+        <input v-model="reschedule" type="checkbox" />
+        <span>Reschedule cards based on my answers</span>
+      </label>
+      <span class="field-hint" style="margin-top: -8px">
+        {{ reschedule ? "Cards will be rescheduled normally." : "Cram mode: scheduling won't change." }}
+      </span>
+
+      <div class="preview-bar">
+        Will study <strong>{{ effectiveCount }}</strong> card{{ effectiveCount === 1 ? "" : "s" }}
+      </div>
+
+      <div class="form-actions">
+        <Button variant="secondary" @click="emit('close')">Cancel</Button>
+        <Button variant="primary" :disabled="!canCreate" @click="handleCreate">
+          {{ creating ? "Creating..." : "Create" }}
+        </Button>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<style scoped>
+.filtered-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.field--half {
+  flex: 1;
+}
+
+.field--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-2);
+  cursor: pointer;
+}
+
+.field--checkbox input {
+  margin: 0;
+}
+
+.field-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+}
+
+.field-input {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+}
+
+.field-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
+}
+
+.field-hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+}
+
+.field-row {
+  display: flex;
+  gap: var(--spacing-3);
+}
+
+.preview-bar {
+  padding: var(--spacing-3);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+  padding-top: var(--spacing-2);
+}
+</style>

--- a/src/scheduler/__tests__/db.test.ts
+++ b/src/scheduler/__tests__/db.test.ts
@@ -1,7 +1,7 @@
 import "fake-indexeddb/auto";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ref, reactive } from "vue";
-import type { SchedulerSettings } from "../types";
+import type { FilteredDeckConfig, SchedulerSettings } from "../types";
 import type { CardState } from "../algorithm";
 import { DEFAULT_SCHEDULER_SETTINGS } from "../types";
 
@@ -182,6 +182,101 @@ describe("ReviewDB", () => {
       const result = await db.getSettings("deck-1");
       expect(result.algorithm).toBe("fsrs");
       expect(result.fsrsParams?.requestRetention).toBe(0.85);
+    });
+  });
+
+  describe("Filtered Decks CRUD", () => {
+    function makeFilteredDeck(overrides: Partial<FilteredDeckConfig> = {}): FilteredDeckConfig {
+      return {
+        id: "fd-1",
+        name: "Test Filtered",
+        query: "is:due",
+        limit: 100,
+        sortOrder: "random",
+        reschedule: true,
+        createdAt: Date.now(),
+        modifiedAt: Date.now(),
+        ...overrides,
+      };
+    }
+
+    it("should save and retrieve a filtered deck", async () => {
+      const config = makeFilteredDeck();
+      await db.saveFilteredDeck(config);
+
+      const result = await db.getFilteredDeck("fd-1");
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("Test Filtered");
+      expect(result!.query).toBe("is:due");
+      expect(result!.limit).toBe(100);
+      expect(result!.sortOrder).toBe("random");
+      expect(result!.reschedule).toBe(true);
+    });
+
+    it("should return null for nonexistent filtered deck", async () => {
+      const result = await db.getFilteredDeck("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("should list all filtered decks", async () => {
+      await db.saveFilteredDeck(makeFilteredDeck({ id: "fd-1", name: "Deck A" }));
+      await db.saveFilteredDeck(makeFilteredDeck({ id: "fd-2", name: "Deck B" }));
+      await db.saveFilteredDeck(makeFilteredDeck({ id: "fd-3", name: "Deck C" }));
+
+      const all = await db.getAllFilteredDecks();
+      expect(all).toHaveLength(3);
+      expect(all.map((d) => d.name).sort()).toEqual(["Deck A", "Deck B", "Deck C"]);
+    });
+
+    it("should update an existing filtered deck", async () => {
+      await db.saveFilteredDeck(makeFilteredDeck());
+
+      await db.saveFilteredDeck(makeFilteredDeck({ query: "is:new", limit: 50 }));
+
+      const result = await db.getFilteredDeck("fd-1");
+      expect(result!.query).toBe("is:new");
+      expect(result!.limit).toBe(50);
+    });
+
+    it("should delete a filtered deck", async () => {
+      await db.saveFilteredDeck(makeFilteredDeck());
+
+      await db.deleteFilteredDeck("fd-1");
+
+      const result = await db.getFilteredDeck("fd-1");
+      expect(result).toBeNull();
+
+      const all = await db.getAllFilteredDecks();
+      expect(all).toHaveLength(0);
+    });
+
+    it("should preserve different sort orders", async () => {
+      const sortOrders = [
+        "random", "orderAdded", "orderDue", "intervalAsc",
+        "intervalDesc", "easeAsc", "easeDesc", "lapsesDesc",
+      ] as const;
+
+      for (const sortOrder of sortOrders) {
+        const id = `fd-${sortOrder}`;
+        await db.saveFilteredDeck(makeFilteredDeck({ id, sortOrder }));
+        const result = await db.getFilteredDeck(id);
+        expect(result!.sortOrder).toBe(sortOrder);
+      }
+    });
+
+    it("should store reschedule=false for cram mode", async () => {
+      await db.saveFilteredDeck(makeFilteredDeck({ reschedule: false }));
+
+      const result = await db.getFilteredDeck("fd-1");
+      expect(result!.reschedule).toBe(false);
+    });
+
+    it("should be cleared by clearAll", async () => {
+      await db.saveFilteredDeck(makeFilteredDeck());
+      await db.clearAll();
+
+      const all = await db.getAllFilteredDecks();
+      expect(all).toHaveLength(0);
     });
   });
 });

--- a/src/scheduler/db.ts
+++ b/src/scheduler/db.ts
@@ -1,6 +1,7 @@
 import type {
   CardReviewState,
   DailyStats,
+  FilteredDeckConfig,
   OptionPreset,
   SchedulerSettings,
   StoredReviewLog,
@@ -9,7 +10,7 @@ import type { CardState } from "./algorithm";
 import { DEFAULT_SCHEDULER_SETTINGS } from "./types";
 
 const DB_NAME = "anki-review-db";
-const DB_VERSION = 5; // 5: added presets store
+const DB_VERSION = 6; // 6: added filteredDecks store
 
 /**
  * IndexedDB wrapper for persisting review state
@@ -115,6 +116,11 @@ class ReviewDB {
         // Store for option presets — added in v5
         if (!db.objectStoreNames.contains("presets")) {
           db.createObjectStore("presets", { keyPath: "id" });
+        }
+
+        // Store for filtered deck configs — added in v6
+        if (!db.objectStoreNames.contains("filteredDecks")) {
+          db.createObjectStore("filteredDecks", { keyPath: "id" });
         }
       };
     });
@@ -424,6 +430,35 @@ class ReviewDB {
     await this.run(["presets"], "readwrite", (tx) => tx.objectStore("presets").delete(id));
   }
 
+  // ── Filtered Decks ──
+
+  async getAllFilteredDecks(): Promise<FilteredDeckConfig[]> {
+    return this.run(["filteredDecks"], "readonly", (tx) =>
+      tx.objectStore("filteredDecks").getAll(),
+    );
+  }
+
+  async getFilteredDeck(id: string): Promise<FilteredDeckConfig | null> {
+    return this.run(
+      ["filteredDecks"],
+      "readonly",
+      (tx) => tx.objectStore("filteredDecks").get(id),
+      (r) => (r as FilteredDeckConfig | null) ?? null,
+    );
+  }
+
+  async saveFilteredDeck(config: FilteredDeckConfig): Promise<void> {
+    await this.run(["filteredDecks"], "readwrite", (tx) =>
+      tx.objectStore("filteredDecks").put(config),
+    );
+  }
+
+  async deleteFilteredDeck(id: string): Promise<void> {
+    await this.run(["filteredDecks"], "readwrite", (tx) =>
+      tx.objectStore("filteredDecks").delete(id),
+    );
+  }
+
   /**
    * Get all cards across all decks.
    */
@@ -462,6 +497,7 @@ class ReviewDB {
         "deletedNotes",
         "deletedDecks",
         "presets",
+        "filteredDecks",
       ];
       const transaction = db.transaction(stores, "readwrite");
 

--- a/src/scheduler/types.ts
+++ b/src/scheduler/types.ts
@@ -310,3 +310,38 @@ export interface StoredReviewLog {
   rating: Answer | number; // Can be Answer string or legacy number rating
   reviewLog: ReviewLogEntry; // Algorithm-specific review log data
 }
+
+/**
+ * Sort order options for filtered decks
+ */
+export type FilteredDeckSortOrder =
+  | "random"
+  | "orderAdded"
+  | "orderDue"
+  | "intervalAsc"
+  | "intervalDesc"
+  | "easeAsc"
+  | "easeDesc"
+  | "lapsesDesc";
+
+/**
+ * Configuration for a filtered (custom study) deck
+ */
+export interface FilteredDeckConfig {
+  /** Unique identifier */
+  id: string;
+  /** Display name */
+  name: string;
+  /** Search query string */
+  query: string;
+  /** Maximum cards to gather */
+  limit: number;
+  /** Sort order for gathered cards */
+  sortOrder: FilteredDeckSortOrder;
+  /** true = normal review (reschedule), false = cram mode */
+  reschedule: boolean;
+  /** Timestamp of creation */
+  createdAt: number;
+  /** Timestamp of last modification */
+  modifiedAt: number;
+}

--- a/src/search/__tests__/engine.test.ts
+++ b/src/search/__tests__/engine.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSearch,
+  matchExpr,
+  ankiCardToSearchable,
+  type SearchableCard,
+  type SearchExpr,
+} from "../engine";
+
+function makeCard(overrides: Partial<SearchableCard> = {}): SearchableCard {
+  return {
+    fields: { Front: "hello world", Back: "goodbye" },
+    deck: "Default",
+    tags: [],
+    templateName: "Basic",
+    queueName: "new",
+    flags: 0,
+    rawEase: null,
+    rawIvl: 0,
+    rawDue: 0,
+    rawDueType: "position",
+    cardCreatedMs: Date.now(),
+    noteModSec: Math.floor(Date.now() / 1000),
+    cardModSec: Math.floor(Date.now() / 1000),
+    reps: 0,
+    lapses: 0,
+    ...overrides,
+  };
+}
+
+const COLLECTION_CREATION = Math.floor(Date.now() / 1000) - 86400 * 30; // 30 days ago
+
+describe("parseSearch", () => {
+  it("returns null for empty query", () => {
+    expect(parseSearch("")).toBeNull();
+    expect(parseSearch("   ")).toBeNull();
+  });
+
+  it("parses a simple text term", () => {
+    const expr = parseSearch("hello");
+    expect(expr).toEqual({ type: "text", value: "hello" });
+  });
+
+  it("parses a quoted text term", () => {
+    const expr = parseSearch('"hello world"');
+    expect(expr).toEqual({ type: "text", value: "hello world" });
+  });
+
+  it("parses deck: qualifier", () => {
+    const expr = parseSearch("deck:Biology");
+    expect(expr).toEqual({ type: "deck", value: "Biology" });
+  });
+
+  it("parses tag: qualifier", () => {
+    const expr = parseSearch("tag:vocab");
+    expect(expr).toEqual({ type: "tag", value: "vocab" });
+  });
+
+  it("parses is: qualifier", () => {
+    const expr = parseSearch("is:new");
+    expect(expr).toEqual({ type: "is", value: "new" });
+  });
+
+  it("parses flag: qualifier with number", () => {
+    const expr = parseSearch("flag:1");
+    expect(expr).toEqual({ type: "flag", value: 1 });
+  });
+
+  it("parses prop: qualifier", () => {
+    const expr = parseSearch("prop:ease>=2.5");
+    expect(expr).toEqual({ type: "prop", prop: "ease", op: ">=", value: 2.5 });
+  });
+
+  it("parses added: qualifier", () => {
+    const expr = parseSearch("added:7");
+    expect(expr).toEqual({ type: "added", days: 7 });
+  });
+
+  it("parses negation", () => {
+    const expr = parseSearch("-is:suspended");
+    expect(expr).toEqual({
+      type: "negate",
+      inner: { type: "is", value: "suspended" },
+    });
+  });
+
+  it("parses implicit AND", () => {
+    const expr = parseSearch("is:new deck:Biology");
+    expect(expr).toEqual({
+      type: "and",
+      left: { type: "is", value: "new" },
+      right: { type: "deck", value: "Biology" },
+    });
+  });
+
+  it("parses OR", () => {
+    const expr = parseSearch("is:new OR is:due");
+    expect(expr).toEqual({
+      type: "or",
+      left: { type: "is", value: "new" },
+      right: { type: "is", value: "due" },
+    });
+  });
+
+  it("parses parenthesized groups", () => {
+    const expr = parseSearch("(is:new OR is:due) deck:Bio");
+    expect(expr).not.toBeNull();
+    expect(expr!.type).toBe("and");
+  });
+
+  it("parses deck with quoted value", () => {
+    const expr = parseSearch('deck:"My Deck"');
+    expect(expr).toEqual({ type: "deck", value: "My Deck" });
+  });
+});
+
+describe("matchExpr", () => {
+  describe("text matching", () => {
+    it("matches text in fields", () => {
+      const card = makeCard({ fields: { Front: "apple pie" } });
+      const expr = parseSearch("apple")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("does not match absent text", () => {
+      const card = makeCard({ fields: { Front: "apple pie" } });
+      const expr = parseSearch("banana")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(false);
+    });
+
+    it("matches text in deck name", () => {
+      const card = makeCard({ deck: "Biology::Cells" });
+      const expr = parseSearch("biology")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches text in tags", () => {
+      const card = makeCard({ tags: ["vocab", "chapter1"] });
+      const expr = parseSearch("vocab")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("empty text matches everything", () => {
+      const card = makeCard();
+      const expr: SearchExpr = { type: "text", value: "" };
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(true);
+    });
+  });
+
+  describe("deck: matching", () => {
+    it("matches exact deck name", () => {
+      const card = makeCard({ deck: "Biology" });
+      const expr = parseSearch("deck:Biology")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches child decks with prefix", () => {
+      const card = makeCard({ deck: "Biology::Cells" });
+      const expr = parseSearch("deck:Biology")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("does not match different deck", () => {
+      const card = makeCard({ deck: "Chemistry" });
+      const expr = parseSearch("deck:Biology")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(false);
+    });
+
+    it("case insensitive", () => {
+      const card = makeCard({ deck: "biology" });
+      const expr = parseSearch("deck:Biology")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(true);
+    });
+  });
+
+  describe("tag: matching", () => {
+    it("matches exact tag", () => {
+      const card = makeCard({ tags: ["vocab"] });
+      const expr = parseSearch("tag:vocab")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches hierarchical tag", () => {
+      const card = makeCard({ tags: ["vocab::chapter1"] });
+      const expr = parseSearch("tag:vocab")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("does not match unrelated tag", () => {
+      const card = makeCard({ tags: ["grammar"] });
+      const expr = parseSearch("tag:vocab")!;
+      expect(matchExpr(card, expr, COLLECTION_CREATION)).toBe(false);
+    });
+  });
+
+  describe("is: matching", () => {
+    it("matches is:new", () => {
+      const card = makeCard({ queueName: "new" });
+      expect(matchExpr(card, parseSearch("is:new")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches is:learn for learning cards", () => {
+      const card = makeCard({ queueName: "learning" });
+      expect(matchExpr(card, parseSearch("is:learn")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches is:learn for dayLearning cards", () => {
+      const card = makeCard({ queueName: "dayLearning" });
+      expect(matchExpr(card, parseSearch("is:learn")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches is:review", () => {
+      const card = makeCard({ queueName: "review" });
+      expect(matchExpr(card, parseSearch("is:review")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches is:due for review cards", () => {
+      const card = makeCard({ queueName: "review" });
+      expect(matchExpr(card, parseSearch("is:due")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches is:suspended", () => {
+      const card = makeCard({ queueName: "suspended" });
+      expect(matchExpr(card, parseSearch("is:suspended")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches is:buried", () => {
+      const card = makeCard({ queueName: "userBuried" });
+      expect(matchExpr(card, parseSearch("is:buried")!, COLLECTION_CREATION)).toBe(true);
+    });
+  });
+
+  describe("flag: matching", () => {
+    it("matches flag number", () => {
+      const card = makeCard({ flags: 1 });
+      expect(matchExpr(card, parseSearch("flag:1")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("does not match different flag", () => {
+      const card = makeCard({ flags: 2 });
+      expect(matchExpr(card, parseSearch("flag:1")!, COLLECTION_CREATION)).toBe(false);
+    });
+
+    it("matches flag:0 for no flag", () => {
+      const card = makeCard({ flags: 0 });
+      expect(matchExpr(card, parseSearch("flag:0")!, COLLECTION_CREATION)).toBe(true);
+    });
+  });
+
+  describe("prop: matching", () => {
+    it("matches prop:ease>=2.5", () => {
+      const card = makeCard({ rawEase: 2.5 });
+      expect(matchExpr(card, parseSearch("prop:ease>=2.5")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches prop:ivl>10", () => {
+      const card = makeCard({ rawIvl: 15 });
+      expect(matchExpr(card, parseSearch("prop:ivl>10")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("does not match when prop is below threshold", () => {
+      const card = makeCard({ rawIvl: 5 });
+      expect(matchExpr(card, parseSearch("prop:ivl>10")!, COLLECTION_CREATION)).toBe(false);
+    });
+
+    it("matches prop:reps>0", () => {
+      const card = makeCard({ reps: 5 });
+      expect(matchExpr(card, parseSearch("prop:reps>0")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("matches prop:lapses>=3", () => {
+      const card = makeCard({ lapses: 4 });
+      expect(matchExpr(card, parseSearch("prop:lapses>=3")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("returns false when ease is null", () => {
+      const card = makeCard({ rawEase: null });
+      expect(matchExpr(card, parseSearch("prop:ease>0")!, COLLECTION_CREATION)).toBe(false);
+    });
+  });
+
+  describe("added: matching", () => {
+    it("matches cards added within N days", () => {
+      const card = makeCard({ cardCreatedMs: Date.now() - 3 * 86400_000 });
+      expect(matchExpr(card, parseSearch("added:7")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("does not match cards added before N days", () => {
+      const card = makeCard({ cardCreatedMs: Date.now() - 10 * 86400_000 });
+      expect(matchExpr(card, parseSearch("added:7")!, COLLECTION_CREATION)).toBe(false);
+    });
+  });
+
+  describe("boolean logic", () => {
+    it("negation inverts match", () => {
+      const card = makeCard({ queueName: "new" });
+      expect(matchExpr(card, parseSearch("-is:new")!, COLLECTION_CREATION)).toBe(false);
+      expect(matchExpr(card, parseSearch("-is:review")!, COLLECTION_CREATION)).toBe(true);
+    });
+
+    it("AND requires both conditions", () => {
+      const card = makeCard({ queueName: "new", deck: "Biology" });
+      expect(matchExpr(card, parseSearch("is:new deck:Biology")!, COLLECTION_CREATION)).toBe(true);
+      expect(matchExpr(card, parseSearch("is:new deck:Chemistry")!, COLLECTION_CREATION)).toBe(false);
+    });
+
+    it("OR requires either condition", () => {
+      const card = makeCard({ queueName: "new" });
+      expect(matchExpr(card, parseSearch("is:new OR is:review")!, COLLECTION_CREATION)).toBe(true);
+      expect(matchExpr(card, parseSearch("is:review OR is:suspended")!, COLLECTION_CREATION)).toBe(false);
+    });
+  });
+});
+
+describe("ankiCardToSearchable", () => {
+  it("converts an anki card to SearchableCard", () => {
+    const card = {
+      values: { Front: "<b>Hello</b>", Back: "World" },
+      tags: ["vocab"],
+      templates: [{ name: "Basic" }] as any,
+      deckName: "Test",
+      guid: "abc123",
+      scheduling: {
+        queueName: "review",
+        flags: 1,
+        easeFactor: 2.5,
+        ivl: 10,
+        due: 100,
+        dueType: "dayOffset",
+        reps: 5,
+        lapses: 1,
+      } as any,
+      ankiCardId: 1234567890,
+      noteMod: 1000000,
+      cardMod: 1000001,
+    };
+
+    const searchable = ankiCardToSearchable(card);
+    expect(searchable.fields.Front).toBe("Hello"); // HTML stripped
+    expect(searchable.fields.Back).toBe("World");
+    expect(searchable.deck).toBe("Test");
+    expect(searchable.tags).toEqual(["vocab"]);
+    expect(searchable.templateName).toBe("Basic");
+    expect(searchable.queueName).toBe("review");
+    expect(searchable.flags).toBe(1);
+    expect(searchable.rawEase).toBe(2.5);
+    expect(searchable.rawIvl).toBe(10);
+    expect(searchable.reps).toBe(5);
+    expect(searchable.lapses).toBe(1);
+  });
+
+  it("handles null scheduling", () => {
+    const card = {
+      values: { Front: "Test" },
+      tags: [],
+      templates: [{ name: "Basic" }] as any,
+      deckName: "Default",
+      guid: "xyz",
+      scheduling: null,
+    };
+
+    const searchable = ankiCardToSearchable(card);
+    expect(searchable.queueName).toBe("new");
+    expect(searchable.flags).toBe(0);
+    expect(searchable.rawEase).toBeNull();
+    expect(searchable.rawIvl).toBe(0);
+    expect(searchable.reps).toBe(0);
+  });
+});

--- a/src/search/engine.ts
+++ b/src/search/engine.ts
@@ -1,0 +1,452 @@
+import { getFlags } from "../lib/flags";
+
+// ── Search AST types ──
+
+export type SearchLeaf =
+  | { type: "text"; value: string }
+  | { type: "deck"; value: string }
+  | { type: "tag"; value: string }
+  | { type: "is"; value: string }
+  | { type: "flag"; value: number }
+  | { type: "card"; value: string }
+  | { type: "note"; value: string }
+  | { type: "prop"; prop: string; op: ">" | "<" | ">=" | "<=" | "=" | "!="; value: number }
+  | { type: "added"; days: number }
+  | { type: "edited"; days: number }
+  | { type: "rated"; days: number };
+
+export type SearchExpr =
+  | SearchLeaf
+  | { type: "negate"; inner: SearchExpr }
+  | { type: "and"; left: SearchExpr; right: SearchExpr }
+  | { type: "or"; left: SearchExpr; right: SearchExpr };
+
+export const IS_VALUES = ["new", "learn", "review", "due", "suspended", "buried"] as const;
+
+export const QUALIFIERS = [
+  "deck:", "tag:", "is:", "flag:", "card:", "note:",
+  "prop:", "added:", "edited:", "rated:",
+] as const;
+
+// ── Searchable card interface ──
+
+export interface SearchableCard {
+  fields: Record<string, string>;
+  deck: string;
+  tags: string[];
+  templateName: string;
+  templateNames?: string;
+  queueName: string;
+  flags: number;
+  rawEase: number | null;
+  rawIvl: number;
+  rawDue: number;
+  rawDueType: string;
+  cardCreatedMs: number;
+  noteModSec: number;
+  cardModSec: number;
+  reps: number;
+  lapses: number;
+}
+
+// ── Lexer ──
+
+type LexToken =
+  | { kind: "term"; value: SearchExpr }
+  | { kind: "or" }
+  | { kind: "lparen" }
+  | { kind: "rparen" };
+
+function getFlagValues() {
+  return [
+    { value: 0, label: "none" },
+    ...getFlags().map((f) => ({ value: f.flag, label: f.label.toLowerCase() })),
+  ];
+}
+
+function parseQualifiedTerm(word: string): SearchLeaf {
+  const colonIdx = word.indexOf(":");
+  if (colonIdx === -1) return { type: "text", value: word };
+
+  const qualifier = word.slice(0, colonIdx).toLowerCase();
+  const val = word.slice(colonIdx + 1);
+
+  switch (qualifier) {
+    case "deck":
+      return { type: "deck", value: val };
+    case "tag":
+      return { type: "tag", value: val };
+    case "is":
+      return { type: "is", value: val.toLowerCase() };
+    case "flag": {
+      const parsed = parseInt(val, 10);
+      if (!isNaN(parsed)) return { type: "flag", value: parsed };
+      const m = getFlagValues().find((f) => f.label.toLowerCase() === val.toLowerCase());
+      return { type: "flag", value: m?.value ?? 0 };
+    }
+    case "card":
+      return { type: "card", value: val };
+    case "note":
+      return { type: "note", value: val };
+    case "prop": {
+      const opMatch = val.match(/^(ease|ivl|due|reps|lapses)(>=|<=|!=|>|<|=)(.+)$/);
+      if (!opMatch) return { type: "text", value: word };
+      const num = parseFloat(opMatch[3]!);
+      if (isNaN(num)) return { type: "text", value: word };
+      return {
+        type: "prop",
+        prop: opMatch[1]!,
+        op: opMatch[2]! as SearchLeaf & { type: "prop" } extends { op: infer O } ? O : never,
+        value: num,
+      };
+    }
+    case "added":
+      return { type: "added", days: parseInt(val, 10) || 1 };
+    case "edited":
+      return { type: "edited", days: parseInt(val, 10) || 1 };
+    case "rated":
+      return { type: "rated", days: parseInt(val, 10) || 1 };
+    default:
+      return { type: "text", value: word };
+  }
+}
+
+function lex(query: string): LexToken[] {
+  const tokens: LexToken[] = [];
+  let i = 0;
+  const len = query.length;
+
+  while (i < len) {
+    const ch = query[i]!;
+    if (ch === " " || ch === "\t") {
+      i++;
+      continue;
+    }
+    if (ch === "(") {
+      tokens.push({ kind: "lparen" });
+      i++;
+      continue;
+    }
+    if (ch === ")") {
+      tokens.push({ kind: "rparen" });
+      i++;
+      continue;
+    }
+
+    // Check for OR keyword
+    if (
+      (ch === "O" || ch === "o") &&
+      i + 1 < len &&
+      (query[i + 1] === "R" || query[i + 1] === "r") &&
+      (i + 2 >= len || " ()\t".includes(query[i + 2]!))
+    ) {
+      tokens.push({ kind: "or" });
+      i += 2;
+      continue;
+    }
+
+    // Parse a term (possibly negated)
+    const negate = ch === "-" && i + 1 < len && query[i + 1] !== " ";
+    if (negate) i++;
+
+    let leaf: SearchLeaf;
+    if (i < len && query[i] === '"') {
+      // Quoted string
+      i++;
+      const start = i;
+      while (i < len && query[i] !== '"') i++;
+      leaf = { type: "text", value: query.slice(start, i) };
+      if (i < len) i++; // skip closing quote
+    } else {
+      // Unquoted word — but qualifier values may contain quoted portions (e.g. deck:"My Deck")
+      const start = i;
+      while (i < len && !" ()\t".includes(query[i]!)) {
+        if (query[i] === '"') {
+          // scan to closing quote
+          i++;
+          while (i < len && query[i] !== '"') i++;
+          if (i < len) i++; // skip closing quote
+        } else {
+          i++;
+        }
+      }
+      const word = query.slice(start, i);
+      // Strip quotes from qualifier values: deck:"My Deck" → deck:My Deck
+      const stripped = word.replace(/"/g, "");
+      leaf = parseQualifiedTerm(stripped);
+    }
+
+    tokens.push({ kind: "term", value: negate ? { type: "negate", inner: leaf } : leaf });
+  }
+
+  return tokens;
+}
+
+// ── Recursive descent parser ──
+// Grammar:
+//   expr    = andExpr (OR andExpr)*
+//   andExpr = unary unary*          (implicit AND)
+//   unary   = LPAREN expr RPAREN | term
+
+export function parseSearch(query: string): SearchExpr | null {
+  const lexTokens = lex(query);
+  if (lexTokens.length === 0) return null;
+
+  let pos = 0;
+
+  function peek(): LexToken | undefined {
+    return lexTokens[pos];
+  }
+  function advance(): LexToken {
+    return lexTokens[pos++]!;
+  }
+
+  function parseExpr(): SearchExpr {
+    let left = parseAndExpr();
+    while (peek()?.kind === "or") {
+      advance();
+      const right = parseAndExpr();
+      left = { type: "or", left, right };
+    }
+    return left;
+  }
+
+  function parseAndExpr(): SearchExpr {
+    let left = parseUnary();
+    while (peek() && peek()!.kind !== "or" && peek()!.kind !== "rparen") {
+      const right = parseUnary();
+      left = { type: "and", left, right };
+    }
+    return left;
+  }
+
+  function parseUnary(): SearchExpr {
+    const tok = peek();
+    if (tok?.kind === "lparen") {
+      advance();
+      const expr = parseExpr();
+      if (peek()?.kind === "rparen") advance();
+      return expr;
+    }
+    if (tok?.kind === "term") {
+      advance();
+      return tok.value;
+    }
+    // Fallback for unexpected tokens
+    advance();
+    return { type: "text", value: "" };
+  }
+
+  return parseExpr();
+}
+
+// ── Matching ──
+
+function compareNumeric(actual: number, op: string, target: number): boolean {
+  switch (op) {
+    case ">":
+      return actual > target;
+    case "<":
+      return actual < target;
+    case ">=":
+      return actual >= target;
+    case "<=":
+      return actual <= target;
+    case "=":
+      return actual === target;
+    case "!=":
+      return actual !== target;
+    default:
+      return false;
+  }
+}
+
+function getDueDaysFromNow(
+  rawDue: number,
+  rawDueType: string,
+  collectionCreationTime: number,
+): number | null {
+  if (rawDueType === "position") return null;
+  if (rawDueType === "timestamp") {
+    return (rawDue - Date.now() / 1000) / 86400;
+  }
+  // dayOffset or dayLearningOffset: due is days since collection creation
+  const todayDay = Math.floor((Date.now() / 1000 - collectionCreationTime) / 86400);
+  return rawDue - todayDay;
+}
+
+function matchProp(
+  card: SearchableCard,
+  expr: SearchLeaf & { type: "prop" },
+  collectionCreationTime: number,
+): boolean {
+  let actual: number | null;
+  switch (expr.prop) {
+    case "ease":
+      actual = card.rawEase;
+      break;
+    case "ivl":
+      actual = card.rawIvl;
+      break;
+    case "due":
+      actual = getDueDaysFromNow(card.rawDue, card.rawDueType, collectionCreationTime);
+      break;
+    case "reps":
+      actual = card.reps;
+      break;
+    case "lapses":
+      actual = card.lapses;
+      break;
+    default:
+      return false;
+  }
+  if (actual == null) return false;
+  return compareNumeric(actual, expr.op, expr.value);
+}
+
+function matchDateRange(
+  card: SearchableCard,
+  field: "added" | "edited" | "rated",
+  days: number,
+): boolean {
+  const cutoffMs = Date.now() - days * 86400_000;
+  switch (field) {
+    case "added":
+      return card.cardCreatedMs > 0 && card.cardCreatedMs >= cutoffMs;
+    case "edited":
+      return card.noteModSec > 0 && card.noteModSec * 1000 >= cutoffMs;
+    case "rated":
+      return card.cardModSec > 0 && card.cardModSec * 1000 >= cutoffMs;
+  }
+}
+
+export function matchExpr(
+  card: SearchableCard,
+  expr: SearchExpr,
+  collectionCreationTime: number,
+): boolean {
+  switch (expr.type) {
+    case "negate":
+      return !matchExpr(card, expr.inner, collectionCreationTime);
+    case "and":
+      return (
+        matchExpr(card, expr.left, collectionCreationTime) &&
+        matchExpr(card, expr.right, collectionCreationTime)
+      );
+    case "or":
+      return (
+        matchExpr(card, expr.left, collectionCreationTime) ||
+        matchExpr(card, expr.right, collectionCreationTime)
+      );
+    case "text": {
+      const q = expr.value.toLowerCase();
+      if (!q) return true;
+      for (const v of Object.values(card.fields)) {
+        if (v.toLowerCase().includes(q)) return true;
+      }
+      if (card.deck.toLowerCase().includes(q)) return true;
+      if (card.tags.some((t) => t.toLowerCase().includes(q))) return true;
+      if (card.templateName.toLowerCase().includes(q)) return true;
+      if (card.templateNames && card.templateNames.toLowerCase().includes(q)) return true;
+      return false;
+    }
+    case "deck": {
+      const v = expr.value.toLowerCase();
+      const deck = card.deck.toLowerCase();
+      return deck === v || deck.startsWith(v + "::");
+    }
+    case "tag": {
+      const v = expr.value.toLowerCase();
+      return card.tags.some((t) => t.toLowerCase() === v || t.toLowerCase().startsWith(v + "::"));
+    }
+    case "is": {
+      const q = card.queueName;
+      switch (expr.value) {
+        case "new":
+          return q === "new";
+        case "learn":
+          return q === "learning" || q === "dayLearning";
+        case "review":
+          return q === "review";
+        case "due":
+          return q === "review" || q === "learning" || q === "dayLearning";
+        case "suspended":
+          return q === "suspended";
+        case "buried":
+          return q === "userBuried" || q === "schedulerBuried";
+        default:
+          return false;
+      }
+    }
+    case "flag":
+      return card.flags === expr.value;
+    case "card":
+    case "note": {
+      const v = expr.value.toLowerCase();
+      if (card.templateName.toLowerCase().includes(v)) return true;
+      if (card.templateNames && card.templateNames.toLowerCase().includes(v)) return true;
+      return false;
+    }
+    case "prop":
+      return matchProp(card, expr, collectionCreationTime);
+    case "added":
+      return matchDateRange(card, "added", expr.days);
+    case "edited":
+      return matchDateRange(card, "edited", expr.days);
+    case "rated":
+      return matchDateRange(card, "rated", expr.days);
+  }
+}
+
+// ── Helper to convert AnkiData card to SearchableCard ──
+
+function stripHtml(val: string | null | undefined): string {
+  if (!val) return "";
+  return val.replace(/<[^>]*>/g, "");
+}
+
+export function ankiCardToSearchable(
+  card: {
+    values: Record<string, string | null>;
+    tags: string[];
+    templates: { name: string }[];
+    deckName: string;
+    guid: string;
+    scheduling: {
+      queueName: string;
+      flags: number;
+      easeFactor: number | null;
+      ivl: number;
+      due: number;
+      dueType: string;
+      reps: number;
+      lapses: number;
+    } | null;
+    ankiCardId?: number;
+    noteMod?: number;
+    cardMod?: number;
+  },
+): SearchableCard {
+  const fields: Record<string, string> = {};
+  for (const [k, v] of Object.entries(card.values)) {
+    fields[k] = stripHtml(v);
+  }
+  const sched = card.scheduling;
+  return {
+    fields,
+    deck: card.deckName,
+    tags: card.tags,
+    templateName: card.templates[0]?.name ?? "",
+    queueName: sched?.queueName ?? "new",
+    flags: sched?.flags ?? 0,
+    rawEase: sched?.easeFactor ?? null,
+    rawIvl: sched?.ivl ?? 0,
+    rawDue: sched?.due ?? 0,
+    rawDueType: sched?.dueType ?? "position",
+    cardCreatedMs: card.ankiCardId ?? 0,
+    noteModSec: card.noteMod ?? 0,
+    cardModSec: card.cardMod ?? 0,
+    reps: sched?.reps ?? 0,
+    lapses: sched?.lapses ?? 0,
+  };
+}

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1501,6 +1501,228 @@ export async function importPresetJson(json: string): Promise<string | null> {
 // Load presets on startup
 loadPresets();
 
+// ── Filtered Decks (Custom Study) ──
+
+import type { FilteredDeckConfig, FilteredDeckSortOrder } from "./scheduler/types";
+import { parseSearch, matchExpr, ankiCardToSearchable } from "./search/engine";
+
+export const filteredDecksSig = ref<FilteredDeckConfig[]>([]);
+export const activeFilteredDeckIdSig = ref<string | null>(null);
+
+export const activeFilteredDeckSig = computed(() => {
+  const id = activeFilteredDeckIdSig.value;
+  if (!id) return null;
+  return filteredDecksSig.value.find((d) => d.id === id) ?? null;
+});
+
+async function loadFilteredDecks(): Promise<void> {
+  filteredDecksSig.value = await reviewDB.getAllFilteredDecks();
+}
+
+/**
+ * Count cards matching a filtered deck query (for preview).
+ */
+export function countFilteredDeckCards(query: string): number {
+  const data = ankiDataSig.value;
+  if (!data || !query.trim()) return 0;
+  const expr = parseSearch(query);
+  if (!expr) return data.cards.length;
+  let count = 0;
+  for (let i = 0; i < data.cards.length; i++) {
+    const card = data.cards[i]!;
+    const searchable = ankiCardToSearchable(card);
+    if (matchExpr(searchable, expr, data.collectionCreationTime)) count++;
+  }
+  return count;
+}
+
+/**
+ * Gather card indices matching a filtered deck config.
+ */
+function gatherFilteredCards(config: FilteredDeckConfig): number[] {
+  const data = ankiDataSig.value;
+  if (!data) return [];
+
+  const expr = parseSearch(config.query);
+  const matching: { index: number; card: (typeof data.cards)[number] }[] = [];
+
+  for (let i = 0; i < data.cards.length; i++) {
+    const card = data.cards[i]!;
+    if (expr) {
+      const searchable = ankiCardToSearchable(card);
+      if (!matchExpr(searchable, expr, data.collectionCreationTime)) continue;
+    }
+    matching.push({ index: i, card });
+  }
+
+  // Sort
+  switch (config.sortOrder) {
+    case "random":
+      for (let i = matching.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [matching[i], matching[j]] = [matching[j]!, matching[i]!];
+      }
+      break;
+    case "orderAdded":
+      matching.sort((a, b) => (a.card.ankiCardId ?? 0) - (b.card.ankiCardId ?? 0));
+      break;
+    case "orderDue":
+      matching.sort((a, b) => (a.card.scheduling?.due ?? 0) - (b.card.scheduling?.due ?? 0));
+      break;
+    case "intervalAsc":
+      matching.sort((a, b) => (a.card.scheduling?.ivl ?? 0) - (b.card.scheduling?.ivl ?? 0));
+      break;
+    case "intervalDesc":
+      matching.sort((a, b) => (b.card.scheduling?.ivl ?? 0) - (a.card.scheduling?.ivl ?? 0));
+      break;
+    case "easeAsc":
+      matching.sort(
+        (a, b) => (a.card.scheduling?.easeFactor ?? 0) - (b.card.scheduling?.easeFactor ?? 0),
+      );
+      break;
+    case "easeDesc":
+      matching.sort(
+        (a, b) => (b.card.scheduling?.easeFactor ?? 0) - (a.card.scheduling?.easeFactor ?? 0),
+      );
+      break;
+    case "lapsesDesc":
+      matching.sort((a, b) => (b.card.scheduling?.lapses ?? 0) - (a.card.scheduling?.lapses ?? 0));
+      break;
+  }
+
+  return matching.slice(0, config.limit).map((m) => m.index);
+}
+
+/**
+ * Create a new filtered deck and start studying it.
+ */
+export async function createFilteredDeck(params: {
+  name: string;
+  query: string;
+  limit: number;
+  sortOrder: FilteredDeckSortOrder;
+  reschedule: boolean;
+}): Promise<string> {
+  const config: FilteredDeckConfig = {
+    id: `filtered-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    name: params.name,
+    query: params.query,
+    limit: params.limit,
+    sortOrder: params.sortOrder,
+    reschedule: params.reschedule,
+    createdAt: Date.now(),
+    modifiedAt: Date.now(),
+  };
+  await reviewDB.saveFilteredDeck(config);
+  filteredDecksSig.value = [...filteredDecksSig.value, config];
+  await studyFilteredDeck(config.id);
+  return config.id;
+}
+
+/**
+ * Start studying a filtered deck.
+ */
+export async function studyFilteredDeck(id: string): Promise<void> {
+  const config = filteredDecksSig.value.find((d) => d.id === id);
+  if (!config) return;
+
+  const data = ankiDataSig.value;
+  if (!data) return;
+
+  const cardIndices = gatherFilteredCards(config);
+  if (cardIndices.length === 0) {
+    activeFilteredDeckIdSig.value = id;
+    reviewModeSig.value = "studying";
+    clearReviewQueueState();
+    return;
+  }
+
+  // Build review queue for these specific cards
+  const deckId = `filtered-${id}`;
+  const settings = await reviewDB.getSettings(deckId);
+  const effectiveSettings = {
+    ...settings,
+    enabled: true,
+    // For filtered decks, remove daily limits — show all gathered cards
+    dailyNewLimit: cardIndices.length,
+    dailyReviewLimit: cardIndices.length,
+  };
+  schedulerSettingsSig.value = effectiveSettings;
+
+  const queue = new ReviewQueue(deckId, effectiveSettings);
+  await queue.init();
+
+  // Map card indices to ankiCardIds
+  const ankiCardIds: number[] = [];
+  for (const idx of cardIndices) {
+    const card = data.cards[idx]!;
+    ankiCardIds.push(card.ankiCardId ?? idx);
+  }
+
+  // Build queue with all templates = 1 since we address individual cards
+  const fullQueue = await queue.buildQueue(cardIndices.length, 1, ankiCardIds);
+
+  let dueCards: ReviewCard[];
+  if (config.reschedule) {
+    dueCards = queue.getDueCards(fullQueue);
+  } else {
+    // Cram mode: show all cards regardless of scheduling
+    dueCards = [...fullQueue];
+  }
+
+  // Patch cardIndex to match position in original ankiData.cards
+  for (let i = 0; i < dueCards.length; i++) {
+    dueCards[i] = { ...dueCards[i]!, cardIndex: cardIndices[dueCards[i]!.cardIndex] ?? 0 };
+  }
+
+  reviewQueueSig.value = queue;
+  fullQueueSig.value = fullQueue;
+  dueCardsSig.value = dueCards;
+  currentReviewCardSig.value = dueCards[0] ?? null;
+  activeFilteredDeckIdSig.value = id;
+
+  // Set selectedDeckIdSig to null so cardsSig returns all cards (filtered deck draws from all)
+  selectedDeckIdSig.value = null;
+  reviewModeSig.value = "studying";
+}
+
+/**
+ * Rebuild a filtered deck (re-run query and rebuild queue).
+ */
+export async function rebuildFilteredDeck(id: string): Promise<void> {
+  await studyFilteredDeck(id);
+}
+
+/**
+ * Empty a filtered deck (stop studying, return to deck list).
+ */
+export function emptyFilteredDeck(id: string): void {
+  if (activeFilteredDeckIdSig.value === id) {
+    activeFilteredDeckIdSig.value = null;
+    clearReviewQueueState();
+    reviewModeSig.value = "deck-list";
+  }
+}
+
+/**
+ * Delete a filtered deck permanently.
+ */
+export async function deleteFilteredDeck(id: string): Promise<void> {
+  emptyFilteredDeck(id);
+  await reviewDB.deleteFilteredDeck(id);
+  filteredDecksSig.value = filteredDecksSig.value.filter((d) => d.id !== id);
+}
+
+// Load filtered decks on startup
+loadFilteredDecks();
+
+// Clear active filtered deck when returning to deck list
+watch(reviewModeSig, (mode) => {
+  if (mode === "deck-list" && activeFilteredDeckIdSig.value) {
+    activeFilteredDeckIdSig.value = null;
+  }
+});
+
 /**
  * Bulk add a tag to multiple notes (by guid).
  * Persists to SQLite for synced collections.


### PR DESCRIPTION
## Summary

- Extract search engine from CardBrowser into reusable `src/search/engine.ts` module
- Add filtered deck creation from search queries with card count preview, sort orders, and limit
- Add custom study presets (review forgotten, review ahead, preview new, cram all)
- Support cram mode (no rescheduling) vs normal review mode
- Add rebuild/empty filtered deck operations with IndexedDB persistence
- Add filtered deck section in deck library and Custom Study button on congrats screen

Closes #111