### PR TITLE
Add image occlusion mask editor and note creation (Phase 1+2)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,11 +60,13 @@ import Tooltip from "./design-system/components/primitives/Tooltip.vue";
 import { markDataChanged, startAutoSync } from "./lib/autoSync";
 import { startAutoBackup } from "./backup/autoBackup";
 import NoteEditModal from "./components/NoteEditModal.vue";
-import { updateNote } from "./stores";
+import ImageOcclusionNoteEditor from "./components/ImageOcclusionNoteEditor.vue";
+import { updateNote, isSyncedCollection, addNote, getOrCreateIONotetype, addMediaToCache, getActiveDeckId } from "./stores";
 
 const activeSide = ref<"front" | "back">("front");
 const reviewStartTime = ref<number>(Date.now());
 const editModalOpen = ref(false);
+const ioCreateModalOpen = ref(false);
 const shortcutsModalOpen = ref(false);
 const typedAnswer = ref("");
 
@@ -286,6 +288,40 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
   editModalOpen.value = false;
 }
 
+async function handleIONoteCreate(payload: { fields: Record<string, string | null>; tags: string[]; imageFile?: File }) {
+  try {
+    // Cache image file if provided
+    if (payload.imageFile) {
+      const imgField = payload.fields["Image Occlusion"] ?? "";
+      const match = imgField.match(/src="([^"]+)"/);
+      const filename = match?.[1];
+      if (filename) {
+        await addMediaToCache(new Map([[filename, payload.imageFile]]));
+      }
+    }
+
+    const ntId = await getOrCreateIONotetype();
+    const deckId = getActiveDeckId();
+
+    // Count shapes to determine number of cards
+    const occSvg = payload.fields.Occlusions ?? "";
+    const ordinals = [...occSvg.matchAll(/data-ordinal="(\d+)"/g)].map((m) => parseInt(m[1]!));
+    const numCards = ordinals.length > 0 ? Math.max(...ordinals) : 1;
+
+    await addNote({
+      notetypeId: ntId,
+      deckId,
+      fields: payload.fields,
+      tags: payload.tags,
+      numCards,
+    });
+
+    ioCreateModalOpen.value = false;
+  } catch (err) {
+    console.error("Failed to create IO note:", err);
+  }
+}
+
 // Handle 'E' key for edit - only on front side to avoid conflict with 'Easy' answer
 function handleEditKeydown(e: KeyboardEvent) {
   if (
@@ -504,6 +540,12 @@ onUnmounted(clearAutoAdvanceTimer);
             </button>
           </Tooltip>
           <span>{{ selectedDeckName }}</span>
+          <button
+            v-if="isSyncedCollection()"
+            class="deck-info-btn io-add-btn"
+            title="Add Image Occlusion Note"
+            @click="ioCreateModalOpen = true"
+          >+IO</button>
         </div>
         <FlashCard
           :active-side="activeSide"
@@ -576,6 +618,21 @@ onUnmounted(clearAutoAdvanceTimer);
     @close="editModalOpen = false"
     @save="handleNoteSave"
   />
+
+  <Modal
+    :is-open="ioCreateModalOpen"
+    title="New Image Occlusion"
+    size="xl"
+    @close="ioCreateModalOpen = false"
+  >
+    <ImageOcclusionNoteEditor
+      :card="null"
+      :media-files="mediaFilesSig"
+      :is-new="true"
+      @save="handleIONoteCreate"
+      @close="ioCreateModalOpen = false"
+    />
+  </Modal>
 
   <Modal
     :is-open="shortcutsModalOpen"
@@ -765,6 +822,13 @@ main {
 .deck-info-btn:hover {
   color: var(--color-text-primary);
   background: var(--color-surface-hover);
+}
+
+.io-add-btn {
+  margin-left: auto;
+  padding: 2px 6px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
 }
 
 .deck-info-content {

--- a/src/components/ImageOcclusionEditor.vue
+++ b/src/components/ImageOcclusionEditor.vue
@@ -1,0 +1,272 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, watch } from "vue";
+import { useImageOcclusionEditor, type IoTool } from "../composables/useImageOcclusionEditor";
+import type { OcclusionShape } from "../utils/imageOcclusion";
+import Button from "../design-system/components/primitives/Button.vue";
+
+const props = defineProps<{
+  imageUrl: string;
+  modelValue: OcclusionShape[];
+  readonly?: boolean;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [shapes: OcclusionShape[]];
+}>();
+
+const svgRef = ref<SVGSVGElement | null>(null);
+const imageNaturalWidth = ref(800);
+const imageNaturalHeight = ref(600);
+const imageLoaded = ref(false);
+
+const editor = useImageOcclusionEditor(props.modelValue);
+
+// Sync external model → editor
+watch(
+  () => props.modelValue,
+  (val) => {
+    if (JSON.stringify(val) !== JSON.stringify(editor.shapes.value)) {
+      editor.setShapes(val);
+    }
+  },
+);
+
+// Sync editor → external model
+watch(
+  () => editor.shapes.value,
+  (val) => {
+    emit("update:modelValue", val);
+  },
+  { deep: true },
+);
+
+// Load image to get natural dimensions
+onMounted(() => {
+  const img = new Image();
+  img.onload = () => {
+    imageNaturalWidth.value = img.naturalWidth;
+    imageNaturalHeight.value = img.naturalHeight;
+    imageLoaded.value = true;
+  };
+  img.src = props.imageUrl;
+});
+
+// Keyboard handling
+function onKeydown(e: KeyboardEvent) {
+  if (props.readonly) return;
+  if (e.key === "Delete" || e.key === "Backspace") {
+    if (editor.selectedShapeId.value) {
+      e.preventDefault();
+      editor.deleteSelectedShape();
+    }
+  }
+}
+
+onMounted(() => document.addEventListener("keydown", onKeydown));
+onUnmounted(() => document.removeEventListener("keydown", onKeydown));
+
+// Convert screen pointer coords to SVG viewBox coords
+function toSvgPoint(e: PointerEvent): { x: number; y: number } | null {
+  const svg = svgRef.value;
+  if (!svg) return null;
+  const ctm = svg.getScreenCTM();
+  if (!ctm) return null;
+  const inv = ctm.inverse();
+  return {
+    x: inv.a * e.clientX + inv.c * e.clientY + inv.e,
+    y: inv.b * e.clientX + inv.d * e.clientY + inv.f,
+  };
+}
+
+// Drag state for move
+let dragState: { shapeId: string; startX: number; startY: number; origX: number; origY: number } | null = null;
+
+function onPointerDown(e: PointerEvent) {
+  if (props.readonly) return;
+  const pt = toSvgPoint(e);
+  if (!pt) return;
+
+  if (editor.activeTool.value === "select") {
+    // Check if clicking on a shape
+    const target = e.target as Element;
+    const shapeEl = target.closest("[data-shape-id]");
+    if (shapeEl) {
+      const id = shapeEl.getAttribute("data-shape-id")!;
+      editor.selectShape(id);
+      const shape = editor.shapes.value.find((s) => s.id === id);
+      if (shape) {
+        dragState = { shapeId: id, startX: pt.x, startY: pt.y, origX: shape.x, origY: shape.y };
+        (e.target as Element).setPointerCapture?.(e.pointerId);
+      }
+    } else {
+      editor.selectShape(null);
+    }
+  } else {
+    editor.startDraw(pt.x, pt.y);
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+  }
+}
+
+function onPointerMove(e: PointerEvent) {
+  if (props.readonly) return;
+  const pt = toSvgPoint(e);
+  if (!pt) return;
+
+  if (editor.isDrawing.value) {
+    editor.updateDraw(pt.x, pt.y);
+  } else if (dragState) {
+    const dx = pt.x - dragState.startX;
+    const dy = pt.y - dragState.startY;
+    editor.resizeShape(dragState.shapeId, {
+      x: dragState.origX + dx,
+      y: dragState.origY + dy,
+      width: editor.shapes.value.find((s) => s.id === dragState!.shapeId)!.width,
+      height: editor.shapes.value.find((s) => s.id === dragState!.shapeId)!.height,
+    });
+  }
+}
+
+function onPointerUp(_e: PointerEvent) {
+  if (editor.isDrawing.value) {
+    editor.endDraw();
+  }
+  dragState = null;
+}
+
+const tools: { key: IoTool; label: string }[] = [
+  { key: "select", label: "Select" },
+  { key: "rect", label: "Rectangle" },
+  { key: "ellipse", label: "Ellipse" },
+];
+</script>
+
+<template>
+  <div class="io-editor">
+    <div v-if="!readonly" class="io-toolbar">
+      <Button
+        v-for="tool in tools"
+        :key="tool.key"
+        :variant="editor.activeTool.value === tool.key ? 'primary' : 'secondary'"
+        size="sm"
+        @click="editor.setTool(tool.key)"
+      >
+        {{ tool.label }}
+      </Button>
+      <Button
+        variant="danger"
+        size="sm"
+        :disabled="!editor.selectedShapeId.value"
+        @click="editor.deleteSelectedShape()"
+      >
+        Delete
+      </Button>
+    </div>
+    <div class="io-canvas-wrapper">
+      <svg
+        v-if="imageLoaded"
+        ref="svgRef"
+        class="io-canvas"
+        :viewBox="`0 0 ${imageNaturalWidth} ${imageNaturalHeight}`"
+        preserveAspectRatio="xMidYMid meet"
+        @pointerdown.prevent="onPointerDown"
+        @pointermove.prevent="onPointerMove"
+        @pointerup.prevent="onPointerUp"
+      >
+        <image :href="imageUrl" :width="imageNaturalWidth" :height="imageNaturalHeight" />
+
+        <template v-for="shape in editor.shapes.value" :key="shape.id">
+          <rect
+            v-if="shape.type === 'rect'"
+            :data-shape-id="shape.id"
+            :x="shape.x"
+            :y="shape.y"
+            :width="shape.width"
+            :height="shape.height"
+            fill="#ffeba2"
+            fill-opacity="0.6"
+            stroke="#2d2d2d"
+            stroke-width="1"
+            :class="{ 'io-shape': true, 'io-shape-selected': shape.id === editor.selectedShapeId.value }"
+            style="cursor: pointer"
+          />
+          <ellipse
+            v-else-if="shape.type === 'ellipse'"
+            :data-shape-id="shape.id"
+            :cx="shape.x + shape.width / 2"
+            :cy="shape.y + shape.height / 2"
+            :rx="shape.width / 2"
+            :ry="shape.height / 2"
+            fill="#ffeba2"
+            fill-opacity="0.6"
+            stroke="#2d2d2d"
+            stroke-width="1"
+            :class="{ 'io-shape': true, 'io-shape-selected': shape.id === editor.selectedShapeId.value }"
+            style="cursor: pointer"
+          />
+          <!-- Ordinal label -->
+          <text
+            :x="shape.x + shape.width / 2"
+            :y="shape.y + shape.height / 2"
+            text-anchor="middle"
+            dominant-baseline="central"
+            font-size="16"
+            font-weight="bold"
+            fill="#333"
+            pointer-events="none"
+          >
+            {{ shape.ordinal }}
+          </text>
+        </template>
+
+        <!-- Selection outline -->
+        <rect
+          v-if="editor.selectedShape.value"
+          :x="editor.selectedShape.value.x - 2"
+          :y="editor.selectedShape.value.y - 2"
+          :width="editor.selectedShape.value.width + 4"
+          :height="editor.selectedShape.value.height + 4"
+          fill="none"
+          stroke="#2196f3"
+          stroke-width="2"
+          stroke-dasharray="6 3"
+          pointer-events="none"
+        />
+      </svg>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.io-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.io-toolbar {
+  display: flex;
+  gap: var(--spacing-1);
+  flex-wrap: wrap;
+}
+
+.io-canvas-wrapper {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-surface-elevated);
+}
+
+.io-canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 60vh;
+  touch-action: none;
+  user-select: none;
+}
+
+.io-shape-selected {
+  stroke: #2196f3;
+  stroke-width: 2;
+}
+</style>

--- a/src/components/ImageOcclusionNoteEditor.vue
+++ b/src/components/ImageOcclusionNoteEditor.vue
@@ -1,0 +1,378 @@
+<script setup lang="ts">
+import { ref, watch, computed } from "vue";
+import ImageOcclusionEditor from "./ImageOcclusionEditor.vue";
+import TiptapEditor from "./TiptapEditor.vue";
+import Button from "../design-system/components/primitives/Button.vue";
+import type { AnkiDB2Data } from "../ankiParser/anki2";
+import {
+  IO_FIELD_NAMES,
+  getImageFilename,
+  parseOcclusionShapesForEditor,
+  serializeShapesToSvg,
+  type OcclusionShape,
+} from "../utils/imageOcclusion";
+
+type Card = AnkiDB2Data["cards"][number];
+
+const props = defineProps<{
+  card: Card | null;
+  mediaFiles?: Map<string, string>;
+  isNew?: boolean;
+}>();
+
+const emit = defineEmits<{
+  save: [payload: { fields: Record<string, string | null>; tags: string[]; imageFile?: File }];
+  close: [];
+}>();
+
+// Editor state
+const shapes = ref<OcclusionShape[]>([]);
+const headerText = ref("");
+const backExtraText = ref("");
+const editTags = ref<string[]>([]);
+const newTagInput = ref("");
+
+// Image state
+const imageUrl = ref<string | null>(null);
+const imageFilename = ref<string | null>(null);
+const imageFile = ref<File | null>(null);
+const imageNaturalWidth = ref(800);
+const imageNaturalHeight = ref(600);
+
+// Initialize from existing card
+watch(
+  () => props.card,
+  (card) => {
+    if (!card) {
+      shapes.value = [];
+      headerText.value = "";
+      backExtraText.value = "";
+      editTags.value = [];
+      imageUrl.value = null;
+      imageFilename.value = null;
+      return;
+    }
+
+    const values = card.values;
+    headerText.value = getFieldValue(values, IO_FIELD_NAMES.header);
+    backExtraText.value = getFieldValue(values, IO_FIELD_NAMES.backExtra);
+    editTags.value = [...card.tags];
+
+    // Parse existing shapes
+    const occSvg = getFieldValue(values, IO_FIELD_NAMES.occlusions);
+    shapes.value = parseOcclusionShapesForEditor(occSvg);
+
+    // Extract image dimensions from SVG viewBox
+    const viewBoxMatch = occSvg.match(/viewBox="0 0 (\d+(?:\.\d+)?) (\d+(?:\.\d+)?)"/);
+    if (viewBoxMatch) {
+      imageNaturalWidth.value = parseFloat(viewBoxMatch[1]!);
+      imageNaturalHeight.value = parseFloat(viewBoxMatch[2]!);
+    }
+
+    // Resolve image URL
+    const imgField = getFieldValue(values, IO_FIELD_NAMES.image);
+    const filename = getImageFilename(imgField);
+    if (filename && props.mediaFiles) {
+      imageFilename.value = filename;
+      imageUrl.value = props.mediaFiles.get(filename) ?? null;
+    }
+  },
+  { immediate: true },
+);
+
+function getFieldValue(values: Record<string, string | null>, name: string): string {
+  if (values[name] != null) return values[name]!;
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(values)) {
+    if (key.toLowerCase() === lower && value != null) return value;
+  }
+  return "";
+}
+
+const hasImage = computed(() => !!imageUrl.value);
+
+function handleImagePick(e: Event) {
+  const input = e.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) return;
+  loadImageFile(file);
+}
+
+function handleDrop(e: DragEvent) {
+  e.preventDefault();
+  const file = e.dataTransfer?.files[0];
+  if (file && file.type.startsWith("image/")) {
+    loadImageFile(file);
+  }
+}
+
+function handleDragOver(e: DragEvent) {
+  e.preventDefault();
+}
+
+function loadImageFile(file: File) {
+  imageFile.value = file;
+  const ext = file.name.split(".").pop() ?? "png";
+  imageFilename.value = `io-${Date.now()}.${ext}`;
+
+  const url = URL.createObjectURL(file);
+  imageUrl.value = url;
+
+  // Get natural dimensions
+  const img = new Image();
+  img.onload = () => {
+    imageNaturalWidth.value = img.naturalWidth;
+    imageNaturalHeight.value = img.naturalHeight;
+  };
+  img.src = url;
+
+  // Reset shapes for new image
+  shapes.value = [];
+}
+
+// Tag management
+function addTag() {
+  const tag = newTagInput.value.trim();
+  if (tag && !editTags.value.includes(tag)) {
+    editTags.value.push(tag);
+  }
+  newTagInput.value = "";
+}
+
+function removeTag(index: number) {
+  editTags.value.splice(index, 1);
+}
+
+function handleTagKeydown(e: KeyboardEvent) {
+  if (e.key === "Enter") {
+    e.preventDefault();
+    addTag();
+  }
+}
+
+function handleSave() {
+  const occSvg = serializeShapesToSvg(shapes.value, imageNaturalWidth.value, imageNaturalHeight.value);
+  const imgTag = imageFilename.value ? `<img src="${imageFilename.value}">` : "";
+
+  const fields: Record<string, string | null> = {
+    [IO_FIELD_NAMES.image]: imgTag || null,
+    [IO_FIELD_NAMES.header]: headerText.value || null,
+    [IO_FIELD_NAMES.backExtra]: backExtraText.value || null,
+    [IO_FIELD_NAMES.occlusions]: occSvg || null,
+  };
+
+  emit("save", {
+    fields,
+    tags: [...editTags.value],
+    imageFile: imageFile.value ?? undefined,
+  });
+}
+</script>
+
+<template>
+  <div class="io-note-editor">
+    <!-- Image picker for new notes -->
+    <div v-if="!hasImage" class="io-image-picker" @drop="handleDrop" @dragover="handleDragOver">
+      <div class="io-picker-content">
+        <p class="io-picker-text">Drop an image here or click to select</p>
+        <input
+          type="file"
+          accept="image/*"
+          class="io-picker-input"
+          @change="handleImagePick"
+        />
+        <Button variant="secondary" @click="($refs.fileInput as HTMLInputElement)?.click()">
+          Choose Image
+        </Button>
+      </div>
+    </div>
+
+    <!-- Mask editor -->
+    <template v-if="hasImage && imageUrl">
+      <ImageOcclusionEditor
+        v-model="shapes"
+        :image-url="imageUrl"
+      />
+    </template>
+
+    <!-- Text fields -->
+    <div class="io-text-fields">
+      <div class="field-group">
+        <label class="field-label">Header</label>
+        <TiptapEditor
+          v-model="headerText"
+          :media-files="mediaFiles"
+        />
+      </div>
+      <div class="field-group">
+        <label class="field-label">Back Extra</label>
+        <TiptapEditor
+          v-model="backExtraText"
+          :media-files="mediaFiles"
+        />
+      </div>
+    </div>
+
+    <!-- Tags -->
+    <div class="tags-section">
+      <label class="field-label">Tags</label>
+      <div class="tags-list">
+        <span v-for="(tag, i) in editTags" :key="tag" class="tag-badge">
+          {{ tag }}
+          <button class="tag-remove" @click="removeTag(i)">&times;</button>
+        </span>
+      </div>
+      <div class="tag-add">
+        <input
+          v-model="newTagInput"
+          type="text"
+          class="tag-input"
+          placeholder="Add tag..."
+          @keydown="handleTagKeydown"
+        />
+        <Button variant="secondary" size="sm" @click="addTag">Add</Button>
+      </div>
+    </div>
+
+    <!-- Actions -->
+    <div class="io-actions">
+      <Button variant="secondary" @click="emit('close')">Cancel</Button>
+      <Button variant="primary" :disabled="!hasImage || shapes.length === 0" @click="handleSave">
+        Save
+      </Button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.io-note-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.io-image-picker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-elevated);
+  position: relative;
+  cursor: pointer;
+}
+
+.io-picker-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.io-picker-text {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.io-picker-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.io-text-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.field-label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+.tags-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-1);
+}
+
+.tag-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: 1px var(--spacing-1-5);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+}
+
+.tag-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--color-text-tertiary);
+  background: none;
+  border: none;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+}
+
+.tag-remove:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover);
+}
+
+.tag-add {
+  display: flex;
+  gap: var(--spacing-2);
+  align-items: center;
+}
+
+.tag-input {
+  flex: 1;
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+}
+
+.tag-input:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+  box-shadow: var(--shadow-focus-ring);
+}
+
+.io-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+}
+</style>

--- a/src/components/NoteEditModal.vue
+++ b/src/components/NoteEditModal.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, computed, watch } from "vue";
 import Modal from "../design-system/components/primitives/Modal.vue";
 import Button from "../design-system/components/primitives/Button.vue";
 import TiptapEditor from "./TiptapEditor.vue";
+import ImageOcclusionNoteEditor from "./ImageOcclusionNoteEditor.vue";
 import type { AnkiDB2Data } from "../ankiParser/anki2";
+import { IO_FIELD_NAMES } from "../utils/imageOcclusion";
 
 type Card = AnkiDB2Data["cards"][number];
 
@@ -21,6 +23,15 @@ const emit = defineEmits<{
 const editFields = ref<Record<string, string>>({});
 const editTags = ref<string[]>([]);
 const newTagInput = ref("");
+
+const isIONote = computed(() => {
+  if (!props.card) return false;
+  const keys = Object.keys(props.card.values).map((k) => k.toLowerCase());
+  return (
+    keys.includes(IO_FIELD_NAMES.image.toLowerCase()) &&
+    keys.includes(IO_FIELD_NAMES.occlusions.toLowerCase())
+  );
+});
 
 watch(
   () => props.isOpen,
@@ -66,39 +77,51 @@ function handleSave() {
 </script>
 
 <template>
-  <Modal :is-open="isOpen" title="Edit Note" size="lg" @close="emit('close')">
-    <div class="edit-form">
-      <div v-for="(val, key) in editFields" :key="key" class="field-group">
-        <label class="field-label">{{ key }}</label>
-        <TiptapEditor
-          v-model="editFields[key]"
-          :media-files="mediaFiles"
-          :field-description="card?.fieldDescriptions?.[key as string]"
-        />
-      </div>
+  <Modal :is-open="isOpen" :title="isIONote ? 'Edit Image Occlusion' : 'Edit Note'" :size="isIONote ? 'xl' : 'lg'" @close="emit('close')">
+    <!-- Image Occlusion editor -->
+    <ImageOcclusionNoteEditor
+      v-if="isIONote"
+      :card="card"
+      :media-files="mediaFiles"
+      @save="(payload) => emit('save', payload)"
+      @close="emit('close')"
+    />
 
-      <div class="tags-section">
-        <label class="field-label">Tags</label>
-        <div class="tags-list">
-          <span v-for="(tag, i) in editTags" :key="tag" class="tag-badge">
-            {{ tag }}
-            <button class="tag-remove" @click="removeTag(i)">&times;</button>
-          </span>
-        </div>
-        <div class="tag-add">
-          <input
-            v-model="newTagInput"
-            type="text"
-            class="tag-input"
-            placeholder="Add tag..."
-            @keydown="handleTagKeydown"
+    <!-- Standard note editor -->
+    <template v-else>
+      <div class="edit-form">
+        <div v-for="(val, key) in editFields" :key="key" class="field-group">
+          <label class="field-label">{{ key }}</label>
+          <TiptapEditor
+            v-model="editFields[key]"
+            :media-files="mediaFiles"
+            :field-description="card?.fieldDescriptions?.[key as string]"
           />
-          <Button variant="secondary" size="sm" @click="addTag">Add</Button>
+        </div>
+
+        <div class="tags-section">
+          <label class="field-label">Tags</label>
+          <div class="tags-list">
+            <span v-for="(tag, i) in editTags" :key="tag" class="tag-badge">
+              {{ tag }}
+              <button class="tag-remove" @click="removeTag(i)">&times;</button>
+            </span>
+          </div>
+          <div class="tag-add">
+            <input
+              v-model="newTagInput"
+              type="text"
+              class="tag-input"
+              placeholder="Add tag..."
+              @keydown="handleTagKeydown"
+            />
+            <Button variant="secondary" size="sm" @click="addTag">Add</Button>
+          </div>
         </div>
       </div>
-    </div>
+    </template>
 
-    <template #footer>
+    <template v-if="!isIONote" #footer>
       <Button variant="secondary" @click="emit('close')">Cancel</Button>
       <Button variant="primary" @click="handleSave">Save</Button>
     </template>

--- a/src/composables/useImageOcclusionEditor.ts
+++ b/src/composables/useImageOcclusionEditor.ts
@@ -1,0 +1,142 @@
+import { ref, computed, type Ref } from "vue";
+import type { OcclusionShape } from "../utils/imageOcclusion";
+
+let shapeIdCounter = 0;
+function generateId(): string {
+  return `shape-${Date.now()}-${++shapeIdCounter}`;
+}
+
+export type IoTool = "select" | "rect" | "ellipse";
+
+export function useImageOcclusionEditor(initialShapes: OcclusionShape[] = []) {
+  const shapes: Ref<OcclusionShape[]> = ref([...initialShapes]);
+  const selectedShapeId = ref<string | null>(null);
+  const activeTool = ref<IoTool>("rect");
+  const isDrawing = ref(false);
+
+  // Internal drawing state (not reactive for performance)
+  let drawStartX = 0;
+  let drawStartY = 0;
+  let drawingShapeId: string | null = null;
+
+  const selectedShape = computed(() =>
+    shapes.value.find((s) => s.id === selectedShapeId.value) ?? null,
+  );
+
+  const nextOrdinal = computed(() => {
+    const max = shapes.value.reduce((m, s) => Math.max(m, s.ordinal), 0);
+    return max + 1;
+  });
+
+  function setTool(tool: IoTool) {
+    activeTool.value = tool;
+    if (tool !== "select") {
+      selectedShapeId.value = null;
+    }
+  }
+
+  function selectShape(id: string | null) {
+    selectedShapeId.value = id;
+  }
+
+  function startDraw(x: number, y: number) {
+    if (activeTool.value === "select") return;
+
+    const id = generateId();
+    const shape: OcclusionShape = {
+      id,
+      type: activeTool.value,
+      ordinal: nextOrdinal.value,
+      x,
+      y,
+      width: 0,
+      height: 0,
+    };
+
+    shapes.value = [...shapes.value, shape];
+    drawingShapeId = id;
+    drawStartX = x;
+    drawStartY = y;
+    isDrawing.value = true;
+    selectedShapeId.value = id;
+  }
+
+  function updateDraw(x: number, y: number) {
+    if (!isDrawing.value || !drawingShapeId) return;
+
+    const minX = Math.min(drawStartX, x);
+    const minY = Math.min(drawStartY, y);
+    const w = Math.abs(x - drawStartX);
+    const h = Math.abs(y - drawStartY);
+
+    shapes.value = shapes.value.map((s) =>
+      s.id === drawingShapeId ? { ...s, x: minX, y: minY, width: w, height: h } : s,
+    );
+  }
+
+  function endDraw() {
+    if (!isDrawing.value || !drawingShapeId) return;
+
+    // Remove if too small (accidental click)
+    const shape = shapes.value.find((s) => s.id === drawingShapeId);
+    if (shape && shape.width < 5 && shape.height < 5) {
+      shapes.value = shapes.value.filter((s) => s.id !== drawingShapeId);
+      selectedShapeId.value = null;
+    }
+
+    drawingShapeId = null;
+    isDrawing.value = false;
+  }
+
+  function moveShape(id: string, dx: number, dy: number) {
+    shapes.value = shapes.value.map((s) =>
+      s.id === id ? { ...s, x: s.x + dx, y: s.y + dy } : s,
+    );
+  }
+
+  function resizeShape(
+    id: string,
+    bounds: { x: number; y: number; width: number; height: number },
+  ) {
+    shapes.value = shapes.value.map((s) =>
+      s.id === id ? { ...s, ...bounds } : s,
+    );
+  }
+
+  function deleteShape(id: string) {
+    shapes.value = shapes.value.filter((s) => s.id !== id);
+    if (selectedShapeId.value === id) {
+      selectedShapeId.value = null;
+    }
+  }
+
+  function deleteSelectedShape() {
+    if (selectedShapeId.value) {
+      deleteShape(selectedShapeId.value);
+    }
+  }
+
+  function setShapes(newShapes: OcclusionShape[]) {
+    shapes.value = [...newShapes];
+    selectedShapeId.value = null;
+  }
+
+  return {
+    shapes,
+    selectedShapeId,
+    activeTool,
+    isDrawing,
+    selectedShape,
+    nextOrdinal,
+    setTool,
+    selectShape,
+    startDraw,
+    updateDraw,
+    endDraw,
+    moveShape,
+    resizeShape,
+    deleteShape,
+    deleteSelectedShape,
+    setShapes,
+  };
+}

--- a/src/lib/notetypeOps.ts
+++ b/src/lib/notetypeOps.ts
@@ -77,6 +77,7 @@ export function getTemplatesForNotetype(db: Database, ntid: string): TemplateRow
 interface CreateNotetypeOptions {
   name: string;
   kind?: number; // 0=normal, 1=cloze
+  originalStockKind?: number; // 6=image occlusion
   css?: string;
   fields: { name: string; config?: Partial<Anki21bFieldConfig> }[];
   templates: { name: string; qfmt: string; afmt: string }[];
@@ -89,6 +90,7 @@ export function createNotetype(db: Database, options: CreateNotetypeOptions): st
 
   const configBlob = encodeNotesTypeConfig({
     kind: options.kind ?? 0,
+    originalStockKind: options.originalStockKind ?? 0,
     css: options.css ?? ".card {\n  font-family: arial;\n  font-size: 20px;\n  text-align: center;\n  color: black;\n  background-color: white;\n}\n",
   });
 

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1395,6 +1395,145 @@ export async function withDbMutation(mutate: (db: import("sql.js").Database) => 
   }
 }
 
+// --- Image Occlusion Note Creation ---
+
+const BASE91_CHARS =
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&()*+,-.:;<=>?@[]^_`{|}~";
+
+function generateGuid(): string {
+  let result = "";
+  for (let i = 0; i < 10; i++) {
+    result += BASE91_CHARS[Math.floor(Math.random() * BASE91_CHARS.length)];
+  }
+  return result;
+}
+
+/**
+ * Find an existing IO notetype, or create one if missing.
+ * Returns the notetype ID.
+ */
+export async function getOrCreateIONotetype(): Promise<string> {
+  const data = ankiDataSig.value;
+  if (!data) throw new Error("No deck loaded");
+
+  // Check existing notetypes for IO
+  for (const nt of data.notesTypes) {
+    if ("originalStockKind" in nt && (nt as { originalStockKind?: number }).originalStockKind === 6) {
+      return String(nt.id);
+    }
+  }
+
+  // Check by name as fallback
+  for (const nt of data.notesTypes) {
+    if ("name" in nt && (nt as { name?: string }).name?.toLowerCase().includes("image occlusion")) {
+      return String(nt.id);
+    }
+  }
+
+  // Create new IO notetype
+  let ntId = "";
+  const { createNotetype } = await import("./lib/notetypeOps");
+  await withDbMutation((db) => {
+    ntId = createNotetype(db, {
+      name: "Image Occlusion",
+      kind: 1, // cloze
+      originalStockKind: 6,
+      css: `.card {
+  font-family: arial;
+  font-size: 20px;
+  text-align: center;
+  color: black;
+  background-color: white;
+}
+`,
+      fields: [
+        { name: "Image Occlusion" },
+        { name: "Header" },
+        { name: "Back Extra" },
+        { name: "Occlusions" },
+      ],
+      templates: [
+        {
+          name: "Card 1",
+          qfmt: '{{#Image Occlusion}}<div class="io-header">{{Header}}</div>{{Image Occlusion}}{{/Image Occlusion}}',
+          afmt: '{{#Image Occlusion}}<div class="io-header">{{Header}}</div>{{Image Occlusion}}<hr id="answer"><div class="io-back-extra">{{Back Extra}}</div>{{/Image Occlusion}}',
+        },
+      ],
+    });
+  });
+
+  return ntId;
+}
+
+/**
+ * Add a new note to the current synced collection.
+ */
+export async function addNote(options: {
+  notetypeId: string;
+  deckId: string;
+  fields: Record<string, string | null>;
+  tags: string[];
+  numCards?: number;
+}): Promise<void> {
+  const input = activeDeckInputSig.value;
+  if (input?.kind !== "sqlite") throw new Error("Can only add notes to synced collections");
+
+  const { executeQueryAll } = await import("./utils/sql");
+  const db = await createDatabase(input.bytes);
+
+  try {
+    const noteId = Date.now() * 1000 + Math.floor(Math.random() * 1000);
+    const guid = generateGuid();
+    const mod = Math.floor(Date.now() / 1000);
+
+    // Get field order from DB
+    const fieldRows = executeQueryAll<{ name: string; ord: number }>(
+      db,
+      "SELECT name, ord FROM fields WHERE ntid=? ORDER BY ord",
+      [options.notetypeId] as unknown as Record<string, string>,
+    );
+
+    // Build flds string (field values joined by \x1f in field order)
+    const flds = fieldRows
+      .map((f) => options.fields[f.name] ?? "")
+      .join("\x1f");
+
+    // Sort field and checksum
+    const sfld = (options.fields[fieldRows[0]?.name ?? ""] ?? "").replace(/<[^>]*>/g, "").trim();
+    const csum = stringHash(sfld);
+
+    const tagsStr = options.tags.length > 0 ? ` ${options.tags.join(" ")} ` : "";
+
+    // Insert note
+    db.run(
+      "INSERT INTO notes (id, guid, mid, mod, usn, tags, flds, sfld, csum, flags, data) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+      [noteId, guid, options.notetypeId, mod, -1, tagsStr, flds, sfld, csum, 0, ""],
+    );
+
+    // Insert cards (one per template, or numCards for cloze)
+    const numCards = options.numCards ?? 1;
+    for (let ord = 0; ord < numCards; ord++) {
+      const cardId = noteId + ord + 1;
+      db.run(
+        "INSERT INTO cards (id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        [cardId, noteId, options.deckId, ord, mod, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ""],
+      );
+    }
+
+    // Persist and re-parse
+    const newBytes = new Uint8Array(db.export());
+    const cache = await caches.open("anki-cache");
+    await cache.put("/sync/collection.sqlite", new Response(new Blob([newBytes as BlobPart])));
+
+    activeDeckInputSig.value = { ...input, bytes: newBytes };
+    const { getAnkiDataFromSqlite } = await import("./ankiParser");
+    ankiDataSig.value = await getAnkiDataFromSqlite(newBytes, input.mediaFiles);
+    markDataChanged();
+  } finally {
+    db.close();
+  }
+}
+
 // --- Option Presets ---
 
 export const presetsSig = ref<OptionPreset[]>([]);

--- a/src/utils/__tests__/imageOcclusion.test.ts
+++ b/src/utils/__tests__/imageOcclusion.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   isImageOcclusionCard,
   parseOcclusionShapes,
+  parseOcclusionShapesForEditor,
+  serializeShapesToSvg,
   renderImageOcclusion,
+  getImageFilename,
+  type OcclusionShape,
 } from "../imageOcclusion";
 
 describe("Image Occlusion", () => {
@@ -15,16 +19,26 @@ describe("Image Occlusion", () => {
       expect(isImageOcclusionCard({ values: {}, originalStockKind: 0 })).toBe(false);
     });
 
-    it("returns false for cloze cards", () => {
-      expect(isImageOcclusionCard({ values: {}, originalStockKind: 5 })).toBe(false);
-    });
-
     it("returns false when originalStockKind is undefined", () => {
       expect(isImageOcclusionCard({ values: {} })).toBe(false);
     });
   });
 
-  describe("parseOcclusionShapes", () => {
+  describe("getImageFilename", () => {
+    it("extracts filename from img tag", () => {
+      expect(getImageFilename('<img src="anatomy.png">')).toBe("anatomy.png");
+    });
+
+    it("returns null for empty string", () => {
+      expect(getImageFilename("")).toBeNull();
+    });
+
+    it("returns null for text without img", () => {
+      expect(getImageFilename("just text")).toBeNull();
+    });
+  });
+
+  describe("parseOcclusionShapes (for rendering)", () => {
     it("parses rect shapes with data-ordinal", () => {
       const svg = `<svg viewBox="0 0 800 600">
         <rect data-ordinal="1" x="10" y="20" width="100" height="50" fill="#ffeba2" />
@@ -42,25 +56,7 @@ describe("Image Occlusion", () => {
       </svg>`;
       const shapes = parseOcclusionShapes(svg);
       expect(shapes).toHaveLength(1);
-      expect(shapes[0]!.ordinal).toBe(1);
       expect(shapes[0]!.svgElement).toContain("ellipse");
-    });
-
-    it("parses polygon shapes", () => {
-      const svg = `<svg viewBox="0 0 800 600">
-        <polygon data-ordinal="3" points="100,10 40,198 190,78 10,78 160,198" />
-      </svg>`;
-      const shapes = parseOcclusionShapes(svg);
-      expect(shapes).toHaveLength(1);
-      expect(shapes[0]!.ordinal).toBe(3);
-    });
-
-    it("parses path shapes", () => {
-      const svg = `<svg viewBox="0 0 800 600">
-        <path data-ordinal="1" d="M10 10 L100 100" />
-      </svg>`;
-      const shapes = parseOcclusionShapes(svg);
-      expect(shapes).toHaveLength(1);
     });
 
     it("ignores shapes without data-ordinal", () => {
@@ -70,11 +66,111 @@ describe("Image Occlusion", () => {
       </svg>`;
       const shapes = parseOcclusionShapes(svg);
       expect(shapes).toHaveLength(1);
-      expect(shapes[0]!.ordinal).toBe(1);
     });
 
     it("returns empty array for empty string", () => {
       expect(parseOcclusionShapes("")).toEqual([]);
+    });
+  });
+
+  describe("parseOcclusionShapesForEditor", () => {
+    it("parses rect into OcclusionShape", () => {
+      const svg = `<svg viewBox="0 0 800 600">
+        <rect data-ordinal="1" x="10" y="20" width="100" height="50" />
+      </svg>`;
+      const shapes = parseOcclusionShapesForEditor(svg);
+      expect(shapes).toHaveLength(1);
+      expect(shapes[0]!.type).toBe("rect");
+      expect(shapes[0]!.ordinal).toBe(1);
+      expect(shapes[0]!.x).toBe(10);
+      expect(shapes[0]!.y).toBe(20);
+      expect(shapes[0]!.width).toBe(100);
+      expect(shapes[0]!.height).toBe(50);
+    });
+
+    it("parses ellipse into OcclusionShape bounding box", () => {
+      const svg = `<svg viewBox="0 0 800 600">
+        <ellipse data-ordinal="2" cx="100" cy="200" rx="50" ry="30" />
+      </svg>`;
+      const shapes = parseOcclusionShapesForEditor(svg);
+      expect(shapes).toHaveLength(1);
+      expect(shapes[0]!.type).toBe("ellipse");
+      expect(shapes[0]!.ordinal).toBe(2);
+      expect(shapes[0]!.x).toBe(50); // cx - rx
+      expect(shapes[0]!.y).toBe(170); // cy - ry
+      expect(shapes[0]!.width).toBe(100); // rx * 2
+      expect(shapes[0]!.height).toBe(60); // ry * 2
+    });
+
+    it("parses circle as ellipse", () => {
+      const svg = `<svg><circle data-ordinal="1" cx="50" cy="50" r="25" /></svg>`;
+      const shapes = parseOcclusionShapesForEditor(svg);
+      expect(shapes).toHaveLength(1);
+      expect(shapes[0]!.type).toBe("ellipse");
+      expect(shapes[0]!.x).toBe(25);
+      expect(shapes[0]!.y).toBe(25);
+      expect(shapes[0]!.width).toBe(50);
+      expect(shapes[0]!.height).toBe(50);
+    });
+
+    it("returns empty for no shapes", () => {
+      expect(parseOcclusionShapesForEditor("")).toEqual([]);
+    });
+  });
+
+  describe("serializeShapesToSvg", () => {
+    it("serializes rect shapes", () => {
+      const shapes: OcclusionShape[] = [
+        { id: "1", type: "rect", ordinal: 1, x: 10, y: 20, width: 100, height: 50 },
+      ];
+      const svg = serializeShapesToSvg(shapes, 800, 600);
+      expect(svg).toContain('viewBox="0 0 800 600"');
+      expect(svg).toContain('data-ordinal="1"');
+      expect(svg).toContain('x="10"');
+      expect(svg).toContain('width="100"');
+    });
+
+    it("serializes ellipse shapes with cx/cy/rx/ry", () => {
+      const shapes: OcclusionShape[] = [
+        { id: "1", type: "ellipse", ordinal: 1, x: 50, y: 70, width: 100, height: 60 },
+      ];
+      const svg = serializeShapesToSvg(shapes, 800, 600);
+      expect(svg).toContain("ellipse");
+      expect(svg).toContain('cx="100"'); // x + width/2
+      expect(svg).toContain('cy="100"'); // y + height/2
+      expect(svg).toContain('rx="50"'); // width/2
+      expect(svg).toContain('ry="30"'); // height/2
+    });
+
+    it("round-trips rect shapes", () => {
+      const original: OcclusionShape[] = [
+        { id: "a", type: "rect", ordinal: 1, x: 10, y: 20, width: 100, height: 50 },
+        { id: "b", type: "rect", ordinal: 2, x: 200, y: 100, width: 80, height: 60 },
+      ];
+      const svg = serializeShapesToSvg(original, 800, 600);
+      const parsed = parseOcclusionShapesForEditor(svg);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0]!.ordinal).toBe(1);
+      expect(parsed[0]!.x).toBe(10);
+      expect(parsed[0]!.y).toBe(20);
+      expect(parsed[0]!.width).toBe(100);
+      expect(parsed[0]!.height).toBe(50);
+      expect(parsed[1]!.ordinal).toBe(2);
+      expect(parsed[1]!.x).toBe(200);
+    });
+
+    it("round-trips ellipse shapes", () => {
+      const original: OcclusionShape[] = [
+        { id: "a", type: "ellipse", ordinal: 1, x: 50, y: 70, width: 100, height: 60 },
+      ];
+      const svg = serializeShapesToSvg(original, 800, 600);
+      const parsed = parseOcclusionShapesForEditor(svg);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]!.type).toBe("ellipse");
+      expect(parsed[0]!.x).toBe(50);
+      expect(parsed[0]!.y).toBe(70);
+      expect(parsed[0]!.width).toBe(100);
+      expect(parsed[0]!.height).toBe(60);
     });
   });
 
@@ -89,171 +185,46 @@ describe("Image Occlusion", () => {
       </svg>`,
     };
 
-    describe("question side (front)", () => {
-      it("wraps image in io-container", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: false,
-        });
-        expect(html).toContain('class="io-container"');
-        expect(html).toContain('<img src="anatomy.png">');
-      });
-
-      it("includes SVG overlay", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: false,
-        });
-        expect(html).toContain('class="io-overlay"');
-        expect(html).toContain('viewBox="0 0 800 600"');
-      });
-
-      it("marks active shape with io-mask-active class", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: false,
-        });
-        expect(html).toContain('class="io-mask io-mask-active"');
-      });
-
-      it("marks non-active shapes with io-mask class only", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: false,
-        });
-        // The second shape (ordinal 2) should just be io-mask
-        const maskMatches = html.match(/class="io-mask"/g);
-        expect(maskMatches).not.toBeNull();
-        expect(maskMatches!.length).toBeGreaterThanOrEqual(1);
-      });
-
-      it("includes header", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: false,
-        });
-        expect(html).toContain('class="io-header"');
-        expect(html).toContain("Brain Anatomy");
-      });
-
-      it("does not include back extra on front", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: false,
-        });
-        expect(html).not.toContain("io-back-extra");
-        expect(html).not.toContain("Gray's Anatomy");
-      });
+    it("renders front side with masks", () => {
+      const html = renderImageOcclusion({ values: sampleValues, cardOrd: 0, isAnswer: false });
+      expect(html).toContain('class="io-container"');
+      expect(html).toContain('class="io-mask io-mask-active"');
+      expect(html).toContain('class="io-mask"');
+      expect(html).toContain("Brain Anatomy");
+      expect(html).not.toContain("io-back-extra");
     });
 
-    describe("answer side (back)", () => {
-      it("reveals active shape with io-mask-reveal class", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: true,
-        });
-        expect(html).toContain('class="io-mask-reveal"');
-      });
-
-      it("keeps non-active shapes as masks", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: true,
-        });
-        expect(html).toContain('class="io-mask"');
-      });
-
-      it("includes back extra with hr separator", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: true,
-        });
-        expect(html).toContain('id="answer"');
-        expect(html).toContain('class="io-back-extra"');
-        expect(html).toContain("Gray's Anatomy");
-      });
-
-      it("includes header", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 0,
-          isAnswer: true,
-        });
-        expect(html).toContain("Brain Anatomy");
-      });
+    it("renders back side with reveal", () => {
+      const html = renderImageOcclusion({ values: sampleValues, cardOrd: 0, isAnswer: true });
+      expect(html).toContain('class="io-mask-reveal"');
+      expect(html).toContain('class="io-mask"');
+      expect(html).toContain("io-back-extra");
+      expect(html).toContain("Gray's Anatomy");
     });
 
-    describe("different card ordinals", () => {
-      it("highlights second shape when cardOrd is 1", () => {
-        const html = renderImageOcclusion({
-          values: sampleValues,
-          cardOrd: 1,
-          isAnswer: false,
-        });
-        // The second rect (ordinal 2) should be active
-        const lines = html.split("\n");
-        const activeLines = lines.filter((l) => l.includes("io-mask-active"));
-        expect(activeLines).toHaveLength(1);
-        // Verify the active one has ordinal 2's attributes
-        expect(activeLines[0]).toContain('x="200"');
-      });
+    it("highlights correct shape for different card ordinals", () => {
+      const html = renderImageOcclusion({ values: sampleValues, cardOrd: 1, isAnswer: false });
+      const lines = html.split("\n");
+      const activeLines = lines.filter((l) => l.includes("io-mask-active"));
+      expect(activeLines).toHaveLength(1);
+      expect(activeLines[0]).toContain('x="200"');
     });
 
-    describe("edge cases", () => {
-      it("handles missing header gracefully", () => {
-        const values = { ...sampleValues, Header: "" };
-        const html = renderImageOcclusion({
-          values,
-          cardOrd: 0,
-          isAnswer: false,
-        });
-        expect(html).not.toContain("io-header");
-      });
+    it("handles missing header", () => {
+      const values = { ...sampleValues, Header: "" };
+      const html = renderImageOcclusion({ values, cardOrd: 0, isAnswer: false });
+      expect(html).not.toContain("io-header");
+    });
 
-      it("handles missing back extra gracefully", () => {
-        const values = { ...sampleValues, "Back Extra": "" };
-        const html = renderImageOcclusion({
-          values,
-          cardOrd: 0,
-          isAnswer: true,
-        });
-        expect(html).not.toContain("io-back-extra");
-      });
-
-      it("handles empty occlusions field", () => {
-        const values = { ...sampleValues, Occlusions: "" };
-        const html = renderImageOcclusion({
-          values,
-          cardOrd: 0,
-          isAnswer: false,
-        });
-        expect(html).toContain("io-container");
-        expect(html).toContain("io-overlay");
-      });
-
-      it("handles case-insensitive field names", () => {
-        const values = {
-          "image occlusion": '<img src="test.png">',
-          header: "Test",
-          occlusions: `<svg viewBox="0 0 100 100"><rect data-ordinal="1" x="0" y="0" width="10" height="10" /></svg>`,
-        };
-        const html = renderImageOcclusion({
-          values,
-          cardOrd: 0,
-          isAnswer: false,
-        });
-        expect(html).toContain('<img src="test.png">');
-        expect(html).toContain("Test");
-      });
+    it("handles case-insensitive field names", () => {
+      const values = {
+        "image occlusion": '<img src="test.png">',
+        header: "Test",
+        occlusions: `<svg viewBox="0 0 100 100"><rect data-ordinal="1" x="0" y="0" width="10" height="10" /></svg>`,
+      };
+      const html = renderImageOcclusion({ values, cardOrd: 0, isAnswer: false });
+      expect(html).toContain('<img src="test.png">');
+      expect(html).toContain("Test");
     });
   });
 });

--- a/src/utils/imageOcclusion.ts
+++ b/src/utils/imageOcclusion.ts
@@ -1,7 +1,6 @@
 /**
- * Image Occlusion rendering utilities.
+ * Image Occlusion utilities for rendering and editing.
  *
- * Handles detection and rendering of Anki image occlusion notes.
  * IO notes have originalStockKind === 6 and contain:
  *   - "Image Occlusion" field: <img> tag referencing the base image
  *   - "Occlusions" field: SVG markup with shapes having data-ordinal attributes
@@ -11,30 +10,40 @@
 
 const ORIGINAL_STOCK_KIND_IMAGE_OCCLUSION = 6;
 
-/** Known field names for IO notes (case-insensitive lookup). */
-const IO_FIELD_NAMES = {
+export const IO_FIELD_NAMES = {
   image: "Image Occlusion",
   header: "Header",
   backExtra: "Back Extra",
   occlusions: "Occlusions",
 } as const;
 
+// --- Types ---
+
+export type OcclusionShape = {
+  id: string;
+  type: "rect" | "ellipse";
+  ordinal: number; // 1-based, maps to cloze number
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 type CardLike = {
   values: Record<string, string | null>;
   originalStockKind?: number;
 };
 
+// --- Detection ---
+
 export function isImageOcclusionCard(card: CardLike): boolean {
   return card.originalStockKind === ORIGINAL_STOCK_KIND_IMAGE_OCCLUSION;
 }
 
-/**
- * Find a field value by name, case-insensitive.
- */
+// --- Field helpers ---
+
 function getField(values: Record<string, string | null>, name: string): string {
-  // Try exact match first
   if (values[name] != null) return values[name]!;
-  // Case-insensitive fallback
   const lower = name.toLowerCase();
   for (const [key, value] of Object.entries(values)) {
     if (key.toLowerCase() === lower && value != null) return value;
@@ -43,18 +52,21 @@ function getField(values: Record<string, string | null>, name: string): string {
 }
 
 /**
- * Parse shape elements from the Occlusions SVG field.
- * Returns an array of shape descriptors with their ordinals.
+ * Extract the image filename from the Image Occlusion field HTML.
  */
+export function getImageFilename(imageFieldHtml: string): string | null {
+  const match = imageFieldHtml.match(/src="([^"]+)"/);
+  return match ? match[1]! : null;
+}
+
+// --- Shape parsing (for rendering) ---
+
 export function parseOcclusionShapes(
   svgString: string,
 ): { ordinal: number; svgElement: string }[] {
   if (!svgString.trim()) return [];
 
   const shapes: { ordinal: number; svgElement: string }[] = [];
-
-  // Match SVG shape elements with data-ordinal attributes
-  // Supports: rect, ellipse, circle, polygon, path
   const shapeRegex =
     /<(rect|ellipse|circle|polygon|path)\b([^>]*?)\/?>(?:<\/\1>)?/gi;
 
@@ -62,11 +74,8 @@ export function parseOcclusionShapes(
   while ((match = shapeRegex.exec(svgString)) !== null) {
     const fullElement = match[0];
     const attrs = match[2] ?? "";
-
-    // Extract ordinal from data-ordinal attribute
     const ordinalMatch = attrs.match(/data-ordinal="(\d+)"/);
     if (!ordinalMatch) continue;
-
     const ordinal = parseInt(ordinalMatch[1]!, 10);
     shapes.push({ ordinal, svgElement: fullElement });
   }
@@ -74,21 +83,113 @@ export function parseOcclusionShapes(
   return shapes;
 }
 
+// --- Shape parsing (for editor) ---
+
+let shapeIdCounter = 0;
+
+function generateShapeId(): string {
+  return `shape-${Date.now()}-${++shapeIdCounter}`;
+}
+
 /**
- * Extract the viewBox from the Occlusions SVG, or return a default.
+ * Parse SVG occlusion data into editable OcclusionShape objects.
  */
+export function parseOcclusionShapesForEditor(svgString: string): OcclusionShape[] {
+  if (!svgString.trim()) return [];
+
+  const shapes: OcclusionShape[] = [];
+  const shapeRegex =
+    /<(rect|ellipse|circle|polygon|path)\b([^>]*?)\/?>(?:<\/\1>)?/gi;
+
+  let match;
+  while ((match = shapeRegex.exec(svgString)) !== null) {
+    const tag = match[1]!.toLowerCase();
+    const attrs = match[2] ?? "";
+
+    const ordinalMatch = attrs.match(/data-ordinal="(\d+)"/);
+    if (!ordinalMatch) continue;
+    const ordinal = parseInt(ordinalMatch[1]!, 10);
+
+    if (tag === "rect") {
+      const x = parseAttr(attrs, "x");
+      const y = parseAttr(attrs, "y");
+      const w = parseAttr(attrs, "width");
+      const h = parseAttr(attrs, "height");
+      shapes.push({ id: generateShapeId(), type: "rect", ordinal, x, y, width: w, height: h });
+    } else if (tag === "ellipse") {
+      const cx = parseAttr(attrs, "cx");
+      const cy = parseAttr(attrs, "cy");
+      const rx = parseAttr(attrs, "rx");
+      const ry = parseAttr(attrs, "ry");
+      shapes.push({
+        id: generateShapeId(),
+        type: "ellipse",
+        ordinal,
+        x: cx - rx,
+        y: cy - ry,
+        width: rx * 2,
+        height: ry * 2,
+      });
+    } else if (tag === "circle") {
+      const cx = parseAttr(attrs, "cx");
+      const cy = parseAttr(attrs, "cy");
+      const r = parseAttr(attrs, "r");
+      shapes.push({
+        id: generateShapeId(),
+        type: "ellipse",
+        ordinal,
+        x: cx - r,
+        y: cy - r,
+        width: r * 2,
+        height: r * 2,
+      });
+    }
+    // polygon and path are read-only for now (rendered but not editable)
+  }
+
+  return shapes;
+}
+
+function parseAttr(attrs: string, name: string): number {
+  const match = attrs.match(new RegExp(`${name}="([^"]+)"`));
+  return match ? parseFloat(match[1]!) : 0;
+}
+
+// --- Shape serialization ---
+
+/**
+ * Serialize OcclusionShape array to SVG string matching Anki desktop format.
+ */
+export function serializeShapesToSvg(
+  shapes: OcclusionShape[],
+  imageWidth: number,
+  imageHeight: number,
+): string {
+  const elements = shapes.map((shape) => {
+    if (shape.type === "ellipse") {
+      const cx = shape.x + shape.width / 2;
+      const cy = shape.y + shape.height / 2;
+      const rx = shape.width / 2;
+      const ry = shape.height / 2;
+      return `<ellipse data-ordinal="${shape.ordinal}" cx="${cx}" cy="${cy}" rx="${rx}" ry="${ry}" fill="#ffeba2" fill-opacity="1" stroke="#2d2d2d" stroke-width="1"/>`;
+    }
+    return `<rect data-ordinal="${shape.ordinal}" x="${shape.x}" y="${shape.y}" width="${shape.width}" height="${shape.height}" fill="#ffeba2" fill-opacity="1" stroke="#2d2d2d" stroke-width="1"/>`;
+  });
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${imageWidth} ${imageHeight}">\n  ${elements.join("\n  ")}\n</svg>`;
+}
+
+// --- SVG viewBox extraction ---
+
 function extractViewBox(svgString: string): string | null {
   const match = svgString.match(/viewBox="([^"]+)"/);
   return match ? match[1]! : null;
 }
 
+// --- Rendering ---
+
 /**
- * Render an image occlusion card to HTML.
- *
- * @param values - The card field values
- * @param cardOrd - The 0-based card ordinal (determines which shape is active)
- * @param isAnswer - Whether rendering the answer (back) side
- * @returns HTML string for the card content
+ * Render an image occlusion card to HTML for review.
  */
 export function renderImageOcclusion({
   values,
@@ -104,17 +205,15 @@ export function renderImageOcclusion({
   const backExtra = getField(values, IO_FIELD_NAMES.backExtra);
   const occlusionsSvg = getField(values, IO_FIELD_NAMES.occlusions);
 
-  const activeOrdinal = cardOrd + 1; // Anki ordinals are 1-based
+  const activeOrdinal = cardOrd + 1;
   const shapes = parseOcclusionShapes(occlusionsSvg);
   const viewBox = extractViewBox(occlusionsSvg);
 
-  // Build the SVG overlay with shapes
   const svgShapes = shapes
     .map(({ ordinal, svgElement }) => {
       const isActive = ordinal === activeOrdinal;
 
       if (isAnswer) {
-        // Answer side: active shape gets reveal styling, others stay as masks
         if (isActive) {
           return svgElement
             .replace(/class="[^"]*"/, "")
@@ -124,7 +223,6 @@ export function renderImageOcclusion({
           .replace(/class="[^"]*"/, "")
           .replace(/<(rect|ellipse|circle|polygon|path)\b/, `<$1 class="io-mask"`);
       } else {
-        // Question side: all shapes shown as masks, active one highlighted
         const cssClass = isActive ? "io-mask io-mask-active" : "io-mask";
         return svgElement
           .replace(/class="[^"]*"/, "")


### PR DESCRIPTION
## Summary

Addresses #107 (Phases 1 & 2 of 3).

**Phase 1 — Import & Render IO Notes**
- Propagate `originalStockKind` from protobuf notetype config through the card data pipeline
- Detect IO notes (`originalStockKind === 6`) and render with SVG mask overlays in review and card browser
- IO overlay CSS in sandboxed iframe

**Phase 2 — Mask Editor**
- New `ImageOcclusionEditor.vue` — SVG-based drawing canvas with rectangle/ellipse tools, select/move/delete
- New `useImageOcclusionEditor` composable for editor state management
- New `ImageOcclusionNoteEditor.vue` — complete IO note editor with image picker, mask editor, text fields, tags
- `NoteEditModal` detects IO notes and delegates to the visual editor
- New `addNote()` and `getOrCreateIONotetype()` store functions
- "+IO" button in study view for creating new IO notes (synced collections only)
- Extended `notetypeOps.ts` with `originalStockKind` support
- 23 unit tests for shape parsing, serialization round-trips, and rendering