### PR TITLE
fix mobile overflow: make status bar tabs scrollable and browser toolbar wrap on small screens

### DIFF
--- a/e2e/mobile-overflow.spec.ts
+++ b/e2e/mobile-overflow.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect } from './fixtures';
+
+const MOBILE_VIEWPORT = { width: 375, height: 667 }; // iPhone SE
+
+interface OverflowInfo {
+  selector: string;
+  tagName: string;
+  rect: { left: number; right: number; width: number; top: number };
+  overflow: number;
+  text: string;
+}
+
+async function findOverflowingElements(page: import('@playwright/test').Page): Promise<OverflowInfo[]> {
+  return page.evaluate(() => {
+    const htmlWidth = document.documentElement.clientWidth;
+    const results: OverflowInfo[] = [];
+    const all = document.querySelectorAll('*');
+
+    // Check if an element is inside a scrollable container
+    function isInsideScrollable(el: Element): boolean {
+      let parent = el.parentElement;
+      while (parent && parent !== document.documentElement) {
+        const style = getComputedStyle(parent);
+        const overflowX = style.overflowX;
+        if ((overflowX === 'auto' || overflowX === 'scroll' || overflowX === 'hidden') &&
+            parent.scrollWidth > parent.clientWidth) {
+          return true;
+        }
+        parent = parent.parentElement;
+      }
+      return false;
+    }
+
+    for (const el of all) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) continue;
+      if (rect.right > htmlWidth + 1) {
+        if (isInsideScrollable(el)) continue;
+
+        // Build a rough selector for debugging
+        let selector = el.tagName.toLowerCase();
+        if (el.id) selector += `#${el.id}`;
+        if (el.className && typeof el.className === 'string') {
+          selector += '.' + el.className.trim().split(/\s+/).slice(0, 3).join('.');
+        }
+
+        results.push({
+          selector,
+          tagName: el.tagName,
+          rect: { left: rect.left, right: rect.right, width: rect.width, top: rect.top },
+          overflow: Math.round(rect.right - htmlWidth),
+          text: (el.textContent || '').slice(0, 80).trim(),
+        });
+      }
+    }
+    return results;
+  });
+}
+
+test.describe('Mobile responsiveness', () => {
+  test.use({ viewport: MOBILE_VIEWPORT });
+
+  test('deck list has no horizontal overflow', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+    const overflows = await findOverflowingElements(page);
+    if (overflows.length > 0) {
+      console.log('Overflowing elements on deck list (empty state):');
+      for (const o of overflows) console.log(`  ${o.selector} overflows by ${o.overflow}px (right=${o.rect.right})`);
+    }
+    expect(overflows).toEqual([]);
+  });
+
+  test('study view has no horizontal overflow', async ({ loadedDeckPage: page }) => {
+    const overflows = await findOverflowingElements(page);
+    if (overflows.length > 0) {
+      console.log('Overflowing elements on study view:');
+      for (const o of overflows) console.log(`  ${o.selector} overflows by ${o.overflow}px (right=${o.rect.right})`);
+    }
+    expect(overflows).toEqual([]);
+  });
+
+  test('study view answer revealed has no horizontal overflow', async ({ loadedDeckPage: page }) => {
+    // Reveal the answer
+    await page.click('.card');
+    await page.waitForTimeout(300);
+
+    const overflows = await findOverflowingElements(page);
+    if (overflows.length > 0) {
+      console.log('Overflowing elements on answer view:');
+      for (const o of overflows) console.log(`  ${o.selector} overflows by ${o.overflow}px (right=${o.rect.right})`);
+    }
+    expect(overflows).toEqual([]);
+  });
+
+  test('stats panel has no horizontal overflow', async ({ loadedDeckPage: page }) => {
+    // Open stats panel - look for stats button
+    const statsBtn = page.locator('button:has-text("Stats"), [aria-label*="stats" i], [aria-label*="Stats"]').first();
+    if (await statsBtn.isVisible()) {
+      await statsBtn.click();
+      await page.waitForTimeout(500);
+
+      const overflows = await findOverflowingElements(page);
+      if (overflows.length > 0) {
+        console.log('Overflowing elements on stats panel:');
+        for (const o of overflows) console.log(`  ${o.selector} overflows by ${o.overflow}px (right=${o.rect.right})`);
+      }
+      expect(overflows).toEqual([]);
+    }
+  });
+
+  test('browse view has no horizontal overflow', async ({ loadedDeckPage: page }) => {
+    // Open browse - look for browse button
+    const browseBtn = page.locator('button:has-text("Browse"), [aria-label*="browse" i]').first();
+    if (await browseBtn.isVisible()) {
+      await browseBtn.click();
+      await page.waitForTimeout(500);
+
+      const overflows = await findOverflowingElements(page);
+      if (overflows.length > 0) {
+        console.log('Overflowing elements on browse view:');
+        for (const o of overflows) console.log(`  ${o.selector} overflows by ${o.overflow}px (right=${o.rect.right})`);
+      }
+      expect(overflows).toEqual([]);
+    }
+  });
+
+  test('sync view has no horizontal overflow', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+    // Navigate to sync tab
+    const syncTab = page.locator('button.tab:has-text("Sync")');
+    if (await syncTab.isVisible()) {
+      await syncTab.click();
+      await page.waitForTimeout(500);
+
+      const overflows = await findOverflowingElements(page);
+      if (overflows.length > 0) {
+        console.log('Overflowing elements on sync view:');
+        for (const o of overflows) console.log(`  ${o.selector} overflows by ${o.overflow}px (right=${o.rect.right})`);
+      }
+      expect(overflows).toEqual([]);
+    }
+  });
+
+  test('create deck view has no horizontal overflow', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+    const createTab = page.locator('button.tab:has-text("Create Deck")');
+    if (await createTab.isVisible()) {
+      await createTab.click();
+      await page.waitForTimeout(500);
+
+      const overflows = await findOverflowingElements(page);
+      if (overflows.length > 0) {
+        console.log('Overflowing elements on create deck view:');
+        for (const o of overflows) console.log(`  ${o.selector} overflows by ${o.overflow}px (right=${o.rect.right})`);
+      }
+      expect(overflows).toEqual([]);
+    }
+  });
+
+  test('backup view has no horizontal overflow', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+    const backupTab = page.locator('button.tab:has-text("Backup")');
+    if (await backupTab.isVisible()) {
+      await backupTab.click();
+      await page.waitForTimeout(500);
+
+      const overflows = await findOverflowingElements(page);
+      if (overflows.length > 0) {
+        console.log('Overflowing elements on backup view:');
+        for (const o of overflows) console.log(`  ${o.selector} overflows by ${o.overflow}px (right=${o.rect.right})`);
+      }
+      expect(overflows).toEqual([]);
+    }
+  });
+});

--- a/src/components/CardBrowser.vue
+++ b/src/components/CardBrowser.vue
@@ -1574,6 +1574,13 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
   border-bottom: 1px solid var(--color-border);
   background: var(--color-surface);
   flex-shrink: 0;
+  overflow: hidden;
+}
+
+@media (max-width: 640px) {
+  .toolbar {
+    flex-wrap: wrap;
+  }
 }
 
 .toolbar-left {
@@ -1582,6 +1589,7 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
   gap: var(--spacing-2);
   flex: 1;
   min-width: 0;
+  overflow: hidden;
 }
 
 .toolbar-right {
@@ -1589,6 +1597,12 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
   align-items: center;
   gap: var(--spacing-2);
   flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .toolbar-right {
+    flex-wrap: wrap;
+  }
 }
 
 .toolbar-icon-btn {
@@ -2076,6 +2090,8 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
   border-bottom: 1px solid var(--color-border);
   background: color-mix(in srgb, var(--color-primary) 6%, var(--color-surface));
   flex-shrink: 0;
+  flex-wrap: wrap;
+  overflow: hidden;
 }
 
 .bulk-count {

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -84,11 +84,19 @@ async function handleRedo() {
   padding: 0 var(--spacing-4);
   background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
+  overflow: hidden;
 }
 
 .tabs {
   display: flex;
   gap: var(--spacing-1);
+  overflow-x: auto;
+  min-width: 0;
+  scrollbar-width: none;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .tab {
@@ -102,6 +110,8 @@ async function handleRedo() {
   cursor: pointer;
   transition: var(--transition-colors);
   box-shadow: none;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tab:hover {


### PR DESCRIPTION
Fix horizontal overflow issues on mobile viewports (375px).

- **StatusBar**: make tab bar horizontally scrollable with hidden scrollbar, add `overflow: hidden` to prevent content breaking out
- **CardBrowser**: wrap toolbar and bulk toolbar on small screens, constrain overflow
- **E2E tests**: add 8 mobile overflow detection tests using `getBoundingClientRect` across all major views (deck list, study, browse, stats, sync, create deck, backup)