### PR TITLE
Add group modes, resize handles, and touch polish (Phase 3)

### DIFF
--- a/src/components/ImageOcclusionEditor.vue
+++ b/src/components/ImageOcclusionEditor.vue
@@ -1,17 +1,19 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch } from "vue";
 import { useImageOcclusionEditor, type IoTool } from "../composables/useImageOcclusionEditor";
-import type { OcclusionShape } from "../utils/imageOcclusion";
+import type { OcclusionShape, OcclusionMode } from "../utils/imageOcclusion";
 import Button from "../design-system/components/primitives/Button.vue";
 
 const props = defineProps<{
   imageUrl: string;
   modelValue: OcclusionShape[];
+  occlusionMode?: OcclusionMode;
   readonly?: boolean;
 }>();
 
 const emit = defineEmits<{
   "update:modelValue": [shapes: OcclusionShape[]];
+  "update:occlusionMode": [mode: OcclusionMode];
 }>();
 
 const svgRef = ref<SVGSVGElement | null>(null);
@@ -20,6 +22,23 @@ const imageNaturalHeight = ref(600);
 const imageLoaded = ref(false);
 
 const editor = useImageOcclusionEditor(props.modelValue);
+
+// Sync occlusion mode from prop
+if (props.occlusionMode) {
+  editor.setOcclusionMode(props.occlusionMode);
+}
+watch(
+  () => props.occlusionMode,
+  (val) => {
+    if (val && val !== editor.occlusionMode.value) {
+      editor.setOcclusionMode(val);
+    }
+  },
+);
+watch(
+  () => editor.occlusionMode.value,
+  (val) => emit("update:occlusionMode", val),
+);
 
 // Sync external model → editor
 watch(
@@ -78,24 +97,67 @@ function toSvgPoint(e: PointerEvent): { x: number; y: number } | null {
   };
 }
 
-// Drag state for move
-let dragState: { shapeId: string; startX: number; startY: number; origX: number; origY: number } | null = null;
+// Interaction state
+type HandleDir = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
+let dragState: {
+  shapeId: string;
+  startX: number;
+  startY: number;
+  origX: number;
+  origY: number;
+  origW: number;
+  origH: number;
+} | null = null;
+let resizeHandle: { shapeId: string; dir: HandleDir; anchorX: number; anchorY: number } | null = null;
+const MIN_DRAG_THRESHOLD = 5;
+let hasDragged = false;
 
 function onPointerDown(e: PointerEvent) {
   if (props.readonly) return;
   const pt = toSvgPoint(e);
   if (!pt) return;
+  hasDragged = false;
 
   if (editor.activeTool.value === "select") {
-    // Check if clicking on a shape
     const target = e.target as Element;
+
+    // Check resize handles first
+    const handleEl = target.closest("[data-handle]");
+    if (handleEl && editor.selectedShape.value) {
+      const dir = handleEl.getAttribute("data-handle") as HandleDir;
+      const shape = editor.selectedShape.value;
+      // Anchor is the opposite corner/edge
+      const anchors: Record<HandleDir, { x: number; y: number }> = {
+        nw: { x: shape.x + shape.width, y: shape.y + shape.height },
+        n: { x: shape.x, y: shape.y + shape.height },
+        ne: { x: shape.x, y: shape.y + shape.height },
+        e: { x: shape.x, y: shape.y },
+        se: { x: shape.x, y: shape.y },
+        s: { x: shape.x, y: shape.y },
+        sw: { x: shape.x + shape.width, y: shape.y },
+        w: { x: shape.x + shape.width, y: shape.y },
+      };
+      resizeHandle = { shapeId: shape.id, dir, anchorX: anchors[dir].x, anchorY: anchors[dir].y };
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+      return;
+    }
+
+    // Check shape click
     const shapeEl = target.closest("[data-shape-id]");
     if (shapeEl) {
       const id = shapeEl.getAttribute("data-shape-id")!;
       editor.selectShape(id);
       const shape = editor.shapes.value.find((s) => s.id === id);
       if (shape) {
-        dragState = { shapeId: id, startX: pt.x, startY: pt.y, origX: shape.x, origY: shape.y };
+        dragState = {
+          shapeId: id,
+          startX: pt.x,
+          startY: pt.y,
+          origX: shape.x,
+          origY: shape.y,
+          origW: shape.width,
+          origH: shape.height,
+        };
         (e.target as Element).setPointerCapture?.(e.pointerId);
       }
     } else {
@@ -114,14 +176,45 @@ function onPointerMove(e: PointerEvent) {
 
   if (editor.isDrawing.value) {
     editor.updateDraw(pt.x, pt.y);
+  } else if (resizeHandle) {
+    // Resize based on handle direction
+    const { dir, anchorX, anchorY, shapeId } = resizeHandle;
+    const shape = editor.shapes.value.find((s) => s.id === shapeId);
+    if (!shape) return;
+
+    let newX = shape.x, newY = shape.y, newW = shape.width, newH = shape.height;
+
+    if (dir.includes("w") || dir.includes("e")) {
+      const minX = dir.includes("w") ? pt.x : anchorX;
+      const maxX = dir.includes("w") ? anchorX : pt.x;
+      newX = Math.min(minX, maxX);
+      newW = Math.abs(maxX - minX);
+    }
+    if (dir.includes("n") || dir.includes("s")) {
+      const minY = dir.includes("n") ? pt.y : anchorY;
+      const maxY = dir.includes("n") ? anchorY : pt.y;
+      newY = Math.min(minY, maxY);
+      newH = Math.abs(maxY - minY);
+    }
+    // Edge-only handles: preserve the other axis
+    if (dir === "n" || dir === "s") { newX = shape.x; newW = shape.width; }
+    if (dir === "e" || dir === "w") { newY = shape.y; newH = shape.height; }
+
+    // Enforce minimum size
+    if (newW < 10) newW = 10;
+    if (newH < 10) newH = 10;
+
+    editor.resizeShape(shapeId, { x: newX, y: newY, width: newW, height: newH });
   } else if (dragState) {
     const dx = pt.x - dragState.startX;
     const dy = pt.y - dragState.startY;
+    if (!hasDragged && Math.abs(dx) < MIN_DRAG_THRESHOLD && Math.abs(dy) < MIN_DRAG_THRESHOLD) return;
+    hasDragged = true;
     editor.resizeShape(dragState.shapeId, {
       x: dragState.origX + dx,
       y: dragState.origY + dy,
-      width: editor.shapes.value.find((s) => s.id === dragState!.shapeId)!.width,
-      height: editor.shapes.value.find((s) => s.id === dragState!.shapeId)!.height,
+      width: dragState.origW,
+      height: dragState.origH,
     });
   }
 }
@@ -131,6 +224,7 @@ function onPointerUp(_e: PointerEvent) {
     editor.endDraw();
   }
   dragState = null;
+  resizeHandle = null;
 }
 
 const tools: { key: IoTool; label: string }[] = [
@@ -138,6 +232,29 @@ const tools: { key: IoTool; label: string }[] = [
   { key: "rect", label: "Rectangle" },
   { key: "ellipse", label: "Ellipse" },
 ];
+
+const HANDLE_SIZE = 8;
+const HANDLE_TOUCH_SIZE = 20; // Invisible larger touch target
+
+type HandleDef = { dir: HandleDir; cx: number; cy: number };
+function getHandles(shape: OcclusionShape): HandleDef[] {
+  const { x, y, width: w, height: h } = shape;
+  return [
+    { dir: "nw", cx: x, cy: y },
+    { dir: "n", cx: x + w / 2, cy: y },
+    { dir: "ne", cx: x + w, cy: y },
+    { dir: "e", cx: x + w, cy: y + h / 2 },
+    { dir: "se", cx: x + w, cy: y + h },
+    { dir: "s", cx: x + w / 2, cy: y + h },
+    { dir: "sw", cx: x, cy: y + h },
+    { dir: "w", cx: x, cy: y + h / 2 },
+  ];
+}
+
+const handleCursors: Record<HandleDir, string> = {
+  nw: "nwse-resize", n: "ns-resize", ne: "nesw-resize", e: "ew-resize",
+  se: "nwse-resize", s: "ns-resize", sw: "nesw-resize", w: "ew-resize",
+};
 </script>
 
 <template>
@@ -152,6 +269,22 @@ const tools: { key: IoTool; label: string }[] = [
       >
         {{ tool.label }}
       </Button>
+      <span class="io-toolbar-sep" />
+      <Button
+        :variant="editor.occlusionMode.value === 'hide-all-guess-one' ? 'primary' : 'secondary'"
+        size="sm"
+        @click="editor.setOcclusionMode('hide-all-guess-one')"
+      >
+        Hide All
+      </Button>
+      <Button
+        :variant="editor.occlusionMode.value === 'hide-one' ? 'primary' : 'secondary'"
+        size="sm"
+        @click="editor.setOcclusionMode('hide-one')"
+      >
+        Hide One
+      </Button>
+      <span class="io-toolbar-sep" />
       <Button
         variant="danger"
         size="sm"
@@ -218,19 +351,44 @@ const tools: { key: IoTool; label: string }[] = [
           </text>
         </template>
 
-        <!-- Selection outline -->
-        <rect
-          v-if="editor.selectedShape.value"
-          :x="editor.selectedShape.value.x - 2"
-          :y="editor.selectedShape.value.y - 2"
-          :width="editor.selectedShape.value.width + 4"
-          :height="editor.selectedShape.value.height + 4"
-          fill="none"
-          stroke="#2196f3"
-          stroke-width="2"
-          stroke-dasharray="6 3"
-          pointer-events="none"
-        />
+        <!-- Selection outline + resize handles -->
+        <template v-if="editor.selectedShape.value && !readonly">
+          <rect
+            :x="editor.selectedShape.value.x - 2"
+            :y="editor.selectedShape.value.y - 2"
+            :width="editor.selectedShape.value.width + 4"
+            :height="editor.selectedShape.value.height + 4"
+            fill="none"
+            stroke="#2196f3"
+            stroke-width="2"
+            stroke-dasharray="6 3"
+            pointer-events="none"
+          />
+          <!-- Resize handles -->
+          <template v-for="handle in getHandles(editor.selectedShape.value)" :key="handle.dir">
+            <!-- Invisible larger touch target -->
+            <rect
+              :data-handle="handle.dir"
+              :x="handle.cx - HANDLE_TOUCH_SIZE / 2"
+              :y="handle.cy - HANDLE_TOUCH_SIZE / 2"
+              :width="HANDLE_TOUCH_SIZE"
+              :height="HANDLE_TOUCH_SIZE"
+              fill="transparent"
+              :style="{ cursor: handleCursors[handle.dir] }"
+            />
+            <!-- Visible handle -->
+            <rect
+              :x="handle.cx - HANDLE_SIZE / 2"
+              :y="handle.cy - HANDLE_SIZE / 2"
+              :width="HANDLE_SIZE"
+              :height="HANDLE_SIZE"
+              fill="white"
+              stroke="#2196f3"
+              stroke-width="1.5"
+              pointer-events="none"
+            />
+          </template>
+        </template>
       </svg>
     </div>
   </div>
@@ -247,6 +405,14 @@ const tools: { key: IoTool; label: string }[] = [
   display: flex;
   gap: var(--spacing-1);
   flex-wrap: wrap;
+  align-items: center;
+}
+
+.io-toolbar-sep {
+  width: 1px;
+  height: 20px;
+  background: var(--color-border);
+  margin: 0 var(--spacing-1);
 }
 
 .io-canvas-wrapper {

--- a/src/components/ImageOcclusionNoteEditor.vue
+++ b/src/components/ImageOcclusionNoteEditor.vue
@@ -9,7 +9,9 @@ import {
   getImageFilename,
   parseOcclusionShapesForEditor,
   serializeShapesToSvg,
+  extractOcclusionMode,
   type OcclusionShape,
+  type OcclusionMode,
 } from "../utils/imageOcclusion";
 
 type Card = AnkiDB2Data["cards"][number];
@@ -27,6 +29,7 @@ const emit = defineEmits<{
 
 // Editor state
 const shapes = ref<OcclusionShape[]>([]);
+const occlusionMode = ref<OcclusionMode>("hide-all-guess-one");
 const headerText = ref("");
 const backExtraText = ref("");
 const editTags = ref<string[]>([]);
@@ -57,6 +60,10 @@ watch(
     headerText.value = getFieldValue(values, IO_FIELD_NAMES.header);
     backExtraText.value = getFieldValue(values, IO_FIELD_NAMES.backExtra);
     editTags.value = [...card.tags];
+
+    // Parse occlusion mode from SVG
+    const occSvgRaw = getFieldValue(values, IO_FIELD_NAMES.occlusions);
+    occlusionMode.value = extractOcclusionMode(occSvgRaw);
 
     // Parse existing shapes
     const occSvg = getFieldValue(values, IO_FIELD_NAMES.occlusions);
@@ -151,7 +158,7 @@ function handleTagKeydown(e: KeyboardEvent) {
 }
 
 function handleSave() {
-  const occSvg = serializeShapesToSvg(shapes.value, imageNaturalWidth.value, imageNaturalHeight.value);
+  const occSvg = serializeShapesToSvg(shapes.value, imageNaturalWidth.value, imageNaturalHeight.value, occlusionMode.value);
   const imgTag = imageFilename.value ? `<img src="${imageFilename.value}">` : "";
 
   const fields: Record<string, string | null> = {
@@ -191,6 +198,7 @@ function handleSave() {
     <template v-if="hasImage && imageUrl">
       <ImageOcclusionEditor
         v-model="shapes"
+        v-model:occlusion-mode="occlusionMode"
         :image-url="imageUrl"
       />
     </template>

--- a/src/composables/useImageOcclusionEditor.ts
+++ b/src/composables/useImageOcclusionEditor.ts
@@ -1,5 +1,5 @@
 import { ref, computed, type Ref } from "vue";
-import type { OcclusionShape } from "../utils/imageOcclusion";
+import type { OcclusionShape, OcclusionMode } from "../utils/imageOcclusion";
 
 let shapeIdCounter = 0;
 function generateId(): string {
@@ -13,6 +13,7 @@ export function useImageOcclusionEditor(initialShapes: OcclusionShape[] = []) {
   const selectedShapeId = ref<string | null>(null);
   const activeTool = ref<IoTool>("rect");
   const isDrawing = ref(false);
+  const occlusionMode = ref<OcclusionMode>("hide-all-guess-one");
 
   // Internal drawing state (not reactive for performance)
   let drawStartX = 0;
@@ -121,11 +122,16 @@ export function useImageOcclusionEditor(initialShapes: OcclusionShape[] = []) {
     selectedShapeId.value = null;
   }
 
+  function setOcclusionMode(mode: OcclusionMode) {
+    occlusionMode.value = mode;
+  }
+
   return {
     shapes,
     selectedShapeId,
     activeTool,
     isDrawing,
+    occlusionMode,
     selectedShape,
     nextOrdinal,
     setTool,
@@ -138,5 +144,6 @@ export function useImageOcclusionEditor(initialShapes: OcclusionShape[] = []) {
     deleteShape,
     deleteSelectedShape,
     setShapes,
+    setOcclusionMode,
   };
 }

--- a/src/utils/__tests__/imageOcclusion.test.ts
+++ b/src/utils/__tests__/imageOcclusion.test.ts
@@ -4,6 +4,7 @@ import {
   parseOcclusionShapes,
   parseOcclusionShapesForEditor,
   serializeShapesToSvg,
+  extractOcclusionMode,
   renderImageOcclusion,
   getImageFilename,
   type OcclusionShape,
@@ -225,6 +226,130 @@ describe("Image Occlusion", () => {
       const html = renderImageOcclusion({ values, cardOrd: 0, isAnswer: false });
       expect(html).toContain('<img src="test.png">');
       expect(html).toContain("Test");
+    });
+  });
+
+  describe("extractOcclusionMode", () => {
+    it("returns hide-all-guess-one by default", () => {
+      const svg = `<svg viewBox="0 0 800 600"><rect data-ordinal="1" x="0" y="0" width="10" height="10" /></svg>`;
+      expect(extractOcclusionMode(svg)).toBe("hide-all-guess-one");
+    });
+
+    it("parses hide-one mode", () => {
+      const svg = `<svg viewBox="0 0 800 600" data-mode="hide-one"><rect data-ordinal="1" x="0" y="0" width="10" height="10" /></svg>`;
+      expect(extractOcclusionMode(svg)).toBe("hide-one");
+    });
+
+    it("parses hide-all-guess-one mode", () => {
+      const svg = `<svg data-mode="hide-all-guess-one" viewBox="0 0 800 600"></svg>`;
+      expect(extractOcclusionMode(svg)).toBe("hide-all-guess-one");
+    });
+
+    it("falls back to default for unknown mode", () => {
+      const svg = `<svg data-mode="unknown" viewBox="0 0 800 600"></svg>`;
+      expect(extractOcclusionMode(svg)).toBe("hide-all-guess-one");
+    });
+  });
+
+  describe("serializeShapesToSvg with mode", () => {
+    it("includes data-mode attribute", () => {
+      const shapes: OcclusionShape[] = [
+        { id: "1", type: "rect", ordinal: 1, x: 0, y: 0, width: 10, height: 10 },
+      ];
+      const svg = serializeShapesToSvg(shapes, 800, 600, "hide-one");
+      expect(svg).toContain('data-mode="hide-one"');
+    });
+
+    it("defaults to hide-all-guess-one", () => {
+      const shapes: OcclusionShape[] = [
+        { id: "1", type: "rect", ordinal: 1, x: 0, y: 0, width: 10, height: 10 },
+      ];
+      const svg = serializeShapesToSvg(shapes, 800, 600);
+      expect(svg).toContain('data-mode="hide-all-guess-one"');
+    });
+
+    it("round-trips mode through serialize/extract", () => {
+      const shapes: OcclusionShape[] = [
+        { id: "1", type: "rect", ordinal: 1, x: 0, y: 0, width: 10, height: 10 },
+      ];
+      const svg = serializeShapesToSvg(shapes, 800, 600, "hide-one");
+      expect(extractOcclusionMode(svg)).toBe("hide-one");
+    });
+  });
+
+  describe("renderImageOcclusion with modes", () => {
+    const makeValues = (mode: string) => ({
+      "Image Occlusion": '<img src="test.png">',
+      Header: "",
+      "Back Extra": "",
+      Occlusions: `<svg viewBox="0 0 800 600" data-mode="${mode}">
+        <rect data-ordinal="1" x="10" y="20" width="100" height="50" fill="#ffeba2" />
+        <rect data-ordinal="2" x="200" y="100" width="80" height="60" fill="#ffeba2" />
+      </svg>`,
+    });
+
+    describe("hide-all-guess-one mode", () => {
+      it("shows all shapes as masks on front", () => {
+        const html = renderImageOcclusion({
+          values: makeValues("hide-all-guess-one"),
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        // Both shapes should be present
+        expect(html).toContain('x="10"');
+        expect(html).toContain('x="200"');
+        // Active one highlighted
+        expect(html).toContain('class="io-mask io-mask-active"');
+        // Non-active one plain mask
+        expect(html).toContain('class="io-mask"');
+      });
+
+      it("reveals active shape on back, keeps others masked", () => {
+        const html = renderImageOcclusion({
+          values: makeValues("hide-all-guess-one"),
+          cardOrd: 0,
+          isAnswer: true,
+        });
+        expect(html).toContain('class="io-mask-reveal"');
+        expect(html).toContain('class="io-mask"');
+      });
+    });
+
+    describe("hide-one mode", () => {
+      it("shows only active shape on front", () => {
+        const html = renderImageOcclusion({
+          values: makeValues("hide-one"),
+          cardOrd: 0,
+          isAnswer: false,
+        });
+        // Active shape should be present
+        expect(html).toContain('x="10"');
+        // Non-active shape should NOT be present
+        expect(html).not.toContain('x="200"');
+      });
+
+      it("reveals only active shape on back", () => {
+        const html = renderImageOcclusion({
+          values: makeValues("hide-one"),
+          cardOrd: 0,
+          isAnswer: true,
+        });
+        expect(html).toContain('class="io-mask-reveal"');
+        // Non-active shape should not be in the output
+        expect(html).not.toContain('x="200"');
+      });
+
+      it("shows different shape when cardOrd changes", () => {
+        const html = renderImageOcclusion({
+          values: makeValues("hide-one"),
+          cardOrd: 1,
+          isAnswer: false,
+        });
+        // Shape 2 (ordinal 2) should be present
+        expect(html).toContain('x="200"');
+        // Shape 1 (ordinal 1) should NOT be present
+        expect(html).not.toContain('x="10"');
+      });
     });
   });
 });

--- a/src/utils/imageOcclusion.ts
+++ b/src/utils/imageOcclusion.ts
@@ -19,6 +19,8 @@ export const IO_FIELD_NAMES = {
 
 // --- Types ---
 
+export type OcclusionMode = "hide-one" | "hide-all-guess-one";
+
 export type OcclusionShape = {
   id: string;
   type: "rect" | "ellipse";
@@ -164,6 +166,7 @@ export function serializeShapesToSvg(
   shapes: OcclusionShape[],
   imageWidth: number,
   imageHeight: number,
+  mode: OcclusionMode = "hide-all-guess-one",
 ): string {
   const elements = shapes.map((shape) => {
     if (shape.type === "ellipse") {
@@ -176,14 +179,26 @@ export function serializeShapesToSvg(
     return `<rect data-ordinal="${shape.ordinal}" x="${shape.x}" y="${shape.y}" width="${shape.width}" height="${shape.height}" fill="#ffeba2" fill-opacity="1" stroke="#2d2d2d" stroke-width="1"/>`;
   });
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${imageWidth} ${imageHeight}">\n  ${elements.join("\n  ")}\n</svg>`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${imageWidth} ${imageHeight}" data-mode="${mode}">\n  ${elements.join("\n  ")}\n</svg>`;
 }
 
-// --- SVG viewBox extraction ---
+// --- SVG metadata extraction ---
 
 function extractViewBox(svgString: string): string | null {
   const match = svgString.match(/viewBox="([^"]+)"/);
   return match ? match[1]! : null;
+}
+
+/**
+ * Extract the occlusion mode from the SVG root element.
+ * Defaults to "hide-all-guess-one" (Anki desktop default).
+ */
+export function extractOcclusionMode(svgString: string): OcclusionMode {
+  const match = svgString.match(/data-mode="([^"]+)"/);
+  if (match && (match[1] === "hide-one" || match[1] === "hide-all-guess-one")) {
+    return match[1];
+  }
+  return "hide-all-guess-one";
 }
 
 // --- Rendering ---
@@ -208,11 +223,26 @@ export function renderImageOcclusion({
   const activeOrdinal = cardOrd + 1;
   const shapes = parseOcclusionShapes(occlusionsSvg);
   const viewBox = extractViewBox(occlusionsSvg);
+  const mode = extractOcclusionMode(occlusionsSvg);
 
   const svgShapes = shapes
     .map(({ ordinal, svgElement }) => {
       const isActive = ordinal === activeOrdinal;
 
+      if (mode === "hide-one") {
+        // Hide one: only the active shape is shown as a mask; others are invisible
+        if (!isActive) return null;
+        if (isAnswer) {
+          return svgElement
+            .replace(/class="[^"]*"/, "")
+            .replace(/<(rect|ellipse|circle|polygon|path)\b/, `<$1 class="io-mask-reveal"`);
+        }
+        return svgElement
+          .replace(/class="[^"]*"/, "")
+          .replace(/<(rect|ellipse|circle|polygon|path)\b/, `<$1 class="io-mask io-mask-active"`);
+      }
+
+      // hide-all-guess-one (default): all shapes masked, active highlighted
       if (isAnswer) {
         if (isActive) {
           return svgElement
@@ -229,6 +259,7 @@ export function renderImageOcclusion({
           .replace(/<(rect|ellipse|circle|polygon|path)\b/, `<$1 class="${cssClass}"`);
       }
     })
+    .filter((s): s is string => s !== null)
     .join("\n    ");
 
   const viewBoxAttr = viewBox ? `viewBox="${viewBox}"` : "";


### PR DESCRIPTION
## Summary

closes #107 (Phase 3 of 3).

**Group Modes**
- `OcclusionMode` type: "hide-all-guess-one" (default) vs "hide-one"
- Mode stored as `data-mode` attribute on SVG root for Anki desktop interop
- `extractOcclusionMode()` parses mode from existing SVG
- `serializeShapesToSvg()` writes mode attribute
- `renderImageOcclusion()` excludes non-active shapes in hide-one mode
- Mode toggle buttons ("Hide All" / "Hide One") in editor toolbar

**Resize Handles**
- 8-direction handles (corners + edges) on selected shapes
- Anchor-based resize logic with minimum size enforcement (10x10)
- Invisible larger touch targets (20px) for mobile

**Touch Polish**
- Minimum drag threshold (5px) to prevent accidental moves on tap-to-select

**Tests**
- 12 new tests for mode extraction, serialization, and both rendering modes (35 IO tests total)