### PR TITLE
refactor: consolidate duplicate utilities, optimize stats and batch DB operations

### DIFF
--- a/src/ankiExporter/csvJsonExport.ts
+++ b/src/ankiExporter/csvJsonExport.ts
@@ -1,4 +1,5 @@
 import type { AnkiData } from "../ankiParser";
+import { stripHtml } from "../utils/stripHtml";
 
 export type ExportFormat = "csv" | "json";
 export type ExportScope = "deck" | "all";
@@ -14,14 +15,6 @@ interface ExportOptions {
 }
 
 type CardData = AnkiData["cards"][number];
-
-function stripHtml(html: string | null | undefined): string {
-  if (!html) return "";
-  return html
-    .replace(/\[sound:[^\]]+\]/g, "")
-    .replace(/<[^>]*>/g, "")
-    .trim();
-}
 
 function getCardsForExport(ankiData: AnkiData, options: ExportOptions): CardData[] {
   if (options.scope === "all" || !options.deckName) {

--- a/src/ankiExporter/index.ts
+++ b/src/ankiExporter/index.ts
@@ -1,15 +1,12 @@
 import { createDatabase } from "~/utils/sql";
 import { BlobWriter, ZipWriter, BlobReader } from "@zip-js/zip-js";
 import type { AnkiDeckSpec } from "../lib/ollama";
-import { stringHash, ANKI_DEFAULT_CSS } from "../utils/constants";
+import { ankiSortField, fieldChecksum, ANKI_DEFAULT_CSS } from "../utils/constants";
 
 function generateId(): number {
   return Date.now() + Math.floor(Math.random() * 1000);
 }
 
-function fieldChecksum(field: string): number {
-  return stringHash(field.replace(/<[^>]*>/g, "").trim());
-}
 
 function guidFromId(_id: number): string {
   // Generate a random base91-like GUID (random source, not derived from ID)
@@ -250,7 +247,7 @@ export async function createApkg(spec: AnkiDeckSpec): Promise<Blob> {
     const flds = `${card.front}\x1f${card.back}`;
     const csum = fieldChecksum(card.front);
     const tags = (card.tags ?? []).join(" ");
-    const sfld = card.front.replace(/<[^>]*>/g, "").trim();
+    const sfld = ankiSortField(card.front);
 
     db.run("INSERT INTO notes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", [
       noteId,

--- a/src/components/BackupPanel.vue
+++ b/src/components/BackupPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
+import { formatFileSize } from "../utils/format";
 import { Download, Upload, Archive, Trash2, RotateCcw } from "lucide-vue-next";
 import Modal from "../design-system/components/primitives/Modal.vue";
 import {
@@ -160,11 +161,6 @@ function formatDate(ts: number): string {
   return new Date(ts).toLocaleString();
 }
 
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 const intervalOptions = [
   { label: "1 hour", value: 60 * 60 * 1000 },
@@ -217,7 +213,7 @@ const intervalOptions = [
           <div class="backup-item-info">
             <span class="backup-item-label">{{ backup.label }}</span>
             <span class="backup-item-meta">
-              {{ formatDate(backup.createdAt) }} · {{ formatSize(backup.sizeBytes) }}
+              {{ formatDate(backup.createdAt) }} · {{ formatFileSize(backup.sizeBytes) }}
             </span>
           </div>
           <div class="backup-item-actions">

--- a/src/components/CardBrowser.vue
+++ b/src/components/CardBrowser.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, nextTick, onBeforeUnmount } from "vue";
 import {
   ankiDataSig,
   mediaFilesSig,
@@ -16,12 +16,14 @@ import FindReplaceModal from "./FindReplaceModal.vue";
 import { getRenderedCardString, replaceMediaFiles } from "../utils/render";
 import { isImageOcclusionCard, renderImageOcclusion } from "../utils/imageOcclusion";
 import { sanitizeHtmlForPreview } from "../utils/sanitize";
+import { stripHtml } from "../utils/stripHtml";
 import { playAudio } from "../utils/sound";
 import Button from "../design-system/components/primitives/Button.vue";
 import Modal from "../design-system/components/primitives/Modal.vue";
 import NoteEditModal from "./NoteEditModal.vue";
 import TagTree from "./TagTree.vue";
-import { buildTagTree } from "../utils/tagTree";
+import { buildTagTree, tagMatchesOrIsChild } from "../utils/tagTree";
+import { useVirtualScroll } from "../composables/useVirtualScroll";
 import { getFlags } from "../lib/flags";
 import { reviewDB } from "../scheduler/db";
 import { QUEUE_USER_BURIED, QUEUE_SUSPENDED } from "../lib/syncWrite";
@@ -130,14 +132,6 @@ watch(viewMode, () => {
   lastClickedKey.value = null;
 });
 
-/** Strip HTML and sound tags to plain text for display and search */
-function stripHtml(html: string | null): string {
-  if (!html) return "";
-  return html
-    .replace(/\[sound:[^\]]+\]/g, "")
-    .replace(/<[^>]*>/g, "")
-    .trim();
-}
 
 /** All unique tags */
 const allTags = computed(() => {
@@ -816,7 +810,7 @@ const filteredRows = computed(() => {
   const tagFilter = activeTagFilter.value;
   if (tagFilter) {
     result = result.filter((row) =>
-      row.tags.some((t) => t === tagFilter || t.startsWith(tagFilter + "::")),
+      row.tags.some((t) => tagMatchesOrIsChild(t, tagFilter)),
     );
   }
 
@@ -892,53 +886,12 @@ function getCellValue(row: Row, col: string): string {
 
 // ── Virtual scrolling ──
 
-const ROW_HEIGHT = 30;
-const OVERSCAN = 10;
-const scrollContainerRef = ref<HTMLElement | null>(null);
-const scrollTop = ref(0);
-const containerHeight = ref(600);
-
-function onTableScroll(e: Event) {
-  const target = e.target as HTMLElement;
-  scrollTop.value = target.scrollTop;
-}
-
-let resizeObserver: ResizeObserver | null = null;
-
-onMounted(() => {
-  if (scrollContainerRef.value) {
-    containerHeight.value = scrollContainerRef.value.clientHeight;
-    resizeObserver = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        containerHeight.value = entry.contentRect.height;
-      }
-    });
-    resizeObserver.observe(scrollContainerRef.value);
-  }
+const { scrollContainerRef, onScroll: onTableScroll, virtualSlice } = useVirtualScroll({
+  items: filteredRows,
 });
 
 onBeforeUnmount(() => {
-  resizeObserver?.disconnect();
   document.removeEventListener("mousedown", handleColumnMenuOutsideClick);
-});
-
-const virtualSlice = computed(() => {
-  const total = filteredRows.value.length;
-  const headerHeight = ROW_HEIGHT;
-  const startIndex = Math.max(
-    0,
-    Math.floor((scrollTop.value - headerHeight) / ROW_HEIGHT) - OVERSCAN,
-  );
-  const visibleCount = Math.ceil(containerHeight.value / ROW_HEIGHT) + OVERSCAN * 2;
-  const endIndex = Math.min(total, startIndex + visibleCount);
-
-  return {
-    startIndex,
-    endIndex,
-    totalHeight: total * ROW_HEIGHT + headerHeight,
-    offsetY: startIndex * ROW_HEIGHT + headerHeight,
-    rows: filteredRows.value.slice(startIndex, endIndex),
-  };
 });
 
 // ── Row selection (multi-select) ──
@@ -1060,16 +1013,21 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/** Pre-compiled media replacement regexps, keyed by mediaFilesSig identity */
+const mediaRegexps = computed(() =>
+  Array.from(mediaFilesSig.value, ([filename, url]) => ({
+    re: new RegExp(`((?:src|data-sound-file)="[^"]*?)${escapeRegExp(filename)}`, "g"),
+    url,
+  })),
+);
+
 function renderFieldHtml(html: string | null): string {
   if (!html) return "";
   let result = html.replace(/\[sound:(.+?)\]/g, (_match, filename) => {
     return `<button class="sound-btn" style="color: var(--color-text-secondary)" data-sound-file="${filename}">${SOUND_ICON_SVG}</button>`;
   });
-  for (const [filename, url] of mediaFilesSig.value) {
-    result = result.replace(
-      new RegExp(`((?:src|data-sound-file)="[^"]*?)${escapeRegExp(filename)}`, "g"),
-      `$1${url}`,
-    );
+  for (const { re, url } of mediaRegexps.value) {
+    result = result.replace(re, `$1${url}`);
   }
   return sanitizeHtmlForPreview(result);
 }
@@ -1115,12 +1073,13 @@ async function bulkSuspend() {
   bulkOperationInProgress.value = true;
   try {
     const indices = getCardIndicesForRows(getSelectedRows());
+    const patches: { cardId: string; patch: { queueOverride: number } }[] = [];
     for (const idx of indices) {
       const card = data.cards[idx];
       if (!card?.scheduling) continue;
       const cardId = card.ankiCardId;
       if (cardId != null) {
-        await reviewDB.patchCard(String(cardId), { queueOverride: QUEUE_SUSPENDED });
+        patches.push({ cardId: String(cardId), patch: { queueOverride: QUEUE_SUSPENDED } });
       }
       card.scheduling = {
         ...card.scheduling,
@@ -1128,6 +1087,7 @@ async function bulkSuspend() {
         queueName: "suspended",
       };
     }
+    await reviewDB.patchCards(patches);
     triggerRef(ankiDataSig);
     markDataChanged();
   } finally {
@@ -1146,6 +1106,7 @@ async function bulkUnsuspend() {
   bulkOperationInProgress.value = true;
   try {
     const indices = getCardIndicesForRows(getSelectedRows());
+    const patches: { cardId: string; patch: { queueOverride: number } }[] = [];
     for (const idx of indices) {
       const card = data.cards[idx];
       if (!card?.scheduling) continue;
@@ -1154,7 +1115,7 @@ async function bulkUnsuspend() {
       const restoredQueueName = TYPE_TO_QUEUE_NAME[card.scheduling.type] ?? "new";
       const cardId = card.ankiCardId;
       if (cardId != null) {
-        await reviewDB.patchCard(String(cardId), { queueOverride: restoredQueue });
+        patches.push({ cardId: String(cardId), patch: { queueOverride: restoredQueue } });
       }
       card.scheduling = {
         ...card.scheduling,
@@ -1162,6 +1123,7 @@ async function bulkUnsuspend() {
         queueName: restoredQueueName,
       };
     }
+    await reviewDB.patchCards(patches);
     triggerRef(ankiDataSig);
     markDataChanged();
   } finally {
@@ -1401,7 +1363,7 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
                     'tr--multi-selected': selectedRowKeys.has(row.key),
                   },
                 ]"
-                :style="{ height: ROW_HEIGHT + 'px' }"
+                class="tr-fixed-height"
                 @click="handleRowClick(row, $event)"
               >
                 <td v-for="col in visibleColumns" :key="col.key" class="td">
@@ -1925,6 +1887,10 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
 .tr {
   cursor: pointer;
   transition: background 0.1s;
+}
+
+.tr-fixed-height {
+  height: 30px;
 }
 
 .tr:hover {

--- a/src/components/FindDuplicates.vue
+++ b/src/components/FindDuplicates.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import { ankiDataSig, activeViewSig } from "../stores";
+import { stripHtml } from "../utils/stripHtml";
+import { truncate } from "../utils/format";
 import {
   findDuplicates,
   buildNoteInfos,
@@ -109,20 +111,6 @@ function runSearch() {
   });
 }
 
-/** Strip HTML for display */
-function stripHtml(html: string | null): string {
-  if (!html) return "";
-  return html
-    .replace(/\[sound:[^\]]+\]/g, "")
-    .replace(/<[^>]*>/g, "")
-    .trim();
-}
-
-/** Truncate text for display */
-function truncate(text: string, maxLen: number = 120): string {
-  if (text.length <= maxLen) return text;
-  return text.slice(0, maxLen) + "...";
-}
 
 /** Get a preview of note fields (excluding the comparison field) */
 function getNotePreview(note: NoteInfo, skipFieldIndex: number): string {

--- a/src/components/FindReplaceModal.vue
+++ b/src/components/FindReplaceModal.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import { ankiDataSig, bulkUpdateNoteFields } from "../stores";
+import { stripHtml } from "../utils/stripHtml";
+import { escapeHtml, truncate } from "../utils/format";
 import Modal from "../design-system/components/primitives/Modal.vue";
 import Button from "../design-system/components/primitives/Button.vue";
 
@@ -177,13 +179,6 @@ const preview = computed<NoteChange[]>(() => {
 
 const totalChanges = computed(() => preview.value.reduce((sum, n) => sum + n.changes.length, 0));
 
-function stripHtml(html: string): string {
-  return html
-    .replace(/\[sound:[^\]]+\]/g, "")
-    .replace(/<[^>]*>/g, "")
-    .trim();
-}
-
 // ── Highlight matches in a string for display ──
 
 function highlightMatches(text: string, isOld: boolean): string {
@@ -219,21 +214,6 @@ function highlightMatches(text: string, isOld: boolean): string {
     parts.push(escapeHtml(text.slice(lastIndex)));
   }
   return parts.join("");
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-// ── Truncate long text for display ──
-
-function truncate(text: string, max = 120): string {
-  if (text.length <= max) return text;
-  return text.slice(0, max) + "...";
 }
 
 // ── Apply changes ──

--- a/src/composables/useVirtualScroll.ts
+++ b/src/composables/useVirtualScroll.ts
@@ -1,0 +1,59 @@
+import { ref, computed, onMounted, onBeforeUnmount, type Ref, type ComputedRef } from "vue";
+
+interface VirtualScrollOptions<T> {
+  items: ComputedRef<T[]> | Ref<T[]>;
+  rowHeight?: number;
+  overscan?: number;
+}
+
+export function useVirtualScroll<T>({ items, rowHeight = 30, overscan = 10 }: VirtualScrollOptions<T>) {
+  const scrollContainerRef = ref<HTMLElement | null>(null);
+  const scrollTop = ref(0);
+  const containerHeight = ref(600);
+  let resizeObserver: ResizeObserver | null = null;
+
+  function onScroll(e: Event) {
+    scrollTop.value = (e.target as HTMLElement).scrollTop;
+  }
+
+  onMounted(() => {
+    if (scrollContainerRef.value) {
+      containerHeight.value = scrollContainerRef.value.clientHeight;
+      resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          containerHeight.value = entry.contentRect.height;
+        }
+      });
+      resizeObserver.observe(scrollContainerRef.value);
+    }
+  });
+
+  onBeforeUnmount(() => {
+    resizeObserver?.disconnect();
+  });
+
+  const virtualSlice = computed(() => {
+    const total = items.value.length;
+    const headerHeight = rowHeight;
+    const startIndex = Math.max(
+      0,
+      Math.floor((scrollTop.value - headerHeight) / rowHeight) - overscan,
+    );
+    const visibleCount = Math.ceil(containerHeight.value / rowHeight) + overscan * 2;
+    const endIndex = Math.min(total, startIndex + visibleCount);
+
+    return {
+      startIndex,
+      endIndex,
+      totalHeight: total * rowHeight + headerHeight,
+      offsetY: startIndex * rowHeight + headerHeight,
+      rows: items.value.slice(startIndex, endIndex),
+    };
+  });
+
+  return {
+    scrollContainerRef,
+    onScroll,
+    virtualSlice,
+  };
+}

--- a/src/deckLibrary.ts
+++ b/src/deckLibrary.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { AnkiData } from "./ankiParser";
+import { formatFileSize } from "./utils/format";
 
 const cachedFileEntrySchema = z.array(
   z.object({
@@ -93,11 +94,6 @@ export function removeCachedFileEntry(cachedFiles: CachedFileEntry[], name: stri
   return cachedFiles.filter((file) => file.name !== name);
 }
 
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 function formatAddedDate(timestamp: number): string {
   return new Date(timestamp).toLocaleDateString(undefined, {

--- a/src/lib/notetypeOps.ts
+++ b/src/lib/notetypeOps.ts
@@ -9,6 +9,7 @@ import {
   parseTemplatesProto,
   type Anki21bFieldConfig,
 } from "~/ankiParser/anki21b/proto";
+import { ankiSortField } from "~/utils/constants";
 
 function now(): number {
   return Math.floor(Date.now() / 1000);
@@ -463,7 +464,7 @@ export function convertNotes(
     });
 
     const newFlds = newSegments.join("\x1f");
-    const sfld = (newSegments[0] ?? "").replace(/<[^>]*>/g, "").trim();
+    const sfld = ankiSortField(newSegments[0] ?? "");
 
     db.run("UPDATE notes SET mid=?, flds=?, sfld=?, mod=?, usn=-1 WHERE id=?", [
       targetNtidNum,

--- a/src/scheduler/db.ts
+++ b/src/scheduler/db.ts
@@ -194,6 +194,37 @@ class ReviewDB {
     });
   }
 
+  /**
+   * Batch-patch multiple cards in a single transaction.
+   */
+  async patchCards(
+    patches: { cardId: string; patch: Partial<CardReviewState> }[],
+  ): Promise<void> {
+    if (patches.length === 0) return;
+    const db = await this.ensureInit();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("cards", "readwrite");
+      const store = tx.objectStore("cards");
+      let remaining = patches.length;
+
+      tx.onerror = () => reject(tx.error);
+      tx.oncomplete = () => resolve();
+
+      for (const { cardId, patch } of patches) {
+        const getReq = store.get(cardId);
+        getReq.onsuccess = () => {
+          const existing = getReq.result as CardReviewState | undefined;
+          if (existing) {
+            store.put({ ...existing, ...patch });
+          }
+          if (--remaining === 0) {
+            // All puts issued; transaction will auto-commit
+          }
+        };
+      }
+    });
+  }
+
   async getCardsForDeck(deckId: string): Promise<CardReviewState[]> {
     return this.run(["cards"], "readonly", (tx) =>
       tx.objectStore("cards").index("deckId").getAll(deckId),

--- a/src/scheduler/queue.ts
+++ b/src/scheduler/queue.ts
@@ -119,11 +119,10 @@ export class ReviewQueue {
    */
   private async unburyCards(): Promise<void> {
     const cards = await reviewDB.getCardsForDeck(this.deckId);
-    for (const card of cards) {
-      if (card.queueOverride === QUEUE_USER_BURIED) {
-        await reviewDB.patchCard(card.cardId, { queueOverride: undefined });
-      }
-    }
+    const patches = cards
+      .filter((c) => c.queueOverride === QUEUE_USER_BURIED)
+      .map((c) => ({ cardId: c.cardId, patch: { queueOverride: undefined } as Partial<import("./types").CardReviewState> }));
+    await reviewDB.patchCards(patches);
   }
 
   /**

--- a/src/search/engine.ts
+++ b/src/search/engine.ts
@@ -1,4 +1,5 @@
 import { getFlags } from "../lib/flags";
+import { stripHtml } from "../utils/stripHtml";
 
 // ── Search AST types ──
 
@@ -399,11 +400,6 @@ export function matchExpr(
 }
 
 // ── Helper to convert AnkiData card to SearchableCard ──
-
-function stripHtml(val: string | null | undefined): string {
-  if (!val) return "";
-  return val.replace(/<[^>]*>/g, "");
-}
 
 export function ankiCardToSearchable(
   card: {

--- a/src/stats/computeStats.ts
+++ b/src/stats/computeStats.ts
@@ -7,8 +7,7 @@ import type {
   CardCountsData,
   TrueRetentionData,
 } from "./types";
-
-const MS_PER_DAY = 86_400_000;
+import { MS_PER_DAY } from "../utils/constants";
 
 function formatDate(ts: number): string {
   const d = new Date(ts);
@@ -32,13 +31,6 @@ export function computeCardCounts(cards: NormalizedCardInfo[]): CardCountsData {
 }
 
 export function computeIntervalDistribution(cards: NormalizedCardInfo[]): BucketData[] {
-  // Only include cards with meaningful intervals (review/young/mature)
-  const intervals = cards
-    .filter((c) => c.phase !== "new" && c.phase !== "learning")
-    .map((c) => c.interval);
-
-  if (intervals.length === 0) return [];
-
   // Create logarithmic-ish buckets: 0-1d, 1-3d, 3-7d, 7-14d, 14-30d, 1-3mo, 3-6mo, 6-12mo, 1y+
   const buckets: [string, number, number][] = [
     ["< 1d", 0, 1],
@@ -52,46 +44,67 @@ export function computeIntervalDistribution(cards: NormalizedCardInfo[]): Bucket
     ["1y+", 365, Infinity],
   ];
 
-  return buckets.map(([label, min, max]) => ({
-    label,
-    count: intervals.filter((i) => i >= min && i < max).length,
-  }));
+  const counts = new Array<number>(buckets.length).fill(0);
+  let total = 0;
+
+  for (const c of cards) {
+    if (c.phase === "new" || c.phase === "learning") continue;
+    total++;
+    const iv = c.interval;
+    for (let b = 0; b < buckets.length; b++) {
+      if (iv >= buckets[b]![1] && iv < buckets[b]![2]) {
+        counts[b]!++;
+        break;
+      }
+    }
+  }
+
+  if (total === 0) return [];
+  return buckets.map(([label], i) => ({ label, count: counts[i]! }));
 }
 
 export function computeEaseDistribution(cards: NormalizedCardInfo[]): BucketData[] {
-  const eases = cards.filter((c) => c.reps > 0).map((c) => Math.round(c.easeFactor * 100));
+  // Buckets from 130% to 350%+ in steps of 20 — single-pass counting
+  const BUCKET_START = 130;
+  const BUCKET_STEP = 20;
+  const NUM_BUCKETS = 12; // 130-150, 150-170, ..., 330-350, 350+
+  const counts = new Array<number>(NUM_BUCKETS).fill(0);
+  let total = 0;
 
-  if (eases.length === 0) return [];
-
-  // Buckets from 130% to 350%+ in steps of 20
-  const buckets: BucketData[] = [];
-  for (let start = 130; start <= 340; start += 20) {
-    const end = start + 20;
-    buckets.push({
-      label: `${start}%`,
-      count: eases.filter((e) => e >= start && e < end).length,
-    });
+  for (const c of cards) {
+    if (c.reps <= 0) continue;
+    total++;
+    const ease = Math.round(c.easeFactor * 100);
+    const idx = Math.min(Math.floor((ease - BUCKET_START) / BUCKET_STEP), NUM_BUCKETS - 1);
+    counts[Math.max(0, idx)]!++;
   }
-  buckets.push({
-    label: "350%+",
-    count: eases.filter((e) => e >= 350).length,
-  });
+
+  if (total === 0) return [];
+
+  const buckets: BucketData[] = [];
+  for (let i = 0; i < NUM_BUCKETS - 1; i++) {
+    buckets.push({ label: `${BUCKET_START + i * BUCKET_STEP}%`, count: counts[i]! });
+  }
+  buckets.push({ label: "350%+", count: counts[NUM_BUCKETS - 1]! });
   return buckets;
 }
 
 export function computeFutureDue(cards: NormalizedCardInfo[], days: number = 30): DayCount[] {
   const now = Date.now();
-  const result: DayCount[] = [];
+  const endMs = now + days * MS_PER_DAY;
 
-  for (let i = 0; i < days; i++) {
-    const dayStart = now + i * MS_PER_DAY;
-    const dayEnd = dayStart + MS_PER_DAY;
-    const date = formatDate(dayStart);
-    const count = cards.filter((c) => c.due >= dayStart && c.due < dayEnd).length;
-    result.push({ date, count });
+  // Single pass: bucket each card into its day
+  const dayCounts = new Array<number>(days).fill(0);
+  for (const c of cards) {
+    if (c.due < now || c.due >= endMs) continue;
+    const dayIndex = Math.floor((c.due - now) / MS_PER_DAY);
+    if (dayIndex >= 0 && dayIndex < days) dayCounts[dayIndex]!++;
   }
 
-  return result;
+  return dayCounts.map((count, i) => ({
+    date: formatDate(now + i * MS_PER_DAY),
+    count,
+  }));
 }
 
 export function computeAddedCards(

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -3,7 +3,8 @@ import { getAnkiDataFromBlob, getAnkiDataFromSqlite } from "./ankiParser";
 import type { AnkiData } from "./ankiParser";
 import { createDatabase } from "./utils/sql";
 
-import { stringHash } from "./utils/constants";
+import { stringHash, ankiSortField } from "./utils/constants";
+import { tagMatchesOrIsChild, removeTags } from "./utils/tagTree";
 import { ReviewQueue, type ReviewCard } from "./scheduler/queue";
 import {
   DEFAULT_SCHEDULER_SETTINGS,
@@ -519,7 +520,7 @@ function formatTagsStr(tags: string[]): string {
 
 /** Compute sort field and checksum from a raw field value. */
 function computeSortField(field: string): { sfld: string; csum: number } {
-  const sfld = field.replace(/<[^>]*>/g, "").trim();
+  const sfld = ankiSortField(field);
   return { sfld, csum: stringHash(sfld) };
 }
 
@@ -1194,8 +1195,10 @@ export async function buryCurrentNote() {
     previousQueueOverrides[cardId] = sibling?.reviewState.queueOverride;
   }
 
+  await reviewDB.patchCards(
+    siblingCardIds.map((cardId) => ({ cardId, patch: { queueOverride: QUEUE_USER_BURIED } })),
+  );
   for (const cardId of siblingCardIds) {
-    await reviewDB.patchCard(cardId, { queueOverride: QUEUE_USER_BURIED });
     const sibling = dueCardsSig.value.find((c) => c.cardId === cardId);
     if (sibling) sibling.reviewState.queueOverride = QUEUE_USER_BURIED;
   }
@@ -1885,7 +1888,7 @@ export async function bulkRemoveTag(guids: string[], tag: string): Promise<void>
     if (!previousTags[card.guid]) {
       previousTags[card.guid] = [...card.tags];
     }
-    card.tags = card.tags.filter((t) => t !== tag && !t.startsWith(tag + "::"));
+    card.tags = removeTags(card.tags, tag);
   }
   triggerRef(ankiDataSig);
 
@@ -1908,8 +1911,7 @@ export async function renameTag(oldTag: string, newTag: string): Promise<void> {
 
   const affectedGuidSet = new Set<string>();
   for (const card of data.cards) {
-    const hasTag = card.tags.some((t) => t === oldTag || t.startsWith(oldTag + "::"));
-    if (!hasTag) continue;
+    if (!card.tags.some((t) => tagMatchesOrIsChild(t, oldTag))) continue;
 
     card.tags = card.tags.map((t) => {
       if (t === oldTag) return newTag;
@@ -1942,14 +1944,13 @@ export async function deleteTag(tag: string): Promise<void> {
   const previousTags: Record<string, string[]> = {};
   const affectedGuidSet = new Set<string>();
   for (const card of data.cards) {
-    const hasTag = card.tags.some((t) => t === tag || t.startsWith(tag + "::"));
-    if (!hasTag) continue;
+    if (!card.tags.some((t) => tagMatchesOrIsChild(t, tag))) continue;
 
     if (!previousTags[card.guid]) {
       previousTags[card.guid] = [...card.tags];
     }
 
-    card.tags = card.tags.filter((t) => t !== tag && !t.startsWith(tag + "::"));
+    card.tags = removeTags(card.tags, tag);
     affectedGuidSet.add(card.guid);
   }
   const affectedGuids = [...affectedGuidSet];

--- a/src/undoRedoExecutor.ts
+++ b/src/undoRedoExecutor.ts
@@ -10,6 +10,7 @@ import {
 } from "./undoRedo";
 import { reviewDB } from "./scheduler/db";
 import type { CardReviewState, StoredReviewLog } from "./scheduler/types";
+import { removeTags } from "./utils/tagTree";
 import {
   ankiDataSig,
   currentReviewCardSig,
@@ -473,7 +474,7 @@ async function redoBulkRemoveTag(entry: UndoEntry): Promise<void> {
   const cards = ankiData.cards as CardLike[];
   for (const card of cards) {
     if (!data.guids.includes(card.guid)) continue;
-    card.tags = card.tags.filter((t) => t !== data.tag && !t.startsWith(data.tag + "::"));
+    card.tags = removeTags(card.tags, data.tag);
   }
   triggerRef(ankiDataSig);
 
@@ -565,7 +566,7 @@ async function redoDeleteTag(entry: UndoEntry): Promise<void> {
 
   const cards = ankiData.cards as CardLike[];
   for (const card of cards) {
-    card.tags = card.tags.filter((t) => t !== data.tag && !t.startsWith(data.tag + "::"));
+    card.tags = removeTags(card.tags, data.tag);
   }
   triggerRef(ankiDataSig);
 
@@ -638,11 +639,12 @@ async function redoSuspendCard(entry: UndoEntry): Promise<void> {
 
 async function undoBuryNote(entry: UndoEntry): Promise<void> {
   const data = entry.undoData as BuryNoteUndoData;
-  for (const cardId of data.cardIds) {
-    await reviewDB.patchCard(cardId, {
-      queueOverride: data.previousQueueOverrides[cardId],
-    });
-  }
+  await reviewDB.patchCards(
+    data.cardIds.map((cardId) => ({
+      cardId,
+      patch: { queueOverride: data.previousQueueOverrides[cardId] },
+    })),
+  );
   await initializeReviewQueue();
 
   pushRedo(
@@ -657,9 +659,9 @@ async function undoBuryNote(entry: UndoEntry): Promise<void> {
 
 async function redoBuryNote(entry: UndoEntry): Promise<void> {
   const data = entry.undoData as BuryNoteUndoData;
-  for (const cardId of data.cardIds) {
-    await reviewDB.patchCard(cardId, { queueOverride: QUEUE_USER_BURIED });
-  }
+  await reviewDB.patchCards(
+    data.cardIds.map((cardId) => ({ cardId, patch: { queueOverride: QUEUE_USER_BURIED } })),
+  );
   await initializeReviewQueue();
 
   pushUndo({

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,6 +20,16 @@ export const ANKI_DEFAULT_CSS = `.card {
   background-color: white;
 }`;
 
+/** Compute Anki's sort field: strip HTML tags and trim (no sound removal). */
+export function ankiSortField(html: string): string {
+  return html.replace(/<[^>]*>/g, "").trim();
+}
+
+/** Compute Anki's field checksum (SHA-1 first 32 bits of the sort field). */
+export function fieldChecksum(field: string): number {
+  return stringHash(ankiSortField(field));
+}
+
 export function stringHash(input: string): number {
   // UTF-8 encode
   const encoder = new TextEncoder();

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,21 @@
+/** Format a byte count as a human-readable file size. */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Truncate text to a maximum length, adding "..." if truncated. */
+export function truncate(text: string, max = 120): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + "...";
+}
+
+/** Escape HTML special characters for safe insertion into HTML. */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -1,0 +1,11 @@
+/**
+ * Strip HTML tags, sound references, and trim whitespace.
+ * Shared utility used across components and modules for plain-text display.
+ */
+export function stripHtml(html: string | null | undefined): string {
+  if (!html) return "";
+  return html
+    .replace(/\[sound:[^\]]+\]/g, "")
+    .replace(/<[^>]*>/g, "")
+    .trim();
+}

--- a/src/utils/tagTree.ts
+++ b/src/utils/tagTree.ts
@@ -53,3 +53,13 @@ export function buildTagTree(tags: string[], tagNoteCounts: Map<string, number>)
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/** Check if a tag matches exactly or is a child of the given parent tag. */
+export function tagMatchesOrIsChild(t: string, tag: string): boolean {
+  return t === tag || t.startsWith(tag + "::");
+}
+
+/** Remove a tag and all its children from a tag list. */
+export function removeTags(tags: string[], tag: string): string[] {
+  return tags.filter((t) => !tagMatchesOrIsChild(t, tag));
+}
+

--- a/src/utils/typeansDiff.ts
+++ b/src/utils/typeansDiff.ts
@@ -6,6 +6,8 @@
  * - Grey (#888) with strikethrough for missing characters
  */
 
+import { escapeHtml } from "./format";
+
 type DiffEntry =
   | { type: "correct"; value: string }
   | { type: "incorrect"; typed: string; expected: string }
@@ -194,14 +196,6 @@ export function renderDiffHtml(typed: string, expected: string): string {
   }
 
   return `<div id="typeans"><div class="typeans-row">${typedRow}</div><hr><div class="typeans-row">${expectedRow}</div></div>`;
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Extract shared utilities**: `stripHtml`, `ankiSortField`, `fieldChecksum`, `tagMatchesOrIsChild`, `removeTags`, `formatFileSize`, `escapeHtml`, `truncate` — eliminating 23 duplicate implementations across 20 files
- **Optimize stats computations**: single-pass bucketing for interval/ease/futureDue distributions (O(cards × buckets) → O(cards))
- **Batch IndexedDB operations**: add `patchCards()` method, replacing N sequential transactions with 1 batched transaction in 5 call sites
- **Extract `useVirtualScroll` composable** from CardBrowser for reuse
- **Cache compiled media RegExps** in CardBrowser to avoid per-render recompilation
- **Static CSS for row height** to eliminate per-row object allocation in virtual scroll