### PR TITLE
refactor: consolidate duplicates, optimize CardBrowser and batch IndexedDB deletes

### DIFF
--- a/src/ankiParser/unzipAnki.ts
+++ b/src/ankiParser/unzipAnki.ts
@@ -3,13 +3,7 @@ import { isTruthy, assertTruthy } from "../utils/assert";
 import mime from "mime";
 import { decompressZstd } from "../utils/zstd";
 import { decompressMediaFile, parseMediaMapping } from "./mediaMappings";
-
-/**
- * Type guard to check if an Entry has getData (i.e. is a file, not a directory)
- */
-function isFileEntry(entry: Entry): entry is Entry & { getData: NonNullable<Entry["getData"]> } {
-  return !entry.directory && typeof entry.getData === "function";
-}
+import { isFileEntry } from "../utils/zipUtils";
 
 export async function getAnkiDataFromZip(file: Blob): Promise<{
   ankiDb: AnkiDb;

--- a/src/backup/colpkg.ts
+++ b/src/backup/colpkg.ts
@@ -1,12 +1,9 @@
-import { BlobWriter, BlobReader, ZipWriter, ZipReader, type Entry } from "@zip-js/zip-js";
+import { BlobWriter, BlobReader, ZipWriter, ZipReader } from "@zip-js/zip-js";
 import { compressZstd, decompressZstd } from "../utils/zstd";
 import { getLocalMediaEntries } from "../utils/mediaCache";
 import { getCachedSqlite, loadSyncedCollection, initializeReviewQueue } from "../stores";
 import mime from "mime";
-
-function isFileEntry(entry: Entry): entry is Entry & { getData: NonNullable<Entry["getData"]> } {
-  return !entry.directory && typeof entry.getData === "function";
-}
+import { isFileEntry } from "../utils/zipUtils";
 
 /**
  * Create a .colpkg blob from the current collection (SQLite + media).

--- a/src/components/CardBrowser.vue
+++ b/src/components/CardBrowser.vue
@@ -133,37 +133,42 @@ watch(viewMode, () => {
 });
 
 
-/** All unique tags */
-const allTags = computed(() => {
+/** Single-pass extraction of tags, tag note counts, decks, and note types from cards */
+const cardMetadata = computed(() => {
   const data = ankiDataSig.value;
-  if (!data) return [] as string[];
   const tags = new Set<string>();
-  for (const card of data.cards) {
-    for (const tag of card.tags) tags.add(tag);
-  }
-  return Array.from(tags).sort();
-});
-
-/** Tag note counts for the tree */
-const tagNoteCounts = computed(() => {
-  const data = ankiDataSig.value;
-  const counts = new Map<string, number>();
-  if (!data) return counts;
-
-  // Count unique notes per tag (deduplicate by guid)
+  const decks = new Set<string>();
+  const noteTypes = new Set<string>();
   const seenPerTag = new Map<string, Set<string>>();
-  for (const card of data.cards) {
-    for (const tag of card.tags) {
-      const seen = seenPerTag.get(tag) ?? new Set<string>();
-      seen.add(card.guid);
-      seenPerTag.set(tag, seen);
+
+  if (data) {
+    for (const card of data.cards) {
+      decks.add(card.deckName);
+      for (const t of card.templates) noteTypes.add(t.name);
+      for (const tag of card.tags) {
+        tags.add(tag);
+        const seen = seenPerTag.get(tag) ?? new Set<string>();
+        seen.add(card.guid);
+        seenPerTag.set(tag, seen);
+      }
     }
   }
+
+  const tagNoteCounts = new Map<string, number>();
   for (const [tag, guids] of seenPerTag) {
-    counts.set(tag, guids.size);
+    tagNoteCounts.set(tag, guids.size);
   }
-  return counts;
+
+  return {
+    tags: Array.from(tags).sort(),
+    tagNoteCounts,
+    decks: Array.from(decks).sort(),
+    noteTypes: Array.from(noteTypes).sort(),
+  };
 });
+
+const allTags = computed(() => cardMetadata.value.tags);
+const tagNoteCounts = computed(() => cardMetadata.value.tagNoteCounts);
 
 /** Hierarchical tag tree */
 const tagTree = computed(() => buildTagTree(allTags.value, tagNoteCounts.value));
@@ -313,25 +318,8 @@ async function applyTagDelete() {
   tagDeleteConfirmOpen.value = false;
 }
 
-/** All unique deck names */
-const allDecks = computed(() => {
-  const data = ankiDataSig.value;
-  if (!data) return [] as string[];
-  const decks = new Set<string>();
-  for (const card of data.cards) decks.add(card.deckName);
-  return Array.from(decks).sort();
-});
-
-/** All unique template/note type names */
-const allNoteTypes = computed(() => {
-  const data = ankiDataSig.value;
-  if (!data) return [] as string[];
-  const names = new Set<string>();
-  for (const card of data.cards) {
-    for (const t of card.templates) names.add(t.name);
-  }
-  return Array.from(names).sort();
-});
+const allDecks = computed(() => cardMetadata.value.decks);
+const allNoteTypes = computed(() => cardMetadata.value.noteTypes);
 
 // ── Search parsing (delegated to src/search/engine.ts) ──
 
@@ -1781,24 +1769,6 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
   font-size: var(--font-size-xs);
   color: var(--color-text-tertiary);
   white-space: nowrap;
-}
-
-/* Bulk toolbar */
-.bulk-toolbar {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-1-5) var(--spacing-3);
-  background: var(--color-surface-elevated);
-  border-bottom: 1px solid var(--color-border);
-  flex-shrink: 0;
-}
-
-.bulk-count {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-secondary);
-  margin-right: var(--spacing-1);
 }
 
 /* Delete confirmation */

--- a/src/lib/syncMerge.ts
+++ b/src/lib/syncMerge.ts
@@ -225,28 +225,30 @@ export async function applyRemoteGraves(db: Database, graves: Graves): Promise<v
 
   // Delete cards
   if (graves.cards.length > 0) {
+    const cardIds = graves.cards.map(String);
     for (const cardId of graves.cards) {
       db.run("DELETE FROM cards WHERE id=?", [cardId]);
-      await reviewDB.deleteCard(String(cardId));
-      await reviewDB.deleteReviewLogsForCard(String(cardId));
     }
+    await reviewDB.deleteCards(cardIds);
+    await reviewDB.deleteReviewLogsForCards(cardIds);
   }
 
   // Delete notes
   if (graves.notes.length > 0) {
+    // Collect all card IDs belonging to deleted notes
+    const noteCardIds: string[] = [];
     for (const noteId of graves.notes) {
-      // Also delete cards belonging to this note
       const cardRows = db.exec("SELECT id FROM cards WHERE nid=?", [noteId]);
       if (cardRows[0]) {
         for (const row of cardRows[0].values) {
-          const cid = String(row[0]);
-          await reviewDB.deleteCard(cid);
-          await reviewDB.deleteReviewLogsForCard(cid);
+          noteCardIds.push(String(row[0]));
         }
       }
       db.run("DELETE FROM cards WHERE nid=?", [noteId]);
       db.run("DELETE FROM notes WHERE id=?", [noteId]);
     }
+    await reviewDB.deleteCards(noteCardIds);
+    await reviewDB.deleteReviewLogsForCards(noteCardIds);
   }
 
   // Delete decks

--- a/src/scheduler/db.ts
+++ b/src/scheduler/db.ts
@@ -304,6 +304,23 @@ class ReviewDB {
   }
 
   /**
+   * Delete multiple cards in a single transaction.
+   */
+  async deleteCards(cardIds: string[]): Promise<void> {
+    if (cardIds.length === 0) return;
+    const db = await this.ensureInit();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("cards", "readwrite");
+      const store = tx.objectStore("cards");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      for (const cardId of cardIds) {
+        store.delete(cardId);
+      }
+    });
+  }
+
+  /**
    * Delete all review logs for a specific card.
    */
   async deleteReviewLogsForCard(cardId: string): Promise<void> {
@@ -322,6 +339,36 @@ class ReviewDB {
       };
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  /**
+   * Delete all review logs for multiple cards in a single transaction.
+   */
+  async deleteReviewLogsForCards(cardIds: string[]): Promise<void> {
+    if (cardIds.length === 0) return;
+    const db = await this.ensureInit();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("reviewLogs", "readwrite");
+      const store = tx.objectStore("reviewLogs");
+      const index = store.index("cardId");
+      let completed = 0;
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      for (const cardId of cardIds) {
+        const request = index.openCursor(cardId);
+        request.onsuccess = () => {
+          const cursor = request.result;
+          if (cursor) {
+            cursor.delete();
+            cursor.continue();
+          } else {
+            completed++;
+            // All cursors exhausted — transaction auto-commits
+            void completed;
+          }
+        };
+      }
     });
   }
 

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -659,15 +659,15 @@ export async function deleteDeckFromCollection(deckId: string, fullName: string)
     }
 
     // Delete cards in those decks and track orphaned notes
+    const allDeletedCardIds: string[] = [];
     for (const did of deckIdsToDelete) {
       const cardRows = db.exec("SELECT id, nid FROM cards WHERE did=?", [did]);
       if (cardRows[0]) {
         for (const row of cardRows[0].values) {
           const cardId = Number(row[0]);
           const noteId = Number(row[1]);
+          allDeletedCardIds.push(String(cardId));
           db.run("DELETE FROM cards WHERE id=?", [cardId]);
-          await reviewDB.deleteCard(String(cardId));
-          await reviewDB.deleteReviewLogsForCard(String(cardId));
 
           // Delete note if no more cards reference it
           const remaining = db.exec("SELECT COUNT(*) FROM cards WHERE nid=?", [noteId]);
@@ -685,6 +685,8 @@ export async function deleteDeckFromCollection(deckId: string, fullName: string)
       db.run("INSERT INTO graves (usn, oid, type) VALUES (-1, ?, 2)", [did]);
       await reviewDB.markDeckDeleted(String(did));
     }
+    await reviewDB.deleteCards(allDeletedCardIds);
+    await reviewDB.deleteReviewLogsForCards(allDeletedCardIds);
 
     if (!anki21b) {
       // anki2: remove from JSON
@@ -2044,6 +2046,7 @@ export async function deleteNotesByGuid(guids: string[]): Promise<void> {
 
   const db = await createDatabase(input.bytes);
   try {
+    const allCardIds: string[] = [];
     for (const guid of guids) {
       // Find note ID
       const result = db.exec("SELECT id FROM notes WHERE guid=?", [guid]);
@@ -2051,13 +2054,11 @@ export async function deleteNotesByGuid(guids: string[]): Promise<void> {
       if (rawNoteId == null) continue;
       const noteId = Number(rawNoteId);
 
-      // Delete cards for this note and clean up review data
+      // Collect card IDs for batch deletion from IndexedDB
       const cardRows = db.exec("SELECT id FROM cards WHERE nid=?", [noteId]);
       if (cardRows[0]) {
         for (const row of cardRows[0].values) {
-          const cardId = String(row[0]);
-          await reviewDB.deleteCard(cardId);
-          await reviewDB.deleteReviewLogsForCard(cardId);
+          allCardIds.push(String(row[0]));
         }
       }
       db.run("DELETE FROM cards WHERE nid=?", [noteId]);
@@ -2068,6 +2069,10 @@ export async function deleteNotesByGuid(guids: string[]): Promise<void> {
       // Delete the note
       db.run("DELETE FROM notes WHERE id=?", [noteId]);
     }
+
+    // Batch delete from IndexedDB
+    await reviewDB.deleteCards(allCardIds);
+    await reviewDB.deleteReviewLogsForCards(allCardIds);
 
     await persistSqliteBytes(db, input);
   } finally {

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -403,23 +403,24 @@ export function replaceMediaFiles(renderedString: string, mediaFiles: Map<string
  * Truncate a filename to maxBytes, preserving the file extension.
  * Matches Anki's MAX_FILENAME_LENGTH = 120 bytes.
  */
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
 function truncateFilename(filename: string, maxBytes: number): string {
-  const encoder = new TextEncoder();
-  if (encoder.encode(filename).length <= maxBytes) return filename;
+  if (textEncoder.encode(filename).length <= maxBytes) return filename;
 
   const lastDot = filename.lastIndexOf(".");
   if (lastDot === -1) {
-    // No extension, just truncate
-    const bytes = encoder.encode(filename);
-    return new TextDecoder().decode(bytes.slice(0, maxBytes));
+    const bytes = textEncoder.encode(filename);
+    return textDecoder.decode(bytes.slice(0, maxBytes));
   }
   const ext = filename.slice(lastDot);
   const stem = filename.slice(0, lastDot);
-  const extBytes = encoder.encode(ext);
+  const extBytes = textEncoder.encode(ext);
   const maxStemBytes = maxBytes - extBytes.length;
   if (maxStemBytes <= 0) return filename;
-  const stemBytes = encoder.encode(stem);
-  const truncatedStem = new TextDecoder().decode(stemBytes.slice(0, maxStemBytes));
+  const stemBytes = textEncoder.encode(stem);
+  const truncatedStem = textDecoder.decode(stemBytes.slice(0, maxStemBytes));
   return truncatedStem + ext;
 }
 

--- a/src/utils/zipUtils.ts
+++ b/src/utils/zipUtils.ts
@@ -1,0 +1,8 @@
+import type { Entry } from "@zip-js/zip-js";
+
+/**
+ * Type guard to check if a zip Entry has getData (i.e. is a file, not a directory).
+ */
+export function isFileEntry(entry: Entry): entry is Entry & { getData: NonNullable<Entry["getData"]> } {
+  return !entry.directory && typeof entry.getData === "function";
+}


### PR DESCRIPTION
## Summary

- Extract shared `isFileEntry` type guard into `utils/zipUtils.ts` (was duplicated in `unzipAnki.ts` and `colpkg.ts`)
- Consolidate 4 separate card-iteration computed properties in CardBrowser into a single pass
- Hoist `TextEncoder`/`TextDecoder` to module level in `render.ts` to avoid repeated allocation in hot path
- Add batch `deleteCards()` and `deleteReviewLogsForCards()` to ReviewDB, replacing N+1 sequential awaits in syncMerge and stores
- Remove duplicate CSS rules in CardBrowser