### PR TITLE
Fix false positive tests: add negative assertions, tighten permissive checks

### DIFF
--- a/e2e/backup.spec.ts
+++ b/e2e/backup.spec.ts
@@ -52,6 +52,11 @@ test.describe('Backup Panel', () => {
 
     const createBtn = page.locator('.backup-btn--primary:has-text("Create Backup")');
     await expect(createBtn).toBeVisible();
-    // Just verify the button is present and clickable (actual backup may fail without synced data)
+    await expect(createBtn).toBeEnabled();
+    await createBtn.click();
+
+    // After clicking, some response should appear (success toast, progress indicator, or error)
+    const response = page.locator('.toast, .backup-progress, .backup-status, .backup-error');
+    await expect(response.first()).toBeVisible({ timeout: 5000 });
   });
 });

--- a/e2e/browse-view.spec.ts
+++ b/e2e/browse-view.spec.ts
@@ -82,13 +82,22 @@ test.describe('Browse View', () => {
     await firstHeader.click();
     await page.waitForTimeout(300);
 
+    // Capture text after first sort
+    const afterFirstSort = await firstCell.textContent();
+
     // Click again to reverse sort
     await firstHeader.click();
     await page.waitForTimeout(300);
 
-    // Table should still be functional
+    const afterSecondSort = await firstCell.textContent();
+
+    // At least one of the sorts should change the first row compared to initial
+    // (unless there's only one row, in which case sorting can't change anything)
     const rowCount = await page.locator('.browse-table tbody tr').count();
-    expect(rowCount).toBeGreaterThan(0);
+    if (rowCount > 1) {
+      const changed = afterFirstSort !== initialText || afterSecondSort !== initialText;
+      expect(changed).toBe(true);
+    }
   });
 
   test('should show card preview in detail pane', async ({ loadedDeckPage: page }) => {

--- a/e2e/bulk-operations.spec.ts
+++ b/e2e/bulk-operations.spec.ts
@@ -140,7 +140,9 @@ test.describe('Bulk Operations', () => {
     await page.locator('.bulk-toolbar button:has-text("Suspend")').first().click();
     await page.waitForTimeout(500);
 
-    // Table should still be visible
+    // TODO: No visible UI indicator for suspended state — both Suspend/Unsuspend
+    // buttons are always shown. Consider adding a "Queue" column or row styling
+    // so this test can verify the state actually changed.
     await expect(page.locator('.browse-table')).toBeVisible();
   });
 
@@ -165,7 +167,7 @@ test.describe('Bulk Operations', () => {
     await page.locator('.bulk-toolbar button:has-text("Unsuspend")').click();
     await page.waitForTimeout(500);
 
-    // Table should still be visible
+    // TODO: Same as suspend test — no visible indicator to verify unsuspend worked.
     await expect(page.locator('.browse-table')).toBeVisible();
   });
 });

--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -52,16 +52,20 @@ test.describe('Command Palette', () => {
 
   test('should navigate commands with arrow keys', async ({ loadedDeckPage: page }) => {
     await page.keyboard.press('Control+k');
-    await expect(page.locator('.command-palette-item.selected')).toBeVisible();
+    const initialSelected = page.locator('.command-palette-item.selected');
+    await expect(initialSelected).toBeVisible();
+    const initialText = await initialSelected.textContent();
 
     // Press down arrow
     await page.keyboard.press('ArrowDown');
     await page.waitForTimeout(100);
 
-    // A different item should be selected
-    const selectedItems = page.locator('.command-palette-item.selected');
-    const count = await selectedItems.count();
+    // A different item should now be selected
+    const newSelected = page.locator('.command-palette-item.selected');
+    const count = await newSelected.count();
     expect(count).toBe(1);
+    const newText = await newSelected.textContent();
+    expect(newText).not.toBe(initialText);
   });
 
   test('should execute command on Enter', async ({ loadedDeckPage: page }) => {

--- a/e2e/congrats-screen.spec.ts
+++ b/e2e/congrats-screen.spec.ts
@@ -66,10 +66,14 @@ test.describe('Congrats Screen', () => {
     const stats = page.locator('.congrats-stats');
     await expect(stats).toBeVisible();
 
-    // Should have stat entries
+    // Should have stat entries with actual values
     const statItems = stats.locator('.stat');
     const count = await statItems.count();
     expect(count).toBeGreaterThan(0);
+
+    // At least one stat should contain a numeric value (not empty/placeholder)
+    const firstStatText = await statItems.first().textContent();
+    expect(firstStatText).toMatch(/\d/);
   });
 
   test('should show Back to Decks button on congrats screen', async ({

--- a/e2e/csv-import.spec.ts
+++ b/e2e/csv-import.spec.ts
@@ -140,9 +140,9 @@ test.describe('CSV Import Wizard', () => {
     await page.click('button:has-text("Next: Map Fields")');
     await page.click('button:has-text("Next: Preview")');
 
-    // Check card count
+    // Check card count — the text is "N cards" so match exactly "3 cards"
     const countText = await page.locator('.preview-count').textContent();
-    expect(countText).toContain('3');
+    expect(countText).toMatch(/\b3\b/);
   });
 
   test('should navigate back through wizard steps', async ({ loadedDeckPage: page }) => {

--- a/e2e/filtered-decks.spec.ts
+++ b/e2e/filtered-decks.spec.ts
@@ -53,7 +53,7 @@ test.describe('Filtered Decks', () => {
     const hint = page.locator('.field-hint').first();
     await expect(hint).toBeVisible();
     const hintText = await hint.textContent();
-    expect(hintText).toMatch(/\d+/);
+    expect(hintText).toMatch(/\d+\s*(cards?|matching)/i);
   });
 
   test('should show preview bar with card count', async ({ loadedDeckPage: page }) => {

--- a/e2e/note-type-manager.spec.ts
+++ b/e2e/note-type-manager.spec.ts
@@ -33,21 +33,6 @@ test.describe('Note Type Manager', () => {
     await expect(page.locator('.sidebar-actions button').first()).toBeVisible();
   });
 
-  test('should show empty state or note type list', async ({ loadedDeckPage: page }) => {
-    await page.keyboard.press('Control+k');
-    await page.locator('.command-palette-input').fill('manage note types');
-    await page.waitForTimeout(200);
-    await page.keyboard.press('Enter');
-    await expect(page.locator('.ds-modal__title:has-text("Manage Note Types")')).toBeVisible();
-
-    // Either note types are listed or an empty state message is shown
-    await page.waitForTimeout(1000);
-    const items = page.locator('.notetype-item');
-    const itemCount = await items.count();
-    // With a non-synced deck, the list may be empty — that's OK
-    expect(itemCount).toBeGreaterThanOrEqual(0);
-  });
-
   test('should close modal', async ({ loadedDeckPage: page }) => {
     await page.keyboard.press('Control+k');
     await page.locator('.command-palette-input').fill('manage note types');

--- a/src/ankiParser/__tests__/parserCorrectness.test.ts
+++ b/src/ankiParser/__tests__/parserCorrectness.test.ts
@@ -1,8 +1,6 @@
 /**
  * Tests for parser correctness issues identified by cross-referencing
  * with the Anki source (ankitects/anki via deepwiki).
- *
- * All tests in this file are EXPECTED TO FAIL against the current implementation.
  */
 import { describe, it, expect } from "vitest";
 import { getDataFromAnki2 } from "../anki2";

--- a/src/scheduler/__tests__/anki-sm2-algorithm.test.ts
+++ b/src/scheduler/__tests__/anki-sm2-algorithm.test.ts
@@ -35,6 +35,7 @@ describe("AnkiSM2Algorithm", () => {
       const result = algo.reviewCard(card, "again");
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.phase).toBe("learning");
+      expect(newState.phase).not.toBe("review"); // shouldn't graduate on again
       expect(newState.step).toBe(0);
       expect(newState.reps).toBe(1);
     });
@@ -45,7 +46,9 @@ describe("AnkiSM2Algorithm", () => {
       const newState = result.cardState as AnkiSM2CardState;
       // Good advances to next step (step 1 of [1, 10])
       expect(newState.phase).toBe("learning");
+      expect(newState.phase).not.toBe("review"); // shouldn't graduate after first good
       expect(newState.step).toBe(1);
+      expect(newState.step).not.toBe(0); // must advance past step 0
     });
 
     it("graduates immediately on 'easy'", () => {
@@ -53,7 +56,10 @@ describe("AnkiSM2Algorithm", () => {
       const result = algo.reviewCard(card, "easy");
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.phase).toBe("review");
+      expect(newState.phase).not.toBe("learning"); // easy must skip learning
       expect(newState.interval).toBe(DEFAULT_SM2_PARAMS.easyInterval);
+      // easyInterval (4) != graduatingInterval (1) — shouldn't use the wrong one
+      expect(newState.interval).not.toBe(DEFAULT_SM2_PARAMS.graduatingInterval);
     });
 
     it("graduates immediately when no learning steps", () => {
@@ -81,6 +87,8 @@ describe("AnkiSM2Algorithm", () => {
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.phase).toBe("review");
       expect(newState.interval).toBe(DEFAULT_SM2_PARAMS.graduatingInterval);
+      // Should use graduatingInterval (1), not easyInterval (4)
+      expect(newState.interval).not.toBe(DEFAULT_SM2_PARAMS.easyInterval);
     });
 
     it("resets to step 0 on 'again'", () => {
@@ -96,7 +104,9 @@ describe("AnkiSM2Algorithm", () => {
       const result = algo.reviewCard(card, "again");
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.phase).toBe("learning");
+      expect(newState.phase).not.toBe("review"); // again must not graduate
       expect(newState.step).toBe(0);
+      expect(newState.step).not.toBe(1); // must actually reset, not stay at current step
     });
 
     it("graduates on 'easy' from learning", () => {
@@ -134,7 +144,10 @@ describe("AnkiSM2Algorithm", () => {
       const result = algo.reviewCard(card, "again");
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.ease).toBe(2.3);
+      expect(newState.ease).not.toBe(2.5); // must not keep original ease
+      expect(newState.ease).not.toBe(2.35); // must not use hard's penalty (-0.15)
       expect(newState.lapses).toBe(1);
+      expect(newState.lapses).not.toBe(0); // again must increment lapses
     });
 
     it("enters relearning on 'again' with relearning steps", () => {
@@ -142,6 +155,8 @@ describe("AnkiSM2Algorithm", () => {
       const result = algo.reviewCard(card, "again");
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.phase).toBe("relearning");
+      expect(newState.phase).not.toBe("learning"); // relearning, not learning
+      expect(newState.phase).not.toBe("review"); // must not stay in review
     });
 
     it("decreases ease on 'hard'", () => {
@@ -149,7 +164,9 @@ describe("AnkiSM2Algorithm", () => {
       const result = algo.reviewCard(card, "hard");
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.ease).toBe(2.35);
+      expect(newState.ease).not.toBe(2.3); // must not use again's penalty (-0.2)
       expect(newState.phase).toBe("review");
+      expect(newState.lapses).toBe(0); // hard must not increment lapses
     });
 
     it("keeps ease on 'good'", () => {
@@ -157,6 +174,9 @@ describe("AnkiSM2Algorithm", () => {
       const result = algo.reviewCard(card, "good");
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.ease).toBe(2.5);
+      expect(newState.ease).not.toBe(2.35); // must not apply hard penalty
+      expect(newState.ease).not.toBe(2.65); // must not apply easy bonus
+      expect(newState.lapses).toBe(0); // good must not increment lapses
     });
 
     it("increases ease on 'easy'", () => {
@@ -164,6 +184,9 @@ describe("AnkiSM2Algorithm", () => {
       const result = algo.reviewCard(card, "easy");
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.ease).toBe(2.65);
+      expect(newState.ease).not.toBe(2.5); // must not keep original ease
+      expect(newState.ease).not.toBe(2.35); // must not decrease ease
+      expect(newState.lapses).toBe(0); // easy must not increment lapses
     });
 
     it("enforces minimum ease of 1.3", () => {
@@ -171,6 +194,9 @@ describe("AnkiSM2Algorithm", () => {
       const result = algo.reviewCard(card, "again");
       const newState = result.cardState as AnkiSM2CardState;
       expect(newState.ease).toBe(1.3);
+      // Must not go below floor (1.3 - 0.2 = 1.1 would be wrong)
+      expect(newState.ease).not.toBe(1.1);
+      expect(newState.ease).not.toBe(0);
     });
 
     it("enforces good > hard interval ordering", () => {
@@ -245,7 +271,23 @@ describe("AnkiSM2Algorithm", () => {
       expect((result.reviewLog as AnkiSM2ReviewLog).leeched).toBe(true);
     });
 
-    it("does not mark as leeched below threshold", () => {
+    it("does not mark as leeched one below threshold", () => {
+      // lapses=6, after 'again' becomes 7 — still below threshold of 8
+      const card: AnkiSM2CardState = {
+        phase: "review",
+        step: 0,
+        ease: 2.5,
+        interval: 10,
+        due: Date.now(),
+        lapses: 6,
+        reps: 15,
+      };
+      const result = algo.reviewCard(card, "again");
+      // Off-by-one: 7 lapses is NOT the threshold (8 is)
+      expect((result.reviewLog as AnkiSM2ReviewLog).leeched).toBe(false);
+    });
+
+    it("does not mark as leeched well below threshold", () => {
       const card: AnkiSM2CardState = {
         phase: "review",
         step: 0,
@@ -263,11 +305,21 @@ describe("AnkiSM2Algorithm", () => {
   describe("getNextIntervals", () => {
     it("returns dates for all four answers", () => {
       const card = algo.createCard();
+      const now = Date.now();
       const intervals = algo.getNextIntervals(card);
       expect(intervals.again).toBeInstanceOf(Date);
       expect(intervals.hard).toBeInstanceOf(Date);
       expect(intervals.good).toBeInstanceOf(Date);
       expect(intervals.easy).toBeInstanceOf(Date);
+
+      // All intervals should be in the future (or at current time)
+      expect(intervals.again.getTime()).toBeGreaterThanOrEqual(now);
+      expect(intervals.hard.getTime()).toBeGreaterThanOrEqual(now);
+      expect(intervals.good.getTime()).toBeGreaterThanOrEqual(now);
+      expect(intervals.easy.getTime()).toBeGreaterThanOrEqual(now);
+
+      // Easy should be further out than again for a new card
+      expect(intervals.easy.getTime()).toBeGreaterThan(intervals.again.getTime());
     });
   });
 

--- a/src/scheduler/__tests__/queue.test.ts
+++ b/src/scheduler/__tests__/queue.test.ts
@@ -44,6 +44,16 @@ describe("ReviewQueue.getDueCards", () => {
     expect(due[0]!.cardId).toBe("c1");
   });
 
+  it("should exclude cards that are not yet due", () => {
+    const futureCard = makeReviewCard({ cardId: "c-future" });
+    // Set due date far in the future
+    (futureCard.reviewState.cardState as { due: number }).due =
+      Date.now() + 7 * 24 * 60 * 60 * 1000;
+    const due = queue.getDueCards([futureCard]);
+    const ids = due.map((c) => c.cardId);
+    expect(ids).not.toContain("c-future");
+  });
+
   it("should exclude suspended cards (queueOverride = -1)", () => {
     const card = makeReviewCard({ cardId: "c1" });
     card.reviewState.queueOverride = -1;
@@ -58,6 +68,30 @@ describe("ReviewQueue.getDueCards", () => {
 
     const due = queue.getDueCards([card]);
     expect(due).toHaveLength(0);
+  });
+
+  it("should not confuse suspended (-1) with buried (-3)", () => {
+    const suspended = makeReviewCard({ cardId: "c-sus" });
+    suspended.reviewState.queueOverride = -1;
+    const buried = makeReviewCard({ cardId: "c-bur" });
+    buried.reviewState.queueOverride = -3;
+    const normal = makeReviewCard({ cardId: "c-norm" });
+
+    // Both excluded, but only the normal card comes through
+    const due = queue.getDueCards([suspended, buried, normal]);
+    expect(due).toHaveLength(1);
+    expect(due[0]!.cardId).toBe("c-norm");
+    expect(due[0]!.cardId).not.toBe("c-sus");
+    expect(due[0]!.cardId).not.toBe("c-bur");
+  });
+
+  it("should not exclude cards with unrelated queueOverride values", () => {
+    const card = makeReviewCard({ cardId: "c1" });
+    // queueOverride = 0 is not suspended or buried
+    card.reviewState.queueOverride = 0;
+
+    const due = queue.getDueCards([card]);
+    expect(due).toHaveLength(1);
   });
 
   it("should include cards without queueOverride alongside filtered ones", () => {

--- a/src/utils/__tests__/duplicates.test.ts
+++ b/src/utils/__tests__/duplicates.test.ts
@@ -25,7 +25,11 @@ describe("normalizeForComparison", () => {
   });
 
   it("strips sound tags", () => {
-    expect(normalizeForComparison("[sound:audio.mp3] hello")).toBe("hello");
+    const result = normalizeForComparison("[sound:audio.mp3] hello");
+    expect(result).toBe("hello");
+    // Must strip the whole tag, not just the brackets
+    expect(result).not.toContain("sound");
+    expect(result).not.toContain("audio.mp3");
   });
 
   it("normalizes whitespace", () => {
@@ -74,6 +78,10 @@ describe("stringSimilarity", () => {
     const sim1 = stringSimilarity("cat", "cats");
     const sim2 = stringSimilarity("cat", "dog");
     expect(sim1).toBeGreaterThan(sim2);
+    // "cat" vs "cats" should be high but not perfect
+    expect(sim1).not.toBe(1);
+    // "cat" vs "dog" should be very low (no shared bigrams)
+    expect(sim2).toBeLessThan(0.5);
   });
 
   it("handles short strings", () => {
@@ -98,8 +106,15 @@ describe("findExactDuplicates", () => {
     });
 
     expect(groups).toHaveLength(1);
+    expect(groups).not.toHaveLength(2); // "world" is unique, must not form its own group
     expect(groups[0]!.notes).toHaveLength(2);
+    expect(groups[0]!.notes).not.toHaveLength(3); // "world" must not be in the group
     expect(groups[0]!.similarity).toBe(1.0);
+    // The group should contain guid 1 and 2, not guid 3
+    const guids = groups[0]!.notes.map((n) => n.guid);
+    expect(guids).toContain("1");
+    expect(guids).toContain("2");
+    expect(guids).not.toContain("3");
   });
 
   it("finds duplicates ignoring HTML", () => {
@@ -134,8 +149,12 @@ describe("findExactDuplicates", () => {
     });
 
     expect(groups).toHaveLength(1);
+    // Must not group cross-deck (all 3 have same Front but are in different decks)
     expect(groups[0]!.notes).toHaveLength(2);
+    expect(groups[0]!.notes).not.toHaveLength(3);
     expect(groups[0]!.notes.every((n) => n.deckName === "Deck A")).toBe(true);
+    // Deck B note must not leak into the group
+    expect(groups[0]!.notes.some((n) => n.deckName === "Deck B")).toBe(false);
   });
 
   it("compares by specified field index", () => {
@@ -210,8 +229,14 @@ describe("findFuzzyDuplicates", () => {
 
     expect(groups).toHaveLength(1);
     expect(groups[0]!.notes).toHaveLength(2);
+    // "fox" vs "fax" is fuzzy, not exact
     expect(groups[0]!.similarity).toBeLessThan(1.0);
     expect(groups[0]!.similarity).toBeGreaterThan(0.7);
+    // "something completely different here" must not be in the group
+    const guids = groups[0]!.notes.map((n) => n.guid);
+    expect(guids).not.toContain("3");
+    expect(guids).toContain("1");
+    expect(guids).toContain("2");
   });
 });
 
@@ -231,7 +256,11 @@ describe("findDuplicates", () => {
     });
 
     expect(groups).toHaveLength(1);
+    // Must not include "hallo" as fuzzy match when fuzzy is disabled
     expect(groups[0]!.notes).toHaveLength(2);
+    expect(groups[0]!.notes).not.toHaveLength(3);
+    const guids = groups[0]!.notes.map((n) => n.guid);
+    expect(guids).not.toContain("3"); // "hallo" is only a fuzzy match
   });
 
   it("returns exact + fuzzy when fuzzy is true", () => {
@@ -248,11 +277,12 @@ describe("findDuplicates", () => {
       fuzzyThreshold: 0.8,
     });
 
-    // Exact group (guid 1, 2) + fuzzy group (guid 3 with one of the others? No - guid 3 is compared with remaining)
-    // guid 1 and 2 are exact, guid 3 is fuzzy-similar to them but excluded from fuzzy since 1,2 are in exact
-    // So there should be 1 exact group only since guid 3 is alone after exclusion
-    expect(groups.length).toBeGreaterThanOrEqual(1);
+    // guid 1 and 2 are exact duplicates (similarity 1.0)
+    // guid 3 ("hello world tess") is fuzzy-similar but excluded from fuzzy since 1,2 are in exact group
+    // So there should be exactly 1 group: the exact match group
+    expect(groups.length).toBe(1);
     expect(groups[0]!.similarity).toBe(1.0);
+    expect(groups[0]!.notes).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace tautological assertions (`>= 0`, type-only checks, overly permissive regexes) with meaningful ones
- Add negative near-miss assertions to SM2 algorithm, queue filtering, and duplicate detection tests
- Add new tests for boundary conditions (leech off-by-one, future due cards, unrelated queueOverride values)
- Tighten e2e tests: sort verification, arrow-key navigation, CSV card count, stats content
- Remove stale "expected to fail" comment from parserCorrectness tests