### PR TITLE
Add image occlusion rendering support (Phase 1)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,8 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import FlashCard from "./components/FlashCard.vue";
 import CardButtons from "./components/CardButtons.vue";
 import type { Answer } from "./scheduler/types";
-import { getRenderedCardString, hasTypeAnswerField, extractExpectedAnswer } from "./utils/render";
+import { getRenderedCardString, hasTypeAnswerField, extractExpectedAnswer, replaceMediaFiles } from "./utils/render";
+import { isImageOcclusionCard, renderImageOcclusion } from "./utils/imageOcclusion";
 import { renderDiffHtml } from "./utils/typeansDiff";
 import { computeDeckInfo } from "./utils/deckInfo";
 import { pushUndo } from "./undoRedo";
@@ -170,6 +171,20 @@ const renderedCard = computed(() => {
   const card = cardsSig.value[data.cardIndex];
 
   if (!template || !card) return null;
+
+  // Image occlusion cards use a dedicated renderer
+  if (isImageOcclusionCard(card)) {
+    const cardOrd = data.templateIndex;
+    const frontSideHtml = replaceMediaFiles(
+      renderImageOcclusion({ values: card.values, cardOrd, isAnswer: false }),
+      mediaFilesSig.value,
+    );
+    const backSideHtml = replaceMediaFiles(
+      renderImageOcclusion({ values: card.values, cardOrd, isAnswer: true }),
+      mediaFilesSig.value,
+    );
+    return { frontSideHtml, backSideHtml, cardCss: card.css ?? "", isTypeAnswer: false };
+  }
 
   const frontSideHtml = getRenderedCardString({
     templateString: template.qfmt,

--- a/src/ankiParser/anki2/index.ts
+++ b/src/ankiParser/anki2/index.ts
@@ -145,6 +145,7 @@ export type AnkiDB2Data = {
     guid: string;
     scheduling: CardScheduling | null;
     noteType: number; // 0=MODEL_STD, 1=MODEL_CLOZE
+    originalStockKind?: number;
     latexSvg: boolean;
     latexPre: string;
     latexPost: string;

--- a/src/ankiParser/anki21b/index.ts
+++ b/src/ankiParser/anki21b/index.ts
@@ -46,6 +46,7 @@ export type AnkiDB21bData = {
     guid: string;
     scheduling: CardScheduling | null;
     noteType: number;
+    originalStockKind?: number;
     latexSvg: boolean;
     latexPre: string;
     latexPost: string;
@@ -287,6 +288,7 @@ export function getDataFromAnki21b(db: Database): AnkiDB21bData {
           deckName: cardDeckName,
           guid: note.guid,
           noteType: noteTypeInfo?.kind ?? 0,
+          originalStockKind: noteTypeInfo?.originalStockKind ?? 0,
           latexSvg: noteTypeInfo?.latexSvg ?? false,
           latexPre: noteTypeInfo?.latexPre ?? "",
           latexPost: noteTypeInfo?.latexPost ?? "",

--- a/src/components/CardBrowser.vue
+++ b/src/components/CardBrowser.vue
@@ -13,7 +13,8 @@ import {
   repositionNewCards,
 } from "../stores";
 import FindReplaceModal from "./FindReplaceModal.vue";
-import { getRenderedCardString } from "../utils/render";
+import { getRenderedCardString, replaceMediaFiles } from "../utils/render";
+import { isImageOcclusionCard, renderImageOcclusion } from "../utils/imageOcclusion";
 import { sanitizeHtmlForPreview } from "../utils/sanitize";
 import { playAudio } from "../utils/sound";
 import Button from "../design-system/components/primitives/Button.vue";
@@ -1292,6 +1293,14 @@ const selectedCard = computed(() => {
 const selectedPreviewFront = computed(() => {
   const card = selectedCard.value;
   if (!card || card.templates.length === 0) return null;
+  if (isImageOcclusionCard(card)) {
+    return sanitizeHtmlForPreview(
+      replaceMediaFiles(
+        renderImageOcclusion({ values: card.values, cardOrd: 0, isAnswer: false }),
+        mediaFilesSig.value,
+      ),
+    );
+  }
   const template = card.templates[0]!;
   return sanitizeHtmlForPreview(
     getRenderedCardString({
@@ -1305,6 +1314,14 @@ const selectedPreviewFront = computed(() => {
 const selectedPreviewBack = computed(() => {
   const card = selectedCard.value;
   if (!card || card.templates.length === 0) return null;
+  if (isImageOcclusionCard(card)) {
+    return sanitizeHtmlForPreview(
+      replaceMediaFiles(
+        renderImageOcclusion({ values: card.values, cardOrd: 0, isAnswer: true }),
+        mediaFilesSig.value,
+      ),
+    );
+  }
   const template = card.templates[0]!;
   if (!template.afmt) return null;
   const frontHtml = getRenderedCardString({

--- a/src/components/SandboxedCard.vue
+++ b/src/components/SandboxedCard.vue
@@ -111,6 +111,14 @@ const BASE_STYLES = `
   }
   .audio-container button svg { pointer-events: none; }
   audio { display: none; }
+  .io-container { position: relative; display: inline-block; max-width: 100%; }
+  .io-container img { display: block; max-width: 100%; height: auto; }
+  .io-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }
+  .io-mask { fill: #ffeba2; stroke: none; opacity: 0.95; }
+  .io-mask-active { fill: #ff8c00; }
+  .io-mask-reveal { fill: transparent; stroke: #4caf50; stroke-width: 2; stroke-dasharray: 6 3; }
+  .io-header { text-align: center; font-size: 1.1em; font-weight: 600; margin-bottom: 0.5rem; }
+  .io-back-extra { margin-top: 0.5rem; }
   ${TYPEANS_STYLES}
 `;
 

--- a/src/utils/__tests__/imageOcclusion.test.ts
+++ b/src/utils/__tests__/imageOcclusion.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from "vitest";
+import {
+  isImageOcclusionCard,
+  parseOcclusionShapes,
+  renderImageOcclusion,
+} from "../imageOcclusion";
+
+describe("Image Occlusion", () => {
+  describe("isImageOcclusionCard", () => {
+    it("returns true for originalStockKind === 6", () => {
+      expect(isImageOcclusionCard({ values: {}, originalStockKind: 6 })).toBe(true);
+    });
+
+    it("returns false for standard cards", () => {
+      expect(isImageOcclusionCard({ values: {}, originalStockKind: 0 })).toBe(false);
+    });
+
+    it("returns false for cloze cards", () => {
+      expect(isImageOcclusionCard({ values: {}, originalStockKind: 5 })).toBe(false);
+    });
+
+    it("returns false when originalStockKind is undefined", () => {
+      expect(isImageOcclusionCard({ values: {} })).toBe(false);
+    });
+  });
+
+  describe("parseOcclusionShapes", () => {
+    it("parses rect shapes with data-ordinal", () => {
+      const svg = `<svg viewBox="0 0 800 600">
+        <rect data-ordinal="1" x="10" y="20" width="100" height="50" fill="#ffeba2" />
+        <rect data-ordinal="2" x="200" y="100" width="80" height="60" fill="#ffeba2" />
+      </svg>`;
+      const shapes = parseOcclusionShapes(svg);
+      expect(shapes).toHaveLength(2);
+      expect(shapes[0]!.ordinal).toBe(1);
+      expect(shapes[1]!.ordinal).toBe(2);
+    });
+
+    it("parses ellipse shapes", () => {
+      const svg = `<svg viewBox="0 0 800 600">
+        <ellipse data-ordinal="1" cx="100" cy="100" rx="50" ry="30" />
+      </svg>`;
+      const shapes = parseOcclusionShapes(svg);
+      expect(shapes).toHaveLength(1);
+      expect(shapes[0]!.ordinal).toBe(1);
+      expect(shapes[0]!.svgElement).toContain("ellipse");
+    });
+
+    it("parses polygon shapes", () => {
+      const svg = `<svg viewBox="0 0 800 600">
+        <polygon data-ordinal="3" points="100,10 40,198 190,78 10,78 160,198" />
+      </svg>`;
+      const shapes = parseOcclusionShapes(svg);
+      expect(shapes).toHaveLength(1);
+      expect(shapes[0]!.ordinal).toBe(3);
+    });
+
+    it("parses path shapes", () => {
+      const svg = `<svg viewBox="0 0 800 600">
+        <path data-ordinal="1" d="M10 10 L100 100" />
+      </svg>`;
+      const shapes = parseOcclusionShapes(svg);
+      expect(shapes).toHaveLength(1);
+    });
+
+    it("ignores shapes without data-ordinal", () => {
+      const svg = `<svg viewBox="0 0 800 600">
+        <rect x="10" y="20" width="100" height="50" />
+        <rect data-ordinal="1" x="200" y="100" width="80" height="60" />
+      </svg>`;
+      const shapes = parseOcclusionShapes(svg);
+      expect(shapes).toHaveLength(1);
+      expect(shapes[0]!.ordinal).toBe(1);
+    });
+
+    it("returns empty array for empty string", () => {
+      expect(parseOcclusionShapes("")).toEqual([]);
+    });
+  });
+
+  describe("renderImageOcclusion", () => {
+    const sampleValues = {
+      "Image Occlusion": '<img src="anatomy.png">',
+      Header: "Brain Anatomy",
+      "Back Extra": "Source: Gray's Anatomy",
+      Occlusions: `<svg viewBox="0 0 800 600">
+        <rect data-ordinal="1" x="10" y="20" width="100" height="50" fill="#ffeba2" />
+        <rect data-ordinal="2" x="200" y="100" width="80" height="60" fill="#ffeba2" />
+      </svg>`,
+    };
+
+    describe("question side (front)", () => {
+      it("wraps image in io-container", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        expect(html).toContain('class="io-container"');
+        expect(html).toContain('<img src="anatomy.png">');
+      });
+
+      it("includes SVG overlay", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        expect(html).toContain('class="io-overlay"');
+        expect(html).toContain('viewBox="0 0 800 600"');
+      });
+
+      it("marks active shape with io-mask-active class", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        expect(html).toContain('class="io-mask io-mask-active"');
+      });
+
+      it("marks non-active shapes with io-mask class only", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        // The second shape (ordinal 2) should just be io-mask
+        const maskMatches = html.match(/class="io-mask"/g);
+        expect(maskMatches).not.toBeNull();
+        expect(maskMatches!.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it("includes header", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        expect(html).toContain('class="io-header"');
+        expect(html).toContain("Brain Anatomy");
+      });
+
+      it("does not include back extra on front", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        expect(html).not.toContain("io-back-extra");
+        expect(html).not.toContain("Gray's Anatomy");
+      });
+    });
+
+    describe("answer side (back)", () => {
+      it("reveals active shape with io-mask-reveal class", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: true,
+        });
+        expect(html).toContain('class="io-mask-reveal"');
+      });
+
+      it("keeps non-active shapes as masks", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: true,
+        });
+        expect(html).toContain('class="io-mask"');
+      });
+
+      it("includes back extra with hr separator", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: true,
+        });
+        expect(html).toContain('id="answer"');
+        expect(html).toContain('class="io-back-extra"');
+        expect(html).toContain("Gray's Anatomy");
+      });
+
+      it("includes header", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 0,
+          isAnswer: true,
+        });
+        expect(html).toContain("Brain Anatomy");
+      });
+    });
+
+    describe("different card ordinals", () => {
+      it("highlights second shape when cardOrd is 1", () => {
+        const html = renderImageOcclusion({
+          values: sampleValues,
+          cardOrd: 1,
+          isAnswer: false,
+        });
+        // The second rect (ordinal 2) should be active
+        const lines = html.split("\n");
+        const activeLines = lines.filter((l) => l.includes("io-mask-active"));
+        expect(activeLines).toHaveLength(1);
+        // Verify the active one has ordinal 2's attributes
+        expect(activeLines[0]).toContain('x="200"');
+      });
+    });
+
+    describe("edge cases", () => {
+      it("handles missing header gracefully", () => {
+        const values = { ...sampleValues, Header: "" };
+        const html = renderImageOcclusion({
+          values,
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        expect(html).not.toContain("io-header");
+      });
+
+      it("handles missing back extra gracefully", () => {
+        const values = { ...sampleValues, "Back Extra": "" };
+        const html = renderImageOcclusion({
+          values,
+          cardOrd: 0,
+          isAnswer: true,
+        });
+        expect(html).not.toContain("io-back-extra");
+      });
+
+      it("handles empty occlusions field", () => {
+        const values = { ...sampleValues, Occlusions: "" };
+        const html = renderImageOcclusion({
+          values,
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        expect(html).toContain("io-container");
+        expect(html).toContain("io-overlay");
+      });
+
+      it("handles case-insensitive field names", () => {
+        const values = {
+          "image occlusion": '<img src="test.png">',
+          header: "Test",
+          occlusions: `<svg viewBox="0 0 100 100"><rect data-ordinal="1" x="0" y="0" width="10" height="10" /></svg>`,
+        };
+        const html = renderImageOcclusion({
+          values,
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        expect(html).toContain('<img src="test.png">');
+        expect(html).toContain("Test");
+      });
+    });
+  });
+});

--- a/src/utils/imageOcclusion.ts
+++ b/src/utils/imageOcclusion.ts
@@ -1,0 +1,158 @@
+/**
+ * Image Occlusion rendering utilities.
+ *
+ * Handles detection and rendering of Anki image occlusion notes.
+ * IO notes have originalStockKind === 6 and contain:
+ *   - "Image Occlusion" field: <img> tag referencing the base image
+ *   - "Occlusions" field: SVG markup with shapes having data-ordinal attributes
+ *   - "Header" field: optional text above the image
+ *   - "Back Extra" field: optional text below the image on the answer side
+ */
+
+const ORIGINAL_STOCK_KIND_IMAGE_OCCLUSION = 6;
+
+/** Known field names for IO notes (case-insensitive lookup). */
+const IO_FIELD_NAMES = {
+  image: "Image Occlusion",
+  header: "Header",
+  backExtra: "Back Extra",
+  occlusions: "Occlusions",
+} as const;
+
+type CardLike = {
+  values: Record<string, string | null>;
+  originalStockKind?: number;
+};
+
+export function isImageOcclusionCard(card: CardLike): boolean {
+  return card.originalStockKind === ORIGINAL_STOCK_KIND_IMAGE_OCCLUSION;
+}
+
+/**
+ * Find a field value by name, case-insensitive.
+ */
+function getField(values: Record<string, string | null>, name: string): string {
+  // Try exact match first
+  if (values[name] != null) return values[name]!;
+  // Case-insensitive fallback
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(values)) {
+    if (key.toLowerCase() === lower && value != null) return value;
+  }
+  return "";
+}
+
+/**
+ * Parse shape elements from the Occlusions SVG field.
+ * Returns an array of shape descriptors with their ordinals.
+ */
+export function parseOcclusionShapes(
+  svgString: string,
+): { ordinal: number; svgElement: string }[] {
+  if (!svgString.trim()) return [];
+
+  const shapes: { ordinal: number; svgElement: string }[] = [];
+
+  // Match SVG shape elements with data-ordinal attributes
+  // Supports: rect, ellipse, circle, polygon, path
+  const shapeRegex =
+    /<(rect|ellipse|circle|polygon|path)\b([^>]*?)\/?>(?:<\/\1>)?/gi;
+
+  let match;
+  while ((match = shapeRegex.exec(svgString)) !== null) {
+    const fullElement = match[0];
+    const attrs = match[2] ?? "";
+
+    // Extract ordinal from data-ordinal attribute
+    const ordinalMatch = attrs.match(/data-ordinal="(\d+)"/);
+    if (!ordinalMatch) continue;
+
+    const ordinal = parseInt(ordinalMatch[1]!, 10);
+    shapes.push({ ordinal, svgElement: fullElement });
+  }
+
+  return shapes;
+}
+
+/**
+ * Extract the viewBox from the Occlusions SVG, or return a default.
+ */
+function extractViewBox(svgString: string): string | null {
+  const match = svgString.match(/viewBox="([^"]+)"/);
+  return match ? match[1]! : null;
+}
+
+/**
+ * Render an image occlusion card to HTML.
+ *
+ * @param values - The card field values
+ * @param cardOrd - The 0-based card ordinal (determines which shape is active)
+ * @param isAnswer - Whether rendering the answer (back) side
+ * @returns HTML string for the card content
+ */
+export function renderImageOcclusion({
+  values,
+  cardOrd,
+  isAnswer,
+}: {
+  values: Record<string, string | null>;
+  cardOrd: number;
+  isAnswer: boolean;
+}): string {
+  const imageHtml = getField(values, IO_FIELD_NAMES.image);
+  const header = getField(values, IO_FIELD_NAMES.header);
+  const backExtra = getField(values, IO_FIELD_NAMES.backExtra);
+  const occlusionsSvg = getField(values, IO_FIELD_NAMES.occlusions);
+
+  const activeOrdinal = cardOrd + 1; // Anki ordinals are 1-based
+  const shapes = parseOcclusionShapes(occlusionsSvg);
+  const viewBox = extractViewBox(occlusionsSvg);
+
+  // Build the SVG overlay with shapes
+  const svgShapes = shapes
+    .map(({ ordinal, svgElement }) => {
+      const isActive = ordinal === activeOrdinal;
+
+      if (isAnswer) {
+        // Answer side: active shape gets reveal styling, others stay as masks
+        if (isActive) {
+          return svgElement
+            .replace(/class="[^"]*"/, "")
+            .replace(/<(rect|ellipse|circle|polygon|path)\b/, `<$1 class="io-mask-reveal"`);
+        }
+        return svgElement
+          .replace(/class="[^"]*"/, "")
+          .replace(/<(rect|ellipse|circle|polygon|path)\b/, `<$1 class="io-mask"`);
+      } else {
+        // Question side: all shapes shown as masks, active one highlighted
+        const cssClass = isActive ? "io-mask io-mask-active" : "io-mask";
+        return svgElement
+          .replace(/class="[^"]*"/, "")
+          .replace(/<(rect|ellipse|circle|polygon|path)\b/, `<$1 class="${cssClass}"`);
+      }
+    })
+    .join("\n    ");
+
+  const viewBoxAttr = viewBox ? `viewBox="${viewBox}"` : "";
+  const svgOverlay = `<svg class="io-overlay" ${viewBoxAttr} xmlns="http://www.w3.org/2000/svg">
+    ${svgShapes}
+  </svg>`;
+
+  const parts: string[] = [];
+
+  if (header) {
+    parts.push(`<div class="io-header">${header}</div>`);
+  }
+
+  parts.push(`<div class="io-container">
+  ${imageHtml}
+  ${svgOverlay}
+</div>`);
+
+  if (isAnswer && backExtra) {
+    parts.push(`<hr id="answer">
+<div class="io-back-extra">${backExtra}</div>`);
+  }
+
+  return parts.join("\n");
+}

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -369,7 +369,7 @@ function processClozeOnly(text: string, cardOrd: number): string {
  * Performs case-insensitive and NFC-normalized matching
  * Falls back to Anki's 120-byte filename truncation if no match
  */
-function replaceMediaFiles(renderedString: string, mediaFiles: Map<string, string>) {
+export function replaceMediaFiles(renderedString: string, mediaFiles: Map<string, string>) {
   if (mediaFiles.size === 0) return renderedString;
 
   // Build a normalized lookup map for case-insensitive + NFC matching


### PR DESCRIPTION
## Summary

Addresses #107 (Phase 1 of 3).

- Propagate `originalStockKind` from protobuf notetype config through the card data pipeline (anki21b parser)
- New `src/utils/imageOcclusion.ts` with IO detection, SVG shape parsing, and overlay HTML generation
- Wire IO rendering into App.vue (review) and CardBrowser.vue (preview)
- Add IO overlay CSS to SandboxedCard iframe (masks, active highlight, reveal styling)
- 25 unit tests for IO detection, SVG parsing, and rendering