### PR TITLE
refactor: replace imperative mutation patterns with functional map/filter/flatMap

### DIFF
--- a/src/ankiParser/anki21b/index.ts
+++ b/src/ankiParser/anki21b/index.ts
@@ -12,6 +12,7 @@ import { executeQuery, executeQueryAll } from "~/utils/sql";
 import { assertTruthy } from "~/utils/assert";
 import { type CardScheduling, type RevlogEntry } from "../anki2";
 import { buildScheduling, resolveCardDeckName, isBlankCard, parseRevlog } from "../shared";
+import { groupBy } from "~/utils/groupBy";
 
 export type Anki21bDeck = {
   id: number;
@@ -140,19 +141,13 @@ export function getDataFromAnki21b(db: Database): AnkiDB21bData {
     }));
   })();
 
-  // Pre-build fields-by-notetype map (sorted by ord) to avoid O(n²) lookups
-  const fieldsByNtid = new Map<string, typeof fields>();
-  for (const field of fields) {
-    let list = fieldsByNtid.get(field.ntid);
-    if (!list) {
-      list = [];
-      fieldsByNtid.set(field.ntid, list);
-    }
-    list.push(field);
-  }
-  for (const list of fieldsByNtid.values()) {
-    list.sort((a, b) => a.ord - b.ord);
-  }
+  // Pre-build fields-by-notetype map (sorted by ord) to avoid O(n^2) lookups
+  const fieldsByNtid = new Map(
+    Object.entries(groupBy(fields, (f) => f.ntid)).map(([ntid, group]) => [
+      ntid,
+      [...group!].sort((a, b) => a.ord - b.ord),
+    ]),
+  );
 
   const templatesMap = (() => {
     const templates = executeQueryAll<{
@@ -162,26 +157,20 @@ export function getDataFromAnki21b(db: Database): AnkiDB21bData {
       ntid: string;
     }>(db, "SELECT name, ord, config, cast(ntid as text) as ntid FROM templates");
 
-    const templatesMap = new Map<
-      string,
-      { name: string; afmt: string; qfmt: string; ord: number }[]
-    >();
-
-    for (const template of templates) {
-      const templateProto = parseTemplatesProto(template.config);
-
-      const { aFormat, qFormat } = templateProto;
-
-      const curTemplate = {
-        name: template.name,
-        afmt: aFormat,
-        qfmt: qFormat,
-        ord: template.ord,
+    const parsed = templates.map((template) => {
+      const { aFormat, qFormat } = parseTemplatesProto(template.config);
+      return {
+        ntid: template.ntid,
+        entry: { name: template.name, afmt: aFormat, qfmt: qFormat, ord: template.ord },
       };
-      templatesMap.set(template.ntid, [...(templatesMap.get(template.ntid) ?? []), curTemplate]);
-    }
+    });
 
-    return templatesMap;
+    return new Map(
+      Object.entries(groupBy(parsed, (p) => p.ntid)).map(([ntid, group]) => [
+        ntid,
+        group!.map((g) => g.entry),
+      ]),
+    );
   })();
 
   const notesTypes = getNotesType(db);

--- a/src/composables/useCommands.ts
+++ b/src/composables/useCommands.ts
@@ -115,37 +115,42 @@ export function useCommands(options: UseCommandsOptions = {}) {
     );
 
     // Undo/redo commands (only show when available)
-    const undoRedoCommands: Command[] = [];
-    if (canUndo.value) {
-      undoRedoCommands.push({
-        id: "undo",
-        title: `Undo: ${undoDescription.value}`,
-        description: "Revert the last operation",
-        icon: icon(Undo2),
-        hotkey: "ctrl+Z",
-        group: "Edit",
-        handler: () => {
-          void executeUndo().then((desc) => {
-            if (desc) options.onUndoToast?.(`Undo: ${desc}`);
-          });
-        },
-      });
-    }
-    if (canRedo.value) {
-      undoRedoCommands.push({
-        id: "redo",
-        title: `Redo: ${redoDescription.value}`,
-        description: "Re-apply the last undone operation",
-        icon: icon(Redo2),
-        hotkey: "ctrl+shift+Z",
-        group: "Edit",
-        handler: () => {
-          void executeRedo().then((desc) => {
-            if (desc) options.onUndoToast?.(`Redo: ${desc}`);
-          });
-        },
-      });
-    }
+    const undoRedoCommands: Command[] = [
+      ...(canUndo.value
+        ? [
+            {
+              id: "undo",
+              title: `Undo: ${undoDescription.value}`,
+              description: "Revert the last operation",
+              icon: icon(Undo2),
+              hotkey: "ctrl+Z",
+              group: "Edit",
+              handler: () => {
+                void executeUndo().then((desc) => {
+                  if (desc) options.onUndoToast?.(`Undo: ${desc}`);
+                });
+              },
+            },
+          ]
+        : []),
+      ...(canRedo.value
+        ? [
+            {
+              id: "redo",
+              title: `Redo: ${redoDescription.value}`,
+              description: "Re-apply the last undone operation",
+              icon: icon(Redo2),
+              hotkey: "ctrl+shift+Z",
+              group: "Edit",
+              handler: () => {
+                void executeRedo().then((desc) => {
+                  if (desc) options.onUndoToast?.(`Redo: ${desc}`);
+                });
+              },
+            },
+          ]
+        : []),
+    ];
 
     const commands: Command[] = [
       ...undoRedoCommands,
@@ -263,7 +268,7 @@ function buildCardActionCommands(ankiData: AnkiData | null, options: UseCommands
   const currentFlag = reviewCard.reviewState.flags ?? 0;
   const isMarked = noteCard?.tags.some((t) => t.toLowerCase() === "marked") ?? false;
 
-  const commands: Command[] = [
+  return [
     {
       id: "bury-card",
       title: "Bury Card",
@@ -327,26 +332,24 @@ function buildCardActionCommands(ankiData: AnkiData | null, options: UseCommands
       metadata: buildCardInfoMetadata(reviewCard, queue),
       handler: () => ({ keepOpen: true }),
     },
-  ];
-
-  if (noteCard) {
-    commands.push({
-      id: "mark-note",
-      title: isMarked ? "Unmark Note" : "Mark Note",
-      description: isMarked
-        ? 'Remove the "marked" tag from this note'
-        : 'Tag this note as "marked" for easy filtering',
-      icon: icon(Star),
-      hotkey: "*",
-      label: isMarked ? "Marked" : undefined,
-      group: "Current Card",
-      handler: () => {
-        markCurrentNote();
-      },
-    });
-  }
-
-  commands.push(
+    ...(noteCard
+      ? [
+          {
+            id: "mark-note",
+            title: isMarked ? "Unmark Note" : "Mark Note",
+            description: isMarked
+              ? 'Remove the "marked" tag from this note'
+              : 'Tag this note as "marked" for easy filtering',
+            icon: icon(Star),
+            hotkey: "*",
+            label: isMarked ? "Marked" : undefined,
+            group: "Current Card",
+            handler: () => {
+              markCurrentNote();
+            },
+          },
+        ]
+      : []),
     {
       id: "edit-card",
       title: "Edit Card",
@@ -403,9 +406,7 @@ function buildCardActionCommands(ankiData: AnkiData | null, options: UseCommands
         }
       },
     },
-  );
-
-  return commands;
+  ];
 }
 
 function buildCardInfoMetadata(
@@ -413,46 +414,38 @@ function buildCardInfoMetadata(
   queue: import("../scheduler/queue").ReviewQueue | null,
 ): Command["metadata"] {
   const displayInfo = queue?.getCardDisplayInfo(reviewCard) ?? {};
-  const entries: NonNullable<Command["metadata"]> = [
-    { label: "Card ID", value: reviewCard.cardId },
-    { label: "New", value: reviewCard.isNew ? "Yes" : "No" },
+  const flags = reviewCard.reviewState.flags ?? 0;
+
+  type MetadataEntry = { label: string; value: string | ReturnType<typeof h> };
+  const conditionalEntries: (MetadataEntry | null)[] = [
+    displayInfo.ease !== undefined
+      ? { label: "Ease Factor", value: String(Math.round((displayInfo.ease as number) * 100)) + "%" }
+      : null,
+    displayInfo.interval !== undefined
+      ? { label: "Interval", value: displayInfo.interval + " days" }
+      : null,
+    displayInfo.repetitions !== undefined
+      ? { label: "Repetitions", value: String(displayInfo.repetitions) }
+      : null,
+    displayInfo.stability !== undefined
+      ? { label: "Stability", value: String(displayInfo.stability) }
+      : null,
+    displayInfo.difficulty !== undefined
+      ? { label: "Difficulty", value: String(displayInfo.difficulty) }
+      : null,
+    flags > 0 ? { label: "Flag", value: getFlagLabel(flags) } : null,
+    reviewCard.reviewState.lastReviewed
+      ? {
+          label: "Last Reviewed",
+          value: new Date(reviewCard.reviewState.lastReviewed).toLocaleDateString(),
+        }
+      : null,
   ];
 
-  if (displayInfo.ease !== undefined) {
-    entries.push({
-      label: "Ease Factor",
-      value: String(Math.round((displayInfo.ease as number) * 100)) + "%",
-    });
-  }
-  if (displayInfo.interval !== undefined) {
-    entries.push({ label: "Interval", value: displayInfo.interval + " days" });
-  }
-  if (displayInfo.repetitions !== undefined) {
-    entries.push({ label: "Repetitions", value: String(displayInfo.repetitions) });
-  }
-  if (displayInfo.stability !== undefined) {
-    entries.push({ label: "Stability", value: String(displayInfo.stability) });
-  }
-  if (displayInfo.difficulty !== undefined) {
-    entries.push({ label: "Difficulty", value: String(displayInfo.difficulty) });
-  }
-
-  const flags = reviewCard.reviewState.flags ?? 0;
-  if (flags > 0) {
-    entries.push({ label: "Flag", value: getFlagLabel(flags) });
-  }
-
-  if (reviewCard.reviewState.lastReviewed) {
-    entries.push({
-      label: "Last Reviewed",
-      value: new Date(reviewCard.reviewState.lastReviewed).toLocaleDateString(),
-    });
-  }
-
-  entries.push({
-    label: "Review Log",
-    value: h(ReviewLogPanel, { cardId: reviewCard.cardId }),
-  });
-
-  return entries;
+  return [
+    { label: "Card ID", value: reviewCard.cardId },
+    { label: "New", value: reviewCard.isNew ? "Yes" : "No" },
+    ...conditionalEntries.filter((e): e is MetadataEntry => e !== null),
+    { label: "Review Log", value: h(ReviewLogPanel, { cardId: reviewCard.cardId }) },
+  ];
 }

--- a/src/lib/autoSync.ts
+++ b/src/lib/autoSync.ts
@@ -105,13 +105,12 @@ async function performAutoSync(): Promise<boolean> {
     try {
       const dlMedia = await downloadMedia(config.serverUrl, state.hkey);
       if (dlMedia.size > 0) {
-        const typedBlobs = new Map<string, Blob>();
-        for (const [filename, blob] of dlMedia) {
-          typedBlobs.set(
+        const typedBlobs = new Map(
+          [...dlMedia].map(([filename, blob]) => [
             filename,
             new Blob([blob], { type: mime.getType(filename) ?? "application/octet-stream" }),
-          );
-        }
+          ]),
+        );
         await addMediaToCache(typedBlobs);
       }
     } catch (dlErr) {

--- a/src/lib/normalSync.ts
+++ b/src/lib/normalSync.ts
@@ -311,10 +311,11 @@ async function sendGraves(
 
   for (let i = 0; i < allIds.length; i += CHUNK_SIZE) {
     const batch = allIds.slice(i, i + CHUNK_SIZE);
-    const chunk: Graves = { cards: [], notes: [], decks: [] };
-    for (const [id, type] of batch) {
-      chunk[type].push(id);
-    }
+    const chunk: Graves = {
+      cards: batch.filter(([, type]) => type === "cards").map(([id]) => id),
+      notes: batch.filter(([, type]) => type === "notes").map(([id]) => id),
+      decks: batch.filter(([, type]) => type === "decks").map(([id]) => id),
+    };
     await syncEndpoint(serverUrl, "applyGraves", hkey, { chunk }, proto, sessionKey);
   }
 
@@ -504,30 +505,23 @@ async function applyDeckConfigsToScheduler(
 
   type RawDconf = z.infer<typeof rawDconfSchema>;
 
-  const configs = new Map<string, RawDconf>();
-
-  if (isAnki21b) {
-    const dcResult = db.exec("SELECT id, config FROM deck_config");
-    if (dcResult[0]) {
-      for (const row of dcResult[0].values) {
-        const parsed = rawDconfSchema.safeParse(safeJsonParse(String(row[1] ?? "")));
-        if (parsed.success) {
-          configs.set(String(row[0]), parsed.data);
-        }
-      }
-    }
-  } else {
-    const dconfRaw = db.exec("SELECT dconf FROM col");
-    if (dconfRaw[0]?.values[0]) {
-      const outer = safeJsonParse(String(dconfRaw[0].values[0][0] ?? ""));
-      if (outer && typeof outer === "object") {
-        for (const [id, raw] of Object.entries(outer)) {
-          const parsed = rawDconfSchema.safeParse(raw);
-          if (parsed.success) configs.set(id, parsed.data);
-        }
-      }
-    }
-  }
+  const configs: Map<string, RawDconf> = isAnki21b
+    ? new Map(
+        (db.exec("SELECT id, config FROM deck_config")[0]?.values ?? [])
+          .map((row) => [String(row[0]), rawDconfSchema.safeParse(safeJsonParse(String(row[1] ?? "")))] as const)
+          .filter((entry): entry is [string, { success: true; data: RawDconf }] => entry[1].success)
+          .map(([id, parsed]) => [id, parsed.data]),
+      )
+    : (() => {
+        const outer = safeJsonParse(String(db.exec("SELECT dconf FROM col")[0]?.values[0]?.[0] ?? ""));
+        if (!outer || typeof outer !== "object") return new Map<string, RawDconf>();
+        return new Map(
+          Object.entries(outer)
+            .map(([id, raw]) => [id, rawDconfSchema.safeParse(raw)] as const)
+            .filter((entry): entry is [string, { success: true; data: RawDconf }] => entry[1].success)
+            .map(([id, parsed]) => [id, parsed.data]),
+        );
+      })();
 
   if (configs.size === 0) return;
 

--- a/src/lib/syncMerge.ts
+++ b/src/lib/syncMerge.ts
@@ -173,13 +173,18 @@ function mergeColJsonField<T extends { id: number; mod?: number }>(
 ): void {
   if (remoteItems.length === 0) return;
   const local = getColJson<Record<string, T>>(db, column, {});
-  for (const item of remoteItems) {
-    const existing = local[String(item.id)];
-    if (!existing || (item.mod ?? 0) >= (existing.mod ?? 0)) {
-      local[String(item.id)] = item;
-    }
-  }
-  db.run(`UPDATE col SET ${column}=?`, [JSON.stringify(local)]);
+  const merged = {
+    ...local,
+    ...Object.fromEntries(
+      remoteItems
+        .filter((item) => {
+          const existing = local[String(item.id)];
+          return !existing || (item.mod ?? 0) >= (existing.mod ?? 0);
+        })
+        .map((item) => [String(item.id), item]),
+    ),
+  };
+  db.run(`UPDATE col SET ${column}=?`, [JSON.stringify(merged)]);
 }
 
 /**
@@ -226,27 +231,19 @@ export async function applyRemoteGraves(db: Database, graves: Graves): Promise<v
   // Delete cards
   if (graves.cards.length > 0) {
     const cardIds = graves.cards.map(String);
-    for (const cardId of graves.cards) {
-      db.run("DELETE FROM cards WHERE id=?", [cardId]);
-    }
+    graves.cards.forEach((cardId) => db.run("DELETE FROM cards WHERE id=?", [cardId]));
     await reviewDB.deleteCards(cardIds);
     await reviewDB.deleteReviewLogsForCards(cardIds);
   }
 
   // Delete notes
   if (graves.notes.length > 0) {
-    // Collect all card IDs belonging to deleted notes
-    const noteCardIds: string[] = [];
-    for (const noteId of graves.notes) {
+    const noteCardIds = graves.notes.flatMap((noteId) => {
       const cardRows = db.exec("SELECT id FROM cards WHERE nid=?", [noteId]);
-      if (cardRows[0]) {
-        for (const row of cardRows[0].values) {
-          noteCardIds.push(String(row[0]));
-        }
-      }
       db.run("DELETE FROM cards WHERE nid=?", [noteId]);
       db.run("DELETE FROM notes WHERE id=?", [noteId]);
-    }
+      return (cardRows[0]?.values ?? []).map((row) => String(row[0]));
+    });
     await reviewDB.deleteCards(noteCardIds);
     await reviewDB.deleteReviewLogsForCards(noteCardIds);
   }
@@ -254,15 +251,15 @@ export async function applyRemoteGraves(db: Database, graves: Graves): Promise<v
   // Delete decks
   if (graves.decks.length > 0) {
     const anki21b = isAnki21bFormat(db);
-    for (const deckId of graves.decks) {
-      if (anki21b) {
-        db.run("DELETE FROM decks WHERE id=?", [deckId]);
-      } else {
-        // anki2: decks are stored as JSON in col.decks
-        const decks = getColJson<Record<string, unknown>>(db, "decks", {});
-        delete decks[String(deckId)];
-        db.run("UPDATE col SET decks=?", [JSON.stringify(decks)]);
-      }
+    if (anki21b) {
+      graves.decks.forEach((deckId) => db.run("DELETE FROM decks WHERE id=?", [deckId]));
+    } else {
+      const decks = getColJson<Record<string, unknown>>(db, "decks", {});
+      const deckIdsToRemove = new Set(graves.decks.map(String));
+      const filtered = Object.fromEntries(
+        Object.entries(decks).filter(([key]) => !deckIdsToRemove.has(key)),
+      );
+      db.run("UPDATE col SET decks=?", [JSON.stringify(filtered)]);
     }
   }
 }
@@ -381,16 +378,18 @@ function applyRemoteUnchunkedAnki2(db: Database, changes: UnchunkedChanges, loca
   // Models — merge with mod-time conflict resolution + schema validation
   if (changes.models.length > 0) {
     const local = getColJson<Record<string, SyncModel>>(db, "models", {});
-    for (const item of changes.models) {
+    const winners = changes.models.filter((item) => {
       const existing = local[String(item.id)];
       if (existing && (item.mod ?? 0) >= (existing.mod ?? 0)) {
         validateNotetypeSchema(existing, item);
       }
-      if (!existing || (item.mod ?? 0) >= (existing.mod ?? 0)) {
-        local[String(item.id)] = item;
-      }
-    }
-    db.run("UPDATE col SET models=?", [JSON.stringify(local)]);
+      return !existing || (item.mod ?? 0) >= (existing.mod ?? 0);
+    });
+    const merged = {
+      ...local,
+      ...Object.fromEntries(winners.map((item) => [String(item.id), item])),
+    };
+    db.run("UPDATE col SET models=?", [JSON.stringify(merged)]);
   }
 
   const [remoteDecks, remoteDconf] = changes.decks;
@@ -400,14 +399,13 @@ function applyRemoteUnchunkedAnki2(db: Database, changes: UnchunkedChanges, loca
   // Tags — merge with USN awareness: remote tags win over non-pending local tags
   if (changes.tags.length > 0) {
     const localTags = getColJson<Record<string, number>>(db, "tags", {});
-    for (const tag of changes.tags) {
-      const localUsn = localTags[tag];
-      // Accept remote tag if: not present locally, or local isn't pending sync
-      if (localUsn === undefined || localUsn !== -1) {
-        localTags[tag] = 0; // Mark as synced
-      }
-    }
-    db.run("UPDATE col SET tags=?", [JSON.stringify(localTags)]);
+    const acceptedTags = Object.fromEntries(
+      changes.tags
+        .filter((tag) => localTags[tag] === undefined || localTags[tag] !== -1)
+        .map((tag) => [tag, 0]),
+    );
+    const mergedTags = { ...localTags, ...acceptedTags };
+    db.run("UPDATE col SET tags=?", [JSON.stringify(mergedTags)]);
   }
 
   // Config — only accept server config if local is not newer (matching desktop Anki)
@@ -508,17 +506,16 @@ function applyRemoteUnchunkedAnki21b(db: Database, changes: UnchunkedChanges, lo
 
 /** Build local graves (deletions) from SQLite rows with usn=-1. */
 export function buildLocalGraves(db: Database): Graves {
-  const graves: Graves = { cards: [], notes: [], decks: [] };
   const result = db.exec("SELECT oid, type FROM graves WHERE usn=-1");
-  if (!result[0]) return graves;
-  for (const row of result[0].values) {
-    const oid = Number(row[0]);
-    const type = Number(row[1]);
-    if (type === 0) graves.cards.push(oid);
-    else if (type === 1) graves.notes.push(oid);
-    else if (type === 2) graves.decks.push(oid);
-  }
-  return graves;
+  const rows = (result[0]?.values ?? []).map((row) => ({
+    oid: Number(row[0]),
+    type: Number(row[1]),
+  }));
+  return {
+    cards: rows.filter((r) => r.type === 0).map((r) => r.oid),
+    notes: rows.filter((r) => r.type === 1).map((r) => r.oid),
+    decks: rows.filter((r) => r.type === 2).map((r) => r.oid),
+  };
 }
 
 /** Build unchunked changes to send. PWA doesn't modify these, so send current state. */
@@ -534,33 +531,25 @@ export function buildLocalUnchunkedChanges(
 }
 
 function buildLocalUnchunkedAnki2(db: Database, localIsNewer: boolean): UnchunkedChanges {
+  const models = Object.values(getColJson<Record<string, SyncModel>>(db, "models", {})).filter(
+    (m) => m.usn === -1,
+  );
+  const pendingDecks = Object.values(getColJson<Record<string, SyncDeck>>(db, "decks", {})).filter(
+    (d) => d.usn === -1,
+  );
+  const pendingDconf = Object.values(
+    getColJson<Record<string, SyncDeckConfig>>(db, "dconf", {}),
+  ).filter((c) => c.usn === -1);
+  const tags = Object.entries(getColJson<Record<string, number>>(db, "tags", {}))
+    .filter(([, usn]) => usn === -1)
+    .map(([tag]) => tag);
+
   const changes: UnchunkedChanges = {
-    models: [],
-    decks: [[], []],
-    tags: [],
+    models,
+    decks: [pendingDecks, pendingDconf],
+    tags,
   };
 
-  // Models (notetypes) with pending changes (usn=-1)
-  for (const m of Object.values(getColJson<Record<string, SyncModel>>(db, "models", {}))) {
-    if (m.usn === -1) changes.models.push(m);
-  }
-
-  // Decks with pending changes (usn=-1)
-  for (const d of Object.values(getColJson<Record<string, SyncDeck>>(db, "decks", {}))) {
-    if (d.usn === -1) changes.decks[0].push(d);
-  }
-
-  // Deck configs with pending changes (usn=-1)
-  for (const c of Object.values(getColJson<Record<string, SyncDeckConfig>>(db, "dconf", {}))) {
-    if (c.usn === -1) changes.decks[1].push(c);
-  }
-
-  // Tags with pending changes (value=-1 in the JSON object)
-  for (const [tag, usn] of Object.entries(getColJson<Record<string, number>>(db, "tags", {}))) {
-    if (usn === -1) changes.tags.push(tag);
-  }
-
-  // If local is newer, include conf and crt so the server can update
   if (localIsNewer) {
     const result = db.exec("SELECT conf, crt FROM col");
     if (result[0]?.values[0]) {
@@ -579,74 +568,51 @@ function buildLocalUnchunkedAnki2(db: Database, localIsNewer: boolean): Unchunke
   return changes;
 }
 
+function safeParseJson(val: unknown): Record<string, unknown> {
+  if (typeof val !== "string") return {};
+  try {
+    return JSON.parse(val);
+  } catch {
+    return {};
+  }
+}
+
 function buildLocalUnchunkedAnki21b(db: Database, localIsNewer: boolean): UnchunkedChanges {
-  const changes: UnchunkedChanges = {
-    models: [],
-    decks: [[], []],
-    tags: [],
-  };
-
-  // Notetypes with pending changes (usn=-1)
   const ntResult = db.exec("SELECT id, name, mtime_secs, usn, config FROM notetypes WHERE usn=-1");
-  if (ntResult[0]) {
-    for (const row of ntResult[0].values) {
-      const configStr = typeof row[4] === "string" ? row[4] : "{}";
-      let parsed: Record<string, unknown> = {};
-      try { parsed = JSON.parse(configStr); } catch { /* skip */ }
-      const obj: SyncModel = {
-        ...parsed,
-        id: Number(row[0]),
-        name: String(row[1] ?? ""),
-        mtime_secs: Number(row[2]),
-        usn: Number(row[3]),
-      };
-      changes.models.push(obj);
-    }
-  }
+  const models: SyncModel[] = (ntResult[0]?.values ?? []).map((row) => ({
+    ...safeParseJson(row[4]),
+    id: Number(row[0]),
+    name: String(row[1] ?? ""),
+    mtime_secs: Number(row[2]),
+    usn: Number(row[3]),
+  }));
 
-  // Decks with pending changes (usn=-1)
   const decksResult = db.exec("SELECT id, name, mtime, usn, common FROM decks WHERE usn=-1");
-  if (decksResult[0]) {
-    for (const row of decksResult[0].values) {
-      const commonStr = typeof row[4] === "string" ? row[4] : "{}";
-      let parsed: Record<string, unknown> = {};
-      try { parsed = JSON.parse(commonStr); } catch { /* skip */ }
-      const obj: SyncDeck = {
-        ...parsed,
-        id: Number(row[0]),
-        name: String(row[1] ?? ""),
-        mtime: Number(row[2]),
-        usn: Number(row[3]),
-      };
-      changes.decks[0].push(obj);
-    }
-  }
+  const pendingDecks: SyncDeck[] = (decksResult[0]?.values ?? []).map((row) => ({
+    ...safeParseJson(row[4]),
+    id: Number(row[0]),
+    name: String(row[1] ?? ""),
+    mtime: Number(row[2]),
+    usn: Number(row[3]),
+  }));
 
-  // Deck configs with pending changes (usn=-1)
   const dcResult = db.exec("SELECT id, name, mtime, usn, config FROM deck_config WHERE usn=-1");
-  if (dcResult[0]) {
-    for (const row of dcResult[0].values) {
-      const configStr = typeof row[4] === "string" ? row[4] : "{}";
-      let parsed: Record<string, unknown> = {};
-      try { parsed = JSON.parse(configStr); } catch { /* skip */ }
-      const obj: SyncDeckConfig = {
-        ...parsed,
-        id: Number(row[0]),
-        name: String(row[1] ?? ""),
-        mtime: Number(row[2]),
-        usn: Number(row[3]),
-      };
-      changes.decks[1].push(obj);
-    }
-  }
+  const pendingDconf: SyncDeckConfig[] = (dcResult[0]?.values ?? []).map((row) => ({
+    ...safeParseJson(row[4]),
+    id: Number(row[0]),
+    name: String(row[1] ?? ""),
+    mtime: Number(row[2]),
+    usn: Number(row[3]),
+  }));
 
-  // Tags with pending changes (usn=-1)
   const tagsResult = db.exec("SELECT tag FROM tags WHERE usn=-1");
-  if (tagsResult[0]) {
-    for (const row of tagsResult[0].values) {
-      changes.tags.push(String(row[0] ?? ""));
-    }
-  }
+  const tags = (tagsResult[0]?.values ?? []).map((row) => String(row[0] ?? ""));
+
+  const changes: UnchunkedChanges = {
+    models,
+    decks: [pendingDecks, pendingDconf],
+    tags,
+  };
 
   if (localIsNewer) {
     const result = db.exec("SELECT conf, crt FROM col");
@@ -669,49 +635,34 @@ function buildLocalUnchunkedAnki21b(db: Database, localIsNewer: boolean): Unchun
 /** Yield local chunks of cards/notes/revlog with usn=-1. */
 export function* buildLocalChunks(db: Database): Generator<Chunk> {
   // Gather all pending items
-  const pendingCards: CardRow[] = [];
   const cardsResult = db.exec(
     "SELECT id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data FROM cards WHERE usn=-1",
   );
-  if (cardsResult[0]) {
-    for (const row of cardsResult[0].values) {
-      pendingCards.push([
-        Number(row[0]), Number(row[1]), Number(row[2]), Number(row[3]),
-        Number(row[4]), Number(row[5]), Number(row[6]), Number(row[7]),
-        Number(row[8]), Number(row[9]), Number(row[10]), Number(row[11]),
-        Number(row[12]), Number(row[13]), Number(row[14]), Number(row[15]),
-        Number(row[16]), String(row[17] ?? ""),
-      ]);
-    }
-  }
+  const pendingCards: CardRow[] = (cardsResult[0]?.values ?? []).map((row) => [
+    Number(row[0]), Number(row[1]), Number(row[2]), Number(row[3]),
+    Number(row[4]), Number(row[5]), Number(row[6]), Number(row[7]),
+    Number(row[8]), Number(row[9]), Number(row[10]), Number(row[11]),
+    Number(row[12]), Number(row[13]), Number(row[14]), Number(row[15]),
+    Number(row[16]), String(row[17] ?? ""),
+  ]);
 
-  const pendingNotes: NoteRow[] = [];
   const notesResult = db.exec(
     "SELECT id, guid, mid, mod, usn, tags, flds, sfld, csum, flags, data FROM notes WHERE usn=-1",
   );
-  if (notesResult[0]) {
-    for (const row of notesResult[0].values) {
-      pendingNotes.push([
-        Number(row[0]), String(row[1] ?? ""), Number(row[2]), Number(row[3]),
-        Number(row[4]), String(row[5] ?? ""), String(row[6] ?? ""), String(row[7] ?? ""),
-        Number(row[8]), Number(row[9]), String(row[10] ?? ""),
-      ]);
-    }
-  }
+  const pendingNotes: NoteRow[] = (notesResult[0]?.values ?? []).map((row) => [
+    Number(row[0]), String(row[1] ?? ""), Number(row[2]), Number(row[3]),
+    Number(row[4]), String(row[5] ?? ""), String(row[6] ?? ""), String(row[7] ?? ""),
+    Number(row[8]), Number(row[9]), String(row[10] ?? ""),
+  ]);
 
-  const pendingRevlog: RevlogRow[] = [];
   const revlogResult = db.exec(
     "SELECT id, cid, usn, ease, ivl, lastIvl, factor, time, type FROM revlog WHERE usn=-1",
   );
-  if (revlogResult[0]) {
-    for (const row of revlogResult[0].values) {
-      pendingRevlog.push([
-        Number(row[0]), Number(row[1]), Number(row[2]), Number(row[3]),
-        Number(row[4]), Number(row[5]), Number(row[6]), Number(row[7]),
-        Number(row[8]),
-      ]);
-    }
-  }
+  const pendingRevlog: RevlogRow[] = (revlogResult[0]?.values ?? []).map((row) => [
+    Number(row[0]), Number(row[1]), Number(row[2]), Number(row[3]),
+    Number(row[4]), Number(row[5]), Number(row[6]), Number(row[7]),
+    Number(row[8]),
+  ]);
 
   // Yield in chunks of CHUNK_SIZE (interleaving types)
   let ci = 0,
@@ -822,15 +773,12 @@ export function finalizeUsn(
     finalizeUsnAnki2Json(db, serverUsn, "dconf");
     // Tags: update usn values in the JSON object
     const tags = getColJson<Record<string, number>>(db, "tags", {});
-    let changed = false;
-    for (const [tag, usn] of Object.entries(tags)) {
-      if (usn === -1) {
-        tags[tag] = serverUsn;
-        changed = true;
-      }
-    }
-    if (changed) {
-      db.run("UPDATE col SET tags=?", [JSON.stringify(tags)]);
+    const hasPending = Object.values(tags).some((usn) => usn === -1);
+    if (hasPending) {
+      const updated = Object.fromEntries(
+        Object.entries(tags).map(([tag, usn]) => [tag, usn === -1 ? serverUsn : usn]),
+      );
+      db.run("UPDATE col SET tags=?", [JSON.stringify(updated)]);
     }
   }
 
@@ -844,14 +792,14 @@ function finalizeUsnAnki2Json(
   column: "models" | "decks" | "dconf",
 ): void {
   const data = getColJson<Record<string, { usn?: number }>>(db, column, {});
-  let changed = false;
-  for (const obj of Object.values(data)) {
-    if (obj.usn === -1) {
-      obj.usn = serverUsn;
-      changed = true;
-    }
-  }
-  if (changed) {
-    db.run(`UPDATE col SET ${column}=?`, [JSON.stringify(data)]);
+  const hasPending = Object.values(data).some((obj) => obj.usn === -1);
+  if (hasPending) {
+    const updated = Object.fromEntries(
+      Object.entries(data).map(([key, obj]) => [
+        key,
+        obj.usn === -1 ? { ...obj, usn: serverUsn } : obj,
+      ]),
+    );
+    db.run(`UPDATE col SET ${column}=?`, [JSON.stringify(updated)]);
   }
 }

--- a/src/lib/syncWrite.ts
+++ b/src/lib/syncWrite.ts
@@ -167,36 +167,33 @@ export function readDeckStepCounts(db: import("sql.js").Database): Map<number, D
   const isAnki21b = (hasNotetypes[0]?.values.length ?? 0) > 0;
 
   if (isAnki21b) {
-    // anki21b: deck_config table has config JSON, decks table references config via common JSON
-    const configMap = new Map<number, DeckStepInfo>();
     const dcResult = db.exec("SELECT id, config FROM deck_config");
-    if (dcResult[0]) {
-      for (const row of dcResult[0].values) {
+    const configMap = new Map<number, DeckStepInfo>(
+      (dcResult[0]?.values ?? []).map((row) => {
         const id = row[0] as number;
         try {
           const cfg = JSON.parse(row[1] as string);
-          configMap.set(id, {
+          return [id, {
             learnSteps: Array.isArray(cfg.new?.delays) ? cfg.new.delays.length : 2,
             relearnSteps: Array.isArray(cfg.lapse?.delays) ? cfg.lapse.delays.length : 1,
-          });
+          }];
         } catch {
-          configMap.set(id, { learnSteps: 2, relearnSteps: 1 });
+          return [id, { learnSteps: 2, relearnSteps: 1 }];
         }
-      }
-    }
-    // Map each deck to its config
+      }),
+    );
+
     const decksResult = db.exec("SELECT id, common FROM decks");
-    if (decksResult[0]) {
-      for (const row of decksResult[0].values) {
-        const deckId = row[0] as number;
-        try {
-          const common = JSON.parse(row[1] as string);
-          const confId = common.conf ?? common.config_id ?? 1;
-          const steps = configMap.get(confId);
-          if (steps) result.set(deckId, steps);
-        } catch { /* use default */ }
-      }
-    }
+    const deckEntries = (decksResult[0]?.values ?? []).flatMap((row) => {
+      const deckId = row[0] as number;
+      try {
+        const common = JSON.parse(row[1] as string);
+        const confId = common.conf ?? common.config_id ?? 1;
+        const steps = configMap.get(confId);
+        return steps ? [[deckId, steps] as const] : [];
+      } catch { return []; }
+    });
+    deckEntries.forEach(([deckId, steps]) => result.set(deckId, steps));
   } else {
     // anki2: col.dconf has deck configs, col.decks has deck → conf mapping
     const colResult = db.exec("SELECT dconf, decks FROM col");
@@ -211,19 +208,19 @@ export function readDeckStepCounts(db: import("sql.js").Database): Map<number, D
           conf?: string | number;
         }>;
 
-        const configMap = new Map<string, DeckStepInfo>();
-        for (const [id, cfg] of Object.entries(dconf)) {
-          configMap.set(id, {
+        const configMap = new Map<string, DeckStepInfo>(
+          Object.entries(dconf).map(([id, cfg]) => [id, {
             learnSteps: Array.isArray(cfg.new?.delays) ? cfg.new.delays.length : 2,
             relearnSteps: Array.isArray(cfg.lapse?.delays) ? cfg.lapse.delays.length : 1,
-          });
-        }
+          }]),
+        );
 
-        for (const deck of Object.values(decks)) {
-          const confId = String(deck.conf ?? "1");
-          const steps = configMap.get(confId);
-          if (steps) result.set(deck.id, steps);
-        }
+        Object.values(decks)
+          .flatMap((deck) => {
+            const steps = configMap.get(String(deck.conf ?? "1"));
+            return steps ? [[deck.id, steps] as const] : [];
+          })
+          .forEach(([deckId, steps]) => result.set(deckId, steps));
       } catch { /* use defaults */ }
     }
   }
@@ -406,14 +403,9 @@ async function insertRevlogs(
 
   if (allLogs.length === 0) return;
 
-  // Get existing revlog IDs to avoid duplicates
-  const existingIds = new Set<number>();
-  const existingResult = db.exec("SELECT id FROM revlog");
-  if (existingResult[0]) {
-    for (const row of existingResult[0].values) {
-      existingIds.add(row[0] as number);
-    }
-  }
+  const existingIds = new Set<number>(
+    (db.exec("SELECT id FROM revlog")[0]?.values ?? []).map((row) => row[0] as number),
+  );
 
   // Build a map of cardId → card state for revlog type lookup
   const cardStateMap = new Map(reviewedCards.map((c) => [c.cardId, c]));
@@ -481,26 +473,15 @@ async function insertGraves(db: import("sql.js").Database, deckId: string): Prom
 
   const insertStmt = db.prepare(GRAVES_INSERT_SQL);
 
-  // Card graves (type 0)
-  for (const deleted of deletedCards) {
-    const ankiCardId = Number(deleted.cardId);
-    if (isNaN(ankiCardId)) continue;
-    insertStmt.run([-1, ankiCardId, 0]);
-  }
+  const graves: [number, number][] = [
+    ...deletedCards.map((d) => [Number(d.cardId), 0] as [number, number]),
+    ...deletedNotes.map((d) => [Number(d.noteId), 1] as [number, number]),
+    ...deletedDecks.map((d) => [Number(d.deletedDeckId), 2] as [number, number]),
+  ];
 
-  // Note graves (type 1)
-  for (const deleted of deletedNotes) {
-    const ankiNoteId = Number(deleted.noteId);
-    if (isNaN(ankiNoteId)) continue;
-    insertStmt.run([-1, ankiNoteId, 1]);
-  }
-
-  // Deck graves (type 2)
-  for (const deleted of deletedDecks) {
-    const ankiDeckId = Number(deleted.deletedDeckId);
-    if (isNaN(ankiDeckId)) continue;
-    insertStmt.run([-1, ankiDeckId, 2]);
-  }
+  graves
+    .filter(([id]) => !isNaN(id))
+    .forEach(([id, type]) => insertStmt.run([-1, id, type]));
 
   insertStmt.free();
 }

--- a/src/scheduler/queue.ts
+++ b/src/scheduler/queue.ts
@@ -4,6 +4,7 @@ import type { SchedulingAlgorithm } from "./algorithm";
 import { FSRSAlgorithm } from "./fsrs-algorithm";
 import { AnkiSM2Algorithm } from "./anki-sm2-algorithm";
 import { QUEUE_SUSPENDED, QUEUE_SCHED_BURIED, QUEUE_USER_BURIED } from "../lib/syncWrite";
+import { groupBy } from "../utils/groupBy";
 
 /**
  * Apply fuzz to a due date to spread reviews across days.
@@ -187,41 +188,37 @@ export class ReviewQueue {
     const now = new Date();
     const nowMs = now.getTime();
 
-    const learningCards: ReviewCard[] = [];
-    const dueReviews: ReviewCard[] = [];
-    const newCards: ReviewCard[] = [];
-    const aheadCards: ReviewCard[] = [];
-    const dueDateCache = new Map<string, number>();
+    const activeCards = queue.filter(
+      (card) =>
+        card.reviewState.queueOverride !== QUEUE_SUSPENDED &&
+        card.reviewState.queueOverride !== QUEUE_USER_BURIED &&
+        card.reviewState.queueOverride !== QUEUE_SCHED_BURIED,
+    );
 
-    for (const card of queue) {
-      try {
-        // Skip suspended cards entirely
-        if (card.reviewState.queueOverride === QUEUE_SUSPENDED) continue;
-        // Skip buried cards (they'll be unburied on day rollover)
-        if (
-          card.reviewState.queueOverride === QUEUE_USER_BURIED ||
-          card.reviewState.queueOverride === QUEUE_SCHED_BURIED
-        )
-          continue;
-
-        const dueDate = this.algorithm.getDueDate(card.reviewState.cardState);
-        const dueMs = dueDate.getTime();
-        dueDateCache.set(card.cardId, dueMs);
-
-        if (card.isNew) {
-          newCards.push(card);
-        } else if (this.algorithm.isInLearning?.(card.reviewState.cardState)) {
-          // Learning/relearning cards — always include (shown when due)
-          learningCards.push(card);
-        } else if (dueMs <= nowMs) {
-          dueReviews.push(card);
-        } else {
-          aheadCards.push(card);
+    const dueDateCache = new Map<string, number>(
+      activeCards.flatMap((card) => {
+        try {
+          return [[card.cardId, this.algorithm.getDueDate(card.reviewState.cardState).getTime()] as const];
+        } catch (error) {
+          console.error("Error processing card in queue:", error, card);
+          return [];
         }
-      } catch (error) {
-        console.error("Error processing card in queue:", error, card);
-      }
-    }
+      }),
+    );
+
+    const categorize = (card: ReviewCard): string => {
+      if (!dueDateCache.has(card.cardId)) return "error";
+      if (card.isNew) return "new";
+      if (this.algorithm.isInLearning?.(card.reviewState.cardState)) return "learning";
+      if (dueDateCache.get(card.cardId)! <= nowMs) return "dueReview";
+      return "ahead";
+    };
+
+    const grouped = groupBy(activeCards, categorize);
+    const learningCards = grouped.learning ?? [];
+    const dueReviews = grouped.dueReview ?? [];
+    const newCards = grouped.new ?? [];
+    const aheadCards = grouped.ahead ?? [];
 
     // Apply easy-days multiplier to daily limits
     const easyMultiplier = getEasyDayMultiplier(now, this.settings.easyDays);

--- a/src/stats/computeStats.ts
+++ b/src/stats/computeStats.ts
@@ -8,6 +8,7 @@ import type {
   TrueRetentionData,
 } from "./types";
 import { MS_PER_DAY } from "../utils/constants";
+import { groupBy } from "../utils/groupBy";
 
 function formatDate(ts: number): string {
   const d = new Date(ts);
@@ -23,15 +24,16 @@ function normalizeRating(rating: Answer | number): Answer {
 // --- Card-based stats ---
 
 export function computeCardCounts(cards: NormalizedCardInfo[]): CardCountsData {
-  const counts: CardCountsData = { new: 0, learning: 0, young: 0, mature: 0 };
-  for (const card of cards) {
-    counts[card.phase]++;
-  }
-  return counts;
+  const grouped = groupBy(cards, (c) => c.phase);
+  return {
+    new: grouped.new?.length ?? 0,
+    learning: grouped.learning?.length ?? 0,
+    young: grouped.young?.length ?? 0,
+    mature: grouped.mature?.length ?? 0,
+  };
 }
 
 export function computeIntervalDistribution(cards: NormalizedCardInfo[]): BucketData[] {
-  // Create logarithmic-ish buckets: 0-1d, 1-3d, 3-7d, 7-14d, 14-30d, 1-3mo, 3-6mo, 6-12mo, 1y+
   const buckets: [string, number, number][] = [
     ["< 1d", 0, 1],
     ["1-3d", 1, 3],
@@ -44,66 +46,44 @@ export function computeIntervalDistribution(cards: NormalizedCardInfo[]): Bucket
     ["1y+", 365, Infinity],
   ];
 
-  const counts = new Array<number>(buckets.length).fill(0);
-  let total = 0;
+  const reviewed = cards.filter((c) => c.phase !== "new" && c.phase !== "learning");
+  if (reviewed.length === 0) return [];
 
-  for (const c of cards) {
-    if (c.phase === "new" || c.phase === "learning") continue;
-    total++;
-    const iv = c.interval;
-    for (let b = 0; b < buckets.length; b++) {
-      if (iv >= buckets[b]![1] && iv < buckets[b]![2]) {
-        counts[b]!++;
-        break;
-      }
-    }
-  }
-
-  if (total === 0) return [];
-  return buckets.map(([label], i) => ({ label, count: counts[i]! }));
+  return buckets.map(([label, min, max]) => ({
+    label,
+    count: reviewed.filter((c) => c.interval >= min && c.interval < max).length,
+  }));
 }
 
 export function computeEaseDistribution(cards: NormalizedCardInfo[]): BucketData[] {
-  // Buckets from 130% to 350%+ in steps of 20 — single-pass counting
   const BUCKET_START = 130;
   const BUCKET_STEP = 20;
-  const NUM_BUCKETS = 12; // 130-150, 150-170, ..., 330-350, 350+
-  const counts = new Array<number>(NUM_BUCKETS).fill(0);
-  let total = 0;
+  const NUM_BUCKETS = 12;
 
-  for (const c of cards) {
-    if (c.reps <= 0) continue;
-    total++;
+  const reviewed = cards.filter((c) => c.reps > 0);
+  if (reviewed.length === 0) return [];
+
+  const grouped = groupBy(reviewed, (c) => {
     const ease = Math.round(c.easeFactor * 100);
-    const idx = Math.min(Math.floor((ease - BUCKET_START) / BUCKET_STEP), NUM_BUCKETS - 1);
-    counts[Math.max(0, idx)]!++;
-  }
+    return Math.max(0, Math.min(Math.floor((ease - BUCKET_START) / BUCKET_STEP), NUM_BUCKETS - 1));
+  });
 
-  if (total === 0) return [];
-
-  const buckets: BucketData[] = [];
-  for (let i = 0; i < NUM_BUCKETS - 1; i++) {
-    buckets.push({ label: `${BUCKET_START + i * BUCKET_STEP}%`, count: counts[i]! });
-  }
-  buckets.push({ label: "350%+", count: counts[NUM_BUCKETS - 1]! });
-  return buckets;
+  return Array.from({ length: NUM_BUCKETS }, (_, i) => ({
+    label: i < NUM_BUCKETS - 1 ? `${BUCKET_START + i * BUCKET_STEP}%` : "350%+",
+    count: grouped[i]?.length ?? 0,
+  }));
 }
 
 export function computeFutureDue(cards: NormalizedCardInfo[], days: number = 30): DayCount[] {
   const now = Date.now();
   const endMs = now + days * MS_PER_DAY;
 
-  // Single pass: bucket each card into its day
-  const dayCounts = new Array<number>(days).fill(0);
-  for (const c of cards) {
-    if (c.due < now || c.due >= endMs) continue;
-    const dayIndex = Math.floor((c.due - now) / MS_PER_DAY);
-    if (dayIndex >= 0 && dayIndex < days) dayCounts[dayIndex]!++;
-  }
+  const dueCards = cards.filter((c) => c.due >= now && c.due < endMs);
+  const grouped = groupBy(dueCards, (c) => Math.floor((c.due - now) / MS_PER_DAY));
 
-  return dayCounts.map((count, i) => ({
+  return Array.from({ length: days }, (_, i) => ({
     date: formatDate(now + i * MS_PER_DAY),
-    count,
+    count: grouped[i]?.length ?? 0,
   }));
 }
 
@@ -112,77 +92,58 @@ export function computeAddedCards(
   startMs: number,
   endMs: number,
 ): DayCount[] {
-  const days = new Map<string, number>();
+  const scaffoldDates = Array.from(
+    { length: Math.ceil((endMs - startMs) / MS_PER_DAY) },
+    (_, i) => formatDate(startMs + i * MS_PER_DAY),
+  );
 
-  // Initialize all days in range
-  for (let ts = startMs; ts < endMs; ts += MS_PER_DAY) {
-    days.set(formatDate(ts), 0);
-  }
+  const cardsInRange = cards.filter((c) => c.createdAt >= startMs && c.createdAt < endMs);
+  const grouped = groupBy(cardsInRange, (c) => formatDate(c.createdAt));
 
-  for (const card of cards) {
-    if (card.createdAt >= startMs && card.createdAt < endMs) {
-      const date = formatDate(card.createdAt);
-      days.set(date, (days.get(date) ?? 0) + 1);
-    }
-  }
+  const allDates = [...new Set([...scaffoldDates, ...Object.keys(grouped)])];
 
-  return Array.from(days.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([date, count]) => ({ date, count }));
+  return allDates
+    .sort((a, b) => a.localeCompare(b))
+    .map((date) => ({ date, count: grouped[date]?.length ?? 0 }));
 }
 
 // --- Review-log-based stats ---
 
 export function computeCalendarHeatmap(logs: StoredReviewLog[]): DayCount[] {
-  const dayCounts = new Map<string, number>();
-  for (const log of logs) {
-    const date = formatDate(log.timestamp);
-    dayCounts.set(date, (dayCounts.get(date) ?? 0) + 1);
-  }
+  const grouped = groupBy(logs, (log) => formatDate(log.timestamp));
 
-  return Array.from(dayCounts.entries())
+  return Object.entries(grouped)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([date, count]) => ({ date, count }));
+    .map(([date, entries]) => ({ date, count: entries!.length }));
 }
 
 export function computeReviewsByHour(logs: StoredReviewLog[]): BucketData[] {
-  const hours = Array.from({ length: 24 }, () => 0);
-  for (const log of logs) {
-    const h = new Date(log.timestamp).getHours();
-    hours[h] = (hours[h] ?? 0) + 1;
-  }
-  return hours.map((count, hour) => ({
+  const grouped = groupBy(logs, (log) => new Date(log.timestamp).getHours());
+
+  return Array.from({ length: 24 }, (_, hour) => ({
     label: `${hour}:00`,
-    count,
+    count: grouped[hour]?.length ?? 0,
   }));
 }
 
 export function computeAnswerButtons(logs: StoredReviewLog[]): AnswerButtonsData {
-  const data: AnswerButtonsData = { again: 0, hard: 0, good: 0, easy: 0 };
-  for (const log of logs) {
-    const rating = normalizeRating(log.rating);
-    data[rating]++;
-  }
-  return data;
+  const grouped = groupBy(logs, (log) => normalizeRating(log.rating));
+  return {
+    again: grouped.again?.length ?? 0,
+    hard: grouped.hard?.length ?? 0,
+    good: grouped.good?.length ?? 0,
+    easy: grouped.easy?.length ?? 0,
+  };
 }
 
 export function computeTrueRetention(
   logs: StoredReviewLog[],
   cards: NormalizedCardInfo[],
 ): TrueRetentionData {
-  // True retention: % of reviews on mature cards that were not "again"
   const matureCardIds = new Set(cards.filter((c) => c.phase === "mature").map((c) => c.cardId));
-
-  let total = 0;
-  let correct = 0;
-
-  for (const log of logs) {
-    if (!matureCardIds.has(log.cardId)) continue;
-    total++;
-    if (normalizeRating(log.rating) !== "again") {
-      correct++;
-    }
-  }
+  const matureLogs = logs.filter((log) => matureCardIds.has(log.cardId));
+  const correct = matureLogs.filter((log) => normalizeRating(log.rating) !== "again").length;
+  const total = matureLogs.length;
 
   return {
     retention: total > 0 ? correct / total : 0,

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -284,14 +284,10 @@ export async function loadSyncedCollection(bytes: Uint8Array, mediaBlobs?: Map<s
   let mediaFiles: Map<string, string> | undefined;
   const newMediaFilenames = new Set<string>();
   if (mediaBlobs && mediaBlobs.size > 0) {
-    mediaFiles = new Map<string, string>();
-    const puts: Promise<void>[] = [];
-    for (const [filename, blob] of mediaBlobs) {
-      newMediaFilenames.add(filename);
-      mediaFiles.set(filename, URL.createObjectURL(blob));
-      puts.push(cache.put(mediaCachePath(filename), new Response(blob)));
-    }
-    await Promise.all(puts);
+    const entries = [...mediaBlobs];
+    entries.forEach(([filename]) => newMediaFilenames.add(filename));
+    mediaFiles = new Map(entries.map(([filename, blob]) => [filename, URL.createObjectURL(blob)]));
+    await Promise.all(entries.map(([filename, blob]) => cache.put(mediaCachePath(filename), new Response(blob))));
   }
 
   // Clear old media entries that weren't replaced by new ones
@@ -1025,18 +1021,17 @@ export function moveToNextReviewCard() {
 
   // First priority: any learning card that is due now (but not the one we just reviewed)
   if (queue) {
-    for (const card of dueCards) {
-      if (card.cardId === currentId) continue;
-      if (!queue.isCardInLearning(card)) continue;
+    const dueLearningCard = dueCards.find((card) => {
+      if (card.cardId === currentId || !queue.isCardInLearning(card)) return false;
       try {
-        const dueMs = new Date((card.reviewState.cardState as { due: number }).due).getTime();
-        if (dueMs <= nowMs) {
-          currentReviewCardSig.value = card;
-          return;
-        }
+        return new Date((card.reviewState.cardState as { due: number }).due).getTime() <= nowMs;
       } catch {
-        // skip
+        return false;
       }
+    });
+    if (dueLearningCard) {
+      currentReviewCardSig.value = dueLearningCard;
+      return;
     }
   }
 
@@ -1051,16 +1046,12 @@ export function moveToNextReviewCard() {
   }
 
   // Third priority: soonest learning card (even if not yet due)
-  let soonest: ReviewCard | null = null;
-  let soonestDue = Infinity;
-  for (const c of dueCards) {
-    if (c.cardId === currentId || !queue?.isCardInLearning(c)) continue;
-    const due = (c.reviewState.cardState as { due: number }).due;
-    if (due < soonestDue) {
-      soonest = c;
-      soonestDue = due;
-    }
-  }
+  const soonest = dueCards
+    .filter((c) => c.cardId !== currentId && queue?.isCardInLearning(c))
+    .toSorted((a, b) =>
+      (a.reviewState.cardState as { due: number }).due -
+      (b.reviewState.cardState as { due: number }).due,
+    )[0];
   if (soonest) {
     currentReviewCardSig.value = soonest;
     return;
@@ -1394,11 +1385,7 @@ const BASE91_CHARS =
   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&()*+,-.:;<=>?@[]^_`{|}~";
 
 function generateGuid(): string {
-  let result = "";
-  for (let i = 0; i < 10; i++) {
-    result += BASE91_CHARS[Math.floor(Math.random() * BASE91_CHARS.length)];
-  }
-  return result;
+  return Array.from({ length: 10 }, () => BASE91_CHARS[Math.floor(Math.random() * BASE91_CHARS.length)]).join("");
 }
 
 /**
@@ -1647,13 +1634,9 @@ export function countFilteredDeckCards(query: string): number {
   if (!data || !query.trim()) return 0;
   const expr = parseSearch(query);
   if (!expr) return data.cards.length;
-  let count = 0;
-  for (let i = 0; i < data.cards.length; i++) {
-    const card = data.cards[i]!;
-    const searchable = ankiCardToSearchable(card);
-    if (matchExpr(searchable, expr, data.collectionCreationTime)) count++;
-  }
-  return count;
+  return data.cards.filter((card) =>
+    matchExpr(ankiCardToSearchable(card), expr, data.collectionCreationTime),
+  ).length;
 }
 
 /**
@@ -1664,16 +1647,11 @@ function gatherFilteredCards(config: FilteredDeckConfig): number[] {
   if (!data) return [];
 
   const expr = parseSearch(config.query);
-  const matching: { index: number; card: (typeof data.cards)[number] }[] = [];
-
-  for (let i = 0; i < data.cards.length; i++) {
-    const card = data.cards[i]!;
-    if (expr) {
-      const searchable = ankiCardToSearchable(card);
-      if (!matchExpr(searchable, expr, data.collectionCreationTime)) continue;
-    }
-    matching.push({ index: i, card });
-  }
+  const matching = data.cards
+    .map((card, index) => ({ index, card }))
+    .filter(({ card }) =>
+      !expr || matchExpr(ankiCardToSearchable(card), expr, data.collectionCreationTime),
+    );
 
   // Sort
   switch (config.sortOrder) {
@@ -2093,19 +2071,17 @@ async function bulkPersistTags(guids: string[]): Promise<void> {
     const mod = nowSecs();
 
     const guidSet = new Set(guids);
-    const cardsByGuid = new Map<string, (typeof data.cards)[number]>();
-    for (const card of data.cards) {
-      if (guidSet.has(card.guid) && !cardsByGuid.has(card.guid)) {
-        cardsByGuid.set(card.guid, card);
-      }
-    }
+    const cardsByGuid = new Map(
+      data.cards
+        .filter((card) => guidSet.has(card.guid))
+        .map((card) => [card.guid, card] as const),
+    );
 
-    for (const guid of guids) {
+    guids.forEach((guid) => {
       const card = cardsByGuid.get(guid);
-      if (!card) continue;
-
+      if (!card) return;
       db.run("UPDATE notes SET tags=?, mod=?, usn=-1 WHERE guid=?", [formatTagsStr(card.tags), mod, guid]);
-    }
+    });
 
     await persistSqliteBytes(db, input);
   } finally {

--- a/src/undoRedoExecutor.ts
+++ b/src/undoRedoExecutor.ts
@@ -332,10 +332,7 @@ async function undoNoteDelete(entry: UndoEntry): Promise<void> {
   if (!ankiData) return;
 
   // Restore cards to in-memory data
-  const cards = ankiData.cards as unknown[];
-  for (const card of data.cards) {
-    cards.push(card);
-  }
+  (ankiData as { cards: unknown[] }).cards = [...ankiData.cards, ...data.cards];
   triggerRef(ankiDataSig);
 
   // Restore review states
@@ -367,12 +364,9 @@ async function redoNoteDelete(entry: UndoEntry): Promise<void> {
   if (!ankiData) return;
 
   // Remove cards from in-memory data
-  const cards = ankiData.cards as Array<{ guid: string }>;
-  for (let i = cards.length - 1; i >= 0; i--) {
-    if (cards[i]!.guid === data.guid) {
-      cards.splice(i, 1);
-    }
-  }
+  (ankiData as { cards: Array<{ guid: string }> }).cards = (
+    ankiData.cards as Array<{ guid: string }>
+  ).filter((card) => card.guid !== data.guid);
   triggerRef(ankiDataSig);
 
   // Delete review states
@@ -720,9 +714,9 @@ async function undoMarkNote(entry: UndoEntry): Promise<void> {
   for (const card of cards) {
     if (card.guid !== data.guid) continue;
     if (data.wasMarked) {
-      if (!card.tags.some((t) => t.toLowerCase() === "marked")) {
-        card.tags.push("marked");
-      }
+      card.tags = card.tags.some((t) => t.toLowerCase() === "marked")
+        ? card.tags
+        : [...card.tags, "marked"];
     } else {
       card.tags = card.tags.filter((t) => t.toLowerCase() !== "marked");
     }
@@ -750,9 +744,9 @@ async function redoMarkNote(entry: UndoEntry): Promise<void> {
     if (data.wasMarked) {
       card.tags = card.tags.filter((t) => t.toLowerCase() !== "marked");
     } else {
-      if (!card.tags.some((t) => t.toLowerCase() === "marked")) {
-        card.tags.push("marked");
-      }
+      card.tags = card.tags.some((t) => t.toLowerCase() === "marked")
+        ? card.tags
+        : [...card.tags, "marked"];
     }
   }
   triggerRef(ankiDataSig);

--- a/src/utils/deckInfo.ts
+++ b/src/utils/deckInfo.ts
@@ -1,5 +1,6 @@
 import type { SubDeckInfo, DeckTreeNode } from "../types";
 import type { AnkiData } from "../ankiParser";
+import { groupBy } from "./groupBy";
 
 export function computeDeckInfo(ankiData: AnkiData) {
   const nameToDeckId = new Map(Object.entries(ankiData.decks).map(([id, deck]) => [deck.name, id]));
@@ -9,7 +10,7 @@ export function computeDeckInfo(ankiData: AnkiData) {
     deckId: nameToDeckId.get(card.deckName),
   }));
 
-  const cardsByDeckId = Object.groupBy(cardsWithDeckIds, (item) => item.deckId ?? "unknown");
+  const cardsByDeckId = groupBy(cardsWithDeckIds, (item) => item.deckId ?? "unknown");
 
   const subdecks: SubDeckInfo[] = Object.entries(ankiData.decks)
     .map(([deckId, deck]) => {
@@ -22,33 +23,14 @@ export function computeDeckInfo(ankiData: AnkiData) {
       const displayName = deck.name.includes("::") ? deck.name.split("::").pop()! : deck.name;
 
       // Compute new/learn/due counts from Anki scheduling data
-      let newCount = 0;
-      let learnCount = 0;
-      let dueCount = 0;
-
-      for (const item of cardsInDeck) {
-        const sched = item.card.scheduling;
-        if (!sched) {
-          // Cards without scheduling data are treated as new
-          newCount++;
-          continue;
-        }
-        // Skip suspended and buried cards
-        if (sched.queue < 0) continue;
-
-        switch (sched.queue) {
-          case 0: // new
-            newCount++;
-            break;
-          case 1: // learning
-          case 3: // day learning
-            learnCount++;
-            break;
-          case 2: // review (due)
-            dueCount++;
-            break;
-        }
-      }
+      const activeCards = cardsInDeck.filter((item) => !item.card.scheduling || item.card.scheduling.queue >= 0);
+      const grouped = groupBy(activeCards, (item) => {
+        const q = item.card.scheduling?.queue;
+        if (q === undefined || q === 0) return "new";
+        if (q === 1 || q === 3) return "learning";
+        if (q === 2) return "due";
+        return "other";
+      });
 
       return {
         id: deckId,
@@ -57,9 +39,9 @@ export function computeDeckInfo(ankiData: AnkiData) {
         description: deck.description,
         cardCount: cardsInDeck.length,
         templateCount: templateNames.size,
-        newCount,
-        learnCount,
-        dueCount,
+        newCount: grouped.new?.length ?? 0,
+        learnCount: grouped.learning?.length ?? 0,
+        dueCount: grouped.due?.length ?? 0,
       };
     })
     .filter((subdeck) => subdeck.cardCount > 0);
@@ -91,51 +73,48 @@ function buildDeckTree(subdecks: SubDeckInfo[]): DeckTreeNode[] {
   const deckMap = new Map(subdecks.map((d) => [d.fullName, d]));
 
   // Collect all unique path prefixes (including virtual parents)
-  const allPaths = new Set<string>();
-  for (const d of subdecks) {
-    const parts = d.fullName.split("::");
-    for (let i = 1; i <= parts.length; i++) {
-      allPaths.add(parts.slice(0, i).join("::"));
-    }
-  }
+  const allPaths = new Set(
+    subdecks.flatMap((d) => {
+      const parts = d.fullName.split("::");
+      return parts.map((_, i) => parts.slice(0, i + 1).join("::"));
+    }),
+  );
 
   // Build nodes for every path
-  const nodeMap = new Map<string, DeckTreeNode>();
-  for (const path of allPaths) {
-    const existing = deckMap.get(path);
-    const parts = path.split("::");
-    const displayName = parts[parts.length - 1]!;
+  const nodeMap = new Map<string, DeckTreeNode>(
+    [...allPaths].map((path) => {
+      const existing = deckMap.get(path);
+      const parts = path.split("::");
+      const displayName = parts[parts.length - 1]!;
 
-    nodeMap.set(path, {
-      id: existing?.id ?? path,
-      name: displayName,
-      fullName: path,
-      cardCount: existing?.cardCount ?? 0,
-      templateCount: existing?.templateCount ?? 0,
-      newCount: existing?.newCount ?? 0,
-      learnCount: existing?.learnCount ?? 0,
-      dueCount: existing?.dueCount ?? 0,
-      children: [],
-      depth: parts.length - 1,
-    });
-  }
+      return [
+        path,
+        {
+          id: existing?.id ?? path,
+          name: displayName,
+          fullName: path,
+          cardCount: existing?.cardCount ?? 0,
+          templateCount: existing?.templateCount ?? 0,
+          newCount: existing?.newCount ?? 0,
+          learnCount: existing?.learnCount ?? 0,
+          dueCount: existing?.dueCount ?? 0,
+          children: [],
+          depth: parts.length - 1,
+        },
+      ];
+    }),
+  );
 
-  // Wire parent-child relationships
-  const roots: DeckTreeNode[] = [];
+  // Wire parent-child relationships (mutation is inherent to tree building)
   for (const [path, node] of nodeMap) {
     const parts = path.split("::");
-    if (parts.length === 1) {
-      roots.push(node);
-    } else {
-      const parentPath = parts.slice(0, -1).join("::");
-      const parent = nodeMap.get(parentPath);
-      if (parent) {
-        parent.children.push(node);
-      } else {
-        roots.push(node);
-      }
-    }
+    if (parts.length <= 1) continue;
+    const parentPath = parts.slice(0, -1).join("::");
+    const parent = nodeMap.get(parentPath);
+    if (parent) parent.children.push(node);
   }
+
+  const roots = [...nodeMap.values()].filter((node) => !node.fullName.includes("::"));
 
   // Sort children alphabetically at each level
   const sortChildren = (nodes: DeckTreeNode[]) => {

--- a/src/utils/duplicates.ts
+++ b/src/utils/duplicates.ts
@@ -14,6 +14,8 @@ export type NoteInfo = {
   fieldNames: string[];
 };
 
+import { groupBy } from "./groupBy";
+
 export type DuplicateGroup = {
   /** The normalized key used to group these notes */
   key: string;
@@ -112,19 +114,20 @@ export function buildNoteInfos(
     templates: { qfmt: string; afmt: string; name: string; ord?: number }[];
   }[],
 ): NoteInfo[] {
-  const seen = new Map<string, NoteInfo>();
-  for (const card of cards) {
-    if (seen.has(card.guid)) continue;
-    const fieldNames = Object.keys(card.values);
-    seen.set(card.guid, {
+  const seen = new Set<string>();
+  return cards
+    .filter((card) => {
+      if (seen.has(card.guid)) return false;
+      seen.add(card.guid);
+      return true;
+    })
+    .map((card) => ({
       guid: card.guid,
       values: card.values,
       tags: card.tags,
       deckName: card.deckName,
-      fieldNames,
-    });
-  }
-  return Array.from(seen.values());
+      fieldNames: Object.keys(card.values),
+    }));
 }
 
 /**
@@ -135,48 +138,35 @@ export function findExactDuplicates(
   options: DuplicateSearchOptions,
 ): DuplicateGroup[] {
   const { fieldIndex, scope } = options;
-  const groups = new Map<string, NoteInfo[]>();
 
-  for (const note of notes) {
-    const raw = getFieldValue(note, fieldIndex);
-    const normalized = normalizeForComparison(raw);
-    if (!normalized) continue;
+  const notesWithKeys = notes
+    .map((note) => {
+      const normalized = normalizeForComparison(getFieldValue(note, fieldIndex));
+      if (!normalized) return null;
+      const key = scope === "deck" ? `${note.deckName}\x1F${normalized}` : normalized;
+      return { note, key };
+    })
+    .filter((entry) => entry !== null);
 
-    // Build the grouping key based on scope
-    let key: string;
-    if (scope === "deck") {
-      key = `${note.deckName}\x1F${normalized}`;
-    } else {
-      key = normalized;
-    }
+  const grouped = groupBy(notesWithKeys, (entry) => entry.key);
 
-    const group = groups.get(key);
-    if (group) {
-      group.push(note);
-    } else {
-      groups.set(key, [note]);
-    }
-  }
-
-  const result: DuplicateGroup[] = [];
-  for (const [key, noteGroup] of groups) {
-    if (noteGroup.length < 2) continue;
-    const displayKey = getFieldValue(noteGroup[0]!, fieldIndex) ?? key;
-    const cleanDisplayKey = displayKey
-      .replace(/<[^>]*>/g, "")
-      .replace(/\[sound:[^\]]+\]/g, "")
-      .trim();
-    result.push({
-      key,
-      displayKey: cleanDisplayKey || key,
-      notes: noteGroup,
-      similarity: 1.0,
-    });
-  }
-
-  // Sort by group size (largest groups first)
-  result.sort((a, b) => b.notes.length - a.notes.length);
-  return result;
+  return Object.entries(grouped)
+    .filter(([, entries]) => entries !== undefined && entries.length >= 2)
+    .map(([key, entries]) => {
+      const noteGroup = entries!.map((e) => e.note);
+      const displayKey = getFieldValue(noteGroup[0]!, fieldIndex) ?? key;
+      const cleanDisplayKey = displayKey
+        .replace(/<[^>]*>/g, "")
+        .replace(/\[sound:[^\]]+\]/g, "")
+        .trim();
+      return {
+        key,
+        displayKey: cleanDisplayKey || key,
+        notes: noteGroup,
+        similarity: 1.0,
+      };
+    })
+    .toSorted((a, b) => b.notes.length - a.notes.length);
 }
 
 /**
@@ -189,114 +179,91 @@ export function findFuzzyDuplicates(
 ): DuplicateGroup[] {
   const { fieldIndex, scope, fuzzyThreshold } = options;
 
-  // Build normalized values
-  const noteValues: { note: NoteInfo; normalized: string; scopeKey: string }[] = [];
-  for (const note of notes) {
-    const raw = getFieldValue(note, fieldIndex);
-    const normalized = normalizeForComparison(raw);
-    if (!normalized) continue;
-    const scopeKey = scope === "deck" ? note.deckName : "all";
-    noteValues.push({ note, normalized, scopeKey });
-  }
+  const noteValues = notes
+    .map((note) => {
+      const normalized = normalizeForComparison(getFieldValue(note, fieldIndex));
+      if (!normalized) return null;
+      const scopeKey = scope === "deck" ? note.deckName : "all";
+      return { note, normalized, scopeKey };
+    })
+    .filter((entry) => entry !== null);
 
-  // Group by scope first
-  const scopeGroups = new Map<string, typeof noteValues>();
-  for (const nv of noteValues) {
-    const group = scopeGroups.get(nv.scopeKey);
-    if (group) group.push(nv);
-    else scopeGroups.set(nv.scopeKey, [nv]);
-  }
+  const scopeGroups = groupBy(noteValues, (nv) => nv.scopeKey);
 
-  const result: DuplicateGroup[] = [];
   const mergedGuids = new Set<string>();
 
-  for (const scopeNotes of scopeGroups.values()) {
-    // Skip exact matches (already handled)
-    // Use Union-Find to group similar notes together
-    const parent = new Map<number, number>();
-    function find(i: number): number {
-      let p = parent.get(i) ?? i;
-      while (p !== (parent.get(p) ?? p)) {
-        p = parent.get(p) ?? p;
-      }
-      parent.set(i, p);
-      return p;
-    }
-    function union(i: number, j: number) {
-      parent.set(find(i), find(j));
-    }
-
-    // Compare all pairs within scope (limit to first 2000 to avoid freezing)
-    // Cache similarity scores to avoid recomputing during cluster averaging
-    const limit = Math.min(scopeNotes.length, 2000);
-    const simCache = new Map<string, number>();
-    for (let i = 0; i < limit; i++) {
-      for (let j = i + 1; j < limit; j++) {
-        const a = scopeNotes[i]!;
-        const b = scopeNotes[j]!;
-        // Skip if exactly the same (handled by exact matching)
-        if (a.normalized === b.normalized) continue;
-        const sim = stringSimilarity(a.normalized, b.normalized);
-        if (sim >= fuzzyThreshold) {
-          simCache.set(`${i}:${j}`, sim);
-          union(i, j);
+  return Object.values(scopeGroups)
+    .filter((group) => group !== undefined)
+    .flatMap((scopeNotes) => {
+      // Union-Find to group similar notes (inherently imperative)
+      const parent = new Map<number, number>();
+      function find(i: number): number {
+        let p = parent.get(i) ?? i;
+        while (p !== (parent.get(p) ?? p)) {
+          p = parent.get(p) ?? p;
         }
+        parent.set(i, p);
+        return p;
       }
-    }
-
-    // Collect groups
-    const clusters = new Map<number, { indices: number[] }>();
-    for (let i = 0; i < limit; i++) {
-      const root = find(i);
-      const cluster = clusters.get(root);
-      if (cluster) {
-        cluster.indices.push(i);
-      } else {
-        clusters.set(root, { indices: [i] });
+      function union(i: number, j: number) {
+        parent.set(find(i), find(j));
       }
-    }
 
-    for (const cluster of clusters.values()) {
-      if (cluster.indices.length < 2) continue;
-
-      // Calculate average similarity from cached scores
-      let totalSim = 0;
-      let count = 0;
-      for (let i = 0; i < cluster.indices.length; i++) {
-        for (let j = i + 1; j < cluster.indices.length; j++) {
-          const a = cluster.indices[i]!;
-          const b = cluster.indices[j]!;
-          const key = a < b ? `${a}:${b}` : `${b}:${a}`;
-          const cached = simCache.get(key);
-          totalSim += cached ?? 1.0; // 1.0 for exact matches (not in cache)
-          count++;
+      const limit = Math.min(scopeNotes.length, 2000);
+      const simCache = new Map<string, number>();
+      for (let i = 0; i < limit; i++) {
+        for (let j = i + 1; j < limit; j++) {
+          const a = scopeNotes[i]!;
+          const b = scopeNotes[j]!;
+          if (a.normalized === b.normalized) continue;
+          const sim = stringSimilarity(a.normalized, b.normalized);
+          if (sim >= fuzzyThreshold) {
+            simCache.set(`${i}:${j}`, sim);
+            union(i, j);
+          }
         }
       }
 
-      const avgSim = count > 0 ? totalSim / count : 1.0;
-      const clusterNotes = cluster.indices.map((i) => scopeNotes[i]!.note);
+      const clusterMap = groupBy(
+        Array.from({ length: limit }, (_, i) => i),
+        (i) => find(i),
+      );
 
-      // Skip if all notes already covered by exact matching
-      if (clusterNotes.every((n) => mergedGuids.has(n.guid))) continue;
-      for (const n of clusterNotes) mergedGuids.add(n.guid);
-
-      const displayKey =
-        getFieldValue(clusterNotes[0]!, fieldIndex)
-          ?.replace(/<[^>]*>/g, "")
-          .replace(/\[sound:[^\]]+\]/g, "")
-          .trim() ?? "";
-
-      result.push({
-        key: `fuzzy-${clusterNotes.map((n) => n.guid).join("-")}`,
-        displayKey: displayKey || "(empty)",
-        notes: clusterNotes,
-        similarity: Math.round(avgSim * 100) / 100,
-      });
-    }
-  }
-
-  result.sort((a, b) => b.notes.length - a.notes.length);
-  return result;
+      return Object.values(clusterMap)
+        .filter((indices): indices is number[] => indices !== undefined && indices.length >= 2)
+        .map((indices) => {
+          let totalSim = 0;
+          let count = 0;
+          for (let i = 0; i < indices.length; i++) {
+            for (let j = i + 1; j < indices.length; j++) {
+              const a = indices[i]!;
+              const b = indices[j]!;
+              const key = a < b ? `${a}:${b}` : `${b}:${a}`;
+              totalSim += simCache.get(key) ?? 1.0;
+              count++;
+            }
+          }
+          const avgSim = count > 0 ? totalSim / count : 1.0;
+          const clusterNotes = indices.map((i) => scopeNotes[i]!.note);
+          const displayKey =
+            getFieldValue(clusterNotes[0]!, fieldIndex)
+              ?.replace(/<[^>]*>/g, "")
+              .replace(/\[sound:[^\]]+\]/g, "")
+              .trim() ?? "";
+          return {
+            key: `fuzzy-${clusterNotes.map((n) => n.guid).join("-")}`,
+            displayKey: displayKey || "(empty)",
+            notes: clusterNotes,
+            similarity: Math.round(avgSim * 100) / 100,
+          };
+        })
+        .filter((group) => {
+          if (group.notes.every((n) => mergedGuids.has(n.guid))) return false;
+          group.notes.forEach((n) => mergedGuids.add(n.guid));
+          return true;
+        });
+    })
+    .toSorted((a, b) => b.notes.length - a.notes.length);
 }
 
 /**
@@ -310,13 +277,7 @@ export function findDuplicates(
 
   if (!options.fuzzy) return exactGroups;
 
-  // For fuzzy, exclude notes already in exact groups
-  const exactGuids = new Set<string>();
-  for (const group of exactGroups) {
-    for (const note of group.notes) {
-      exactGuids.add(note.guid);
-    }
-  }
+  const exactGuids = new Set(exactGroups.flatMap((group) => group.notes.map((n) => n.guid)));
 
   const remainingNotes = notes.filter((n) => !exactGuids.has(n.guid));
   const fuzzyGroups = findFuzzyDuplicates(remainingNotes, options);

--- a/src/utils/groupBy.ts
+++ b/src/utils/groupBy.ts
@@ -1,0 +1,15 @@
+/**
+ * Polyfill-style groupBy that works on Node 20 (which lacks Object.groupBy).
+ * Returns a plain object keyed by the result of the callback.
+ */
+export function groupBy<T, K extends PropertyKey>(
+  items: Iterable<T>,
+  keyFn: (item: T) => K,
+): Partial<Record<K, T[]>> {
+  const result = Object.create(null) as Record<K, T[]>;
+  for (const item of items) {
+    const key = keyFn(item);
+    (result[key] ??= []).push(item);
+  }
+  return result;
+}

--- a/src/utils/integrityCheck.ts
+++ b/src/utils/integrityCheck.ts
@@ -42,37 +42,46 @@ function isAnki21b(db: Database): boolean {
   return tableExists(db, "notetypes");
 }
 
+function countByKey<T, K extends string | number>(items: T[], keyFn: (item: T) => K): Map<K, number> {
+  const map = new Map<K, number>();
+  items.forEach((item) => {
+    const key = keyFn(item);
+    map.set(key, (map.get(key) ?? 0) + 1);
+  });
+  return map;
+}
+
+function sumValues(map: Map<unknown, number>): number {
+  let total = 0;
+  map.forEach((v) => { total += v; });
+  return total;
+}
+
 /**
  * Get all notetype IDs and their field counts from the database.
  */
 function getNotetypeFieldCounts(db: Database): Map<number, number> {
-  const result = new Map<number, number>();
-
   if (isAnki21b(db)) {
-    // anki21b: fields table with ntid
     const rows = executeQueryAll<{ ntid: number; cnt: number }>(
       db,
       "SELECT ntid, COUNT(*) as cnt FROM fields GROUP BY ntid",
     );
-    for (const row of rows) {
-      result.set(row.ntid, row.cnt);
-    }
-  } else {
-    // anki2: models stored as JSON in col table
-    try {
-      const col = executeQueryAll<{ models: string }>(db, "SELECT models FROM col");
-      if (col.length > 0 && col[0]!.models) {
-        const models = JSON.parse(col[0]!.models) as Record<string, { flds: unknown[] }>;
-        for (const [id, model] of Object.entries(models)) {
-          result.set(Number(id), model.flds?.length ?? 0);
-        }
-      }
-    } catch {
-      // If parsing fails, return empty
-    }
+    return new Map(rows.map((row) => [row.ntid, row.cnt]));
   }
 
-  return result;
+  try {
+    const col = executeQueryAll<{ models: string }>(db, "SELECT models FROM col");
+    if (col.length > 0 && col[0]!.models) {
+      const models = JSON.parse(col[0]!.models) as Record<string, { flds: unknown[] }>;
+      return new Map(
+        Object.entries(models).map(([id, model]) => [Number(id), model.flds?.length ?? 0]),
+      );
+    }
+  } catch {
+    // If parsing fails, return empty
+  }
+
+  return new Map();
 }
 
 /**
@@ -117,12 +126,151 @@ function getNotetypeIds(db: Database): Set<number> {
   }
 }
 
+function checkOrphanedCards(cards: CardRow[], noteIdSet: Set<number>): IntegrityIssue | null {
+  const orphanedCards = cards.filter((c) => !noteIdSet.has(c.nid));
+  if (orphanedCards.length === 0) return null;
+  return {
+    type: "orphaned-cards",
+    severity: "error",
+    title: "Orphaned Cards",
+    description: "Cards that reference notes which no longer exist. These cards cannot be studied.",
+    count: orphanedCards.length,
+    details: orphanedCards.slice(0, 20).map((c) => `Card ${c.id} → missing note ${c.nid}`),
+    fixable: true,
+  };
+}
+
+function checkOrphanedNotes(notes: NoteRow[], cardNoteIds: Set<number>): IntegrityIssue | null {
+  const orphanedNotes = notes.filter((n) => !cardNoteIds.has(n.id));
+  if (orphanedNotes.length === 0) return null;
+  return {
+    type: "orphaned-notes",
+    severity: "warning",
+    title: "Notes Without Cards",
+    description: "Notes that have no associated cards. They take up space but cannot be studied.",
+    count: orphanedNotes.length,
+    details: orphanedNotes.slice(0, 20).map((n) => `Note ${n.id} (guid: ${n.guid})`),
+    fixable: true,
+  };
+}
+
+function checkMissingNotetypes(notes: NoteRow[], notetypeIds: Set<number>): IntegrityIssue | null {
+  const missingNotetypes = countByKey(
+    notes.filter((n) => !notetypeIds.has(n.mid)),
+    (n) => n.mid,
+  );
+  if (missingNotetypes.size === 0) return null;
+  return {
+    type: "missing-notetype",
+    severity: "error",
+    title: "Missing Note Types",
+    description: "Notes reference note types that don't exist in the database.",
+    count: sumValues(missingNotetypes),
+    details: Array.from(missingNotetypes.entries()).map(
+      ([mid, cnt]) => `Notetype ${mid}: ${cnt} note${cnt !== 1 ? "s" : ""} affected`,
+    ),
+    fixable: false,
+  };
+}
+
+function checkMissingDecks(cards: CardRow[], deckIds: Set<number>): IntegrityIssue | null {
+  const missingDecks = countByKey(
+    cards.filter((c) => !deckIds.has(c.odid !== 0 ? c.odid : c.did)),
+    (c) => (c.odid !== 0 ? c.odid : c.did),
+  );
+  if (missingDecks.size === 0) return null;
+  return {
+    type: "missing-deck",
+    severity: "error",
+    title: "Missing Decks",
+    description: "Cards reference decks that don't exist in the database.",
+    count: sumValues(missingDecks),
+    details: Array.from(missingDecks.entries()).map(
+      ([did, cnt]) => `Deck ${did}: ${cnt} card${cnt !== 1 ? "s" : ""} affected`,
+    ),
+    fixable: true,
+  };
+}
+
+function checkFieldCountMismatches(notes: NoteRow[], notetypeFieldCounts: Map<number, number>): IntegrityIssue | null {
+  const fieldMismatches = notes
+    .filter((note) => notetypeFieldCounts.has(note.mid))
+    .map((note) => ({
+      noteId: note.id,
+      expected: notetypeFieldCounts.get(note.mid)!,
+      actual: note.flds.split("\x1f").length,
+    }))
+    .filter((m) => m.actual !== m.expected);
+  if (fieldMismatches.length === 0) return null;
+  return {
+    type: "field-count-mismatch",
+    severity: "warning",
+    title: "Field Count Mismatches",
+    description: "Notes whose field count doesn't match their note type definition.",
+    count: fieldMismatches.length,
+    details: fieldMismatches.slice(0, 20).map(
+      (m) => `Note ${m.noteId}: expected ${m.expected} fields, has ${m.actual}`,
+    ),
+    fixable: false,
+  };
+}
+
+function hasInvalidScheduling(card: CardRow): boolean {
+  return (card.ivl < 0 && card.type === 2) || card.type < 0 || card.type > 3 || card.queue < -3 || card.queue > 4;
+}
+
+function describeSchedulingIssue(card: CardRow): string[] {
+  return [
+    ...(card.ivl < 0 && card.type === 2 ? [`Card ${card.id}: negative interval on review card`] : []),
+    ...(card.type < 0 || card.type > 3 ? [`Card ${card.id}: invalid type ${card.type}`] : []),
+    ...(card.queue < -3 || card.queue > 4 ? [`Card ${card.id}: invalid queue ${card.queue}`] : []),
+  ];
+}
+
+function checkInvalidScheduling(cards: CardRow[]): IntegrityIssue | null {
+  const invalidCards = cards.filter(hasInvalidScheduling);
+  const details = invalidCards.flatMap(describeSchedulingIssue);
+  if (details.length === 0) return null;
+  return {
+    type: "invalid-scheduling",
+    severity: "warning",
+    title: "Invalid Scheduling Data",
+    description: "Cards with impossible scheduling values (negative intervals, invalid types/queues).",
+    count: details.length,
+    details: details.slice(0, 20),
+    fixable: true,
+  };
+}
+
+function checkDuplicateIds<T>(
+  items: T[],
+  keyFn: (item: T) => string | number,
+  type: IssueType,
+  severity: IssueSeverity,
+  title: string,
+  description: string,
+  labelFn: (key: string | number, cnt: number) => string,
+  limit?: number,
+): IntegrityIssue | null {
+  const counts = countByKey(items, keyFn);
+  const dups = Array.from(counts.entries()).filter(([, cnt]) => cnt > 1);
+  if (dups.length === 0) return null;
+  const details = limit !== undefined ? dups.slice(0, limit) : dups;
+  return {
+    type,
+    severity,
+    title,
+    description,
+    count: sumValues(new Map(dups)),
+    details: details.map(([key, cnt]) => labelFn(key, cnt)),
+    fixable: false,
+  };
+}
+
 /**
  * Run all integrity checks against the database and return issues found.
  */
 export function checkDatabaseIntegrity(db: Database): IntegrityIssue[] {
-  const issues: IntegrityIssue[] = [];
-
   const notes = executeQueryAll<NoteRow>(db, "SELECT id, mid, flds, guid FROM notes");
   const cards = executeQueryAll<CardRow>(
     db,
@@ -135,185 +283,33 @@ export function checkDatabaseIntegrity(db: Database): IntegrityIssue[] {
   const notetypeIds = getNotetypeIds(db);
   const notetypeFieldCounts = getNotetypeFieldCounts(db);
 
-  // 1. Orphaned cards (cards whose note doesn't exist)
-  const orphanedCards = cards.filter((c) => !noteIdSet.has(c.nid));
-  if (orphanedCards.length > 0) {
-    issues.push({
-      type: "orphaned-cards",
-      severity: "error",
-      title: "Orphaned Cards",
-      description: "Cards that reference notes which no longer exist. These cards cannot be studied.",
-      count: orphanedCards.length,
-      details: orphanedCards.slice(0, 20).map((c) => `Card ${c.id} → missing note ${c.nid}`),
-      fixable: true,
-    });
-  }
-
-  // 2. Orphaned notes (notes with no cards)
-  const orphanedNotes = notes.filter((n) => !cardNoteIds.has(n.id));
-  if (orphanedNotes.length > 0) {
-    issues.push({
-      type: "orphaned-notes",
-      severity: "warning",
-      title: "Notes Without Cards",
-      description: "Notes that have no associated cards. They take up space but cannot be studied.",
-      count: orphanedNotes.length,
-      details: orphanedNotes.slice(0, 20).map((n) => `Note ${n.id} (guid: ${n.guid})`),
-      fixable: true,
-    });
-  }
-
-  // 3. Missing notetypes
-  const missingNotetypes = new Map<number, number>();
-  for (const note of notes) {
-    if (!notetypeIds.has(note.mid)) {
-      missingNotetypes.set(note.mid, (missingNotetypes.get(note.mid) ?? 0) + 1);
-    }
-  }
-  if (missingNotetypes.size > 0) {
-    const total = Array.from(missingNotetypes.values()).reduce((a, b) => a + b, 0);
-    issues.push({
-      type: "missing-notetype",
-      severity: "error",
-      title: "Missing Note Types",
-      description: "Notes reference note types that don't exist in the database.",
-      count: total,
-      details: Array.from(missingNotetypes.entries()).map(
-        ([mid, cnt]) => `Notetype ${mid}: ${cnt} note${cnt !== 1 ? "s" : ""} affected`,
-      ),
-      fixable: false,
-    });
-  }
-
-  // 4. Missing decks
-  const missingDecks = new Map<number, number>();
-  for (const card of cards) {
-    const effectiveDid = card.odid !== 0 ? card.odid : card.did;
-    if (!deckIds.has(effectiveDid)) {
-      missingDecks.set(effectiveDid, (missingDecks.get(effectiveDid) ?? 0) + 1);
-    }
-  }
-  if (missingDecks.size > 0) {
-    const total = Array.from(missingDecks.values()).reduce((a, b) => a + b, 0);
-    issues.push({
-      type: "missing-deck",
-      severity: "error",
-      title: "Missing Decks",
-      description: "Cards reference decks that don't exist in the database.",
-      count: total,
-      details: Array.from(missingDecks.entries()).map(
-        ([did, cnt]) => `Deck ${did}: ${cnt} card${cnt !== 1 ? "s" : ""} affected`,
-      ),
-      fixable: true,
-    });
-  }
-
-  // 5. Field count mismatches
-  const fieldMismatches: { noteId: number; expected: number; actual: number }[] = [];
-  for (const note of notes) {
-    const expectedCount = notetypeFieldCounts.get(note.mid);
-    if (expectedCount === undefined) continue; // already caught by missing notetype check
-    const actualCount = note.flds.split("\x1f").length;
-    if (actualCount !== expectedCount) {
-      fieldMismatches.push({ noteId: note.id, expected: expectedCount, actual: actualCount });
-    }
-  }
-  if (fieldMismatches.length > 0) {
-    issues.push({
-      type: "field-count-mismatch",
-      severity: "warning",
-      title: "Field Count Mismatches",
-      description: "Notes whose field count doesn't match their note type definition.",
-      count: fieldMismatches.length,
-      details: fieldMismatches.slice(0, 20).map(
-        (m) => `Note ${m.noteId}: expected ${m.expected} fields, has ${m.actual}`,
-      ),
-      fixable: false,
-    });
-  }
-
-  // 6. Invalid scheduling data
-  const invalidScheduling: { cardId: number; reason: string }[] = [];
-  for (const card of cards) {
-    if (card.ivl < 0 && card.type === 2) {
-      invalidScheduling.push({ cardId: card.id, reason: "negative interval on review card" });
-    }
-    if (card.type < 0 || card.type > 3) {
-      invalidScheduling.push({ cardId: card.id, reason: `invalid type ${card.type}` });
-    }
-    if (card.queue < -3 || card.queue > 4) {
-      invalidScheduling.push({ cardId: card.id, reason: `invalid queue ${card.queue}` });
-    }
-  }
-  if (invalidScheduling.length > 0) {
-    issues.push({
-      type: "invalid-scheduling",
-      severity: "warning",
-      title: "Invalid Scheduling Data",
-      description: "Cards with impossible scheduling values (negative intervals, invalid types/queues).",
-      count: invalidScheduling.length,
-      details: invalidScheduling.slice(0, 20).map(
-        (s) => `Card ${s.cardId}: ${s.reason}`,
-      ),
-      fixable: true,
-    });
-  }
-
-  // 7. Duplicate note IDs
-  const noteIdCounts = new Map<number, number>();
-  for (const note of notes) {
-    noteIdCounts.set(note.id, (noteIdCounts.get(note.id) ?? 0) + 1);
-  }
-  const dupNoteIds = Array.from(noteIdCounts.entries()).filter(([, cnt]) => cnt > 1);
-  if (dupNoteIds.length > 0) {
-    issues.push({
-      type: "duplicate-note-ids",
-      severity: "error",
-      title: "Duplicate Note IDs",
-      description: "Multiple notes share the same ID, which can cause data corruption.",
-      count: dupNoteIds.reduce((a, [, cnt]) => a + cnt, 0),
-      details: dupNoteIds.map(([id, cnt]) => `Note ID ${id}: ${cnt} occurrences`),
-      fixable: false,
-    });
-  }
-
-  // 8. Duplicate card IDs
-  const cardIdCounts = new Map<number, number>();
-  for (const card of cards) {
-    cardIdCounts.set(card.id, (cardIdCounts.get(card.id) ?? 0) + 1);
-  }
-  const dupCardIds = Array.from(cardIdCounts.entries()).filter(([, cnt]) => cnt > 1);
-  if (dupCardIds.length > 0) {
-    issues.push({
-      type: "duplicate-card-ids",
-      severity: "error",
-      title: "Duplicate Card IDs",
-      description: "Multiple cards share the same ID, which can cause data corruption.",
-      count: dupCardIds.reduce((a, [, cnt]) => a + cnt, 0),
-      details: dupCardIds.map(([id, cnt]) => `Card ID ${id}: ${cnt} occurrences`),
-      fixable: false,
-    });
-  }
-
-  // 9. Duplicate GUIDs
-  const guidCounts = new Map<string, number>();
-  for (const note of notes) {
-    guidCounts.set(note.guid, (guidCounts.get(note.guid) ?? 0) + 1);
-  }
-  const dupGuids = Array.from(guidCounts.entries()).filter(([, cnt]) => cnt > 1);
-  if (dupGuids.length > 0) {
-    issues.push({
-      type: "duplicate-guids",
-      severity: "warning",
-      title: "Duplicate Note GUIDs",
-      description: "Multiple notes share the same GUID. This can cause sync conflicts.",
-      count: dupGuids.reduce((a, [, cnt]) => a + cnt, 0),
-      details: dupGuids.slice(0, 20).map(([guid, cnt]) => `GUID "${guid}": ${cnt} occurrences`),
-      fixable: false,
-    });
-  }
-
-  return issues;
+  return [
+    checkOrphanedCards(cards, noteIdSet),
+    checkOrphanedNotes(notes, cardNoteIds),
+    checkMissingNotetypes(notes, notetypeIds),
+    checkMissingDecks(cards, deckIds),
+    checkFieldCountMismatches(notes, notetypeFieldCounts),
+    checkInvalidScheduling(cards),
+    checkDuplicateIds(
+      notes, (n) => n.id,
+      "duplicate-note-ids", "error", "Duplicate Note IDs",
+      "Multiple notes share the same ID, which can cause data corruption.",
+      (id, cnt) => `Note ID ${id}: ${cnt} occurrences`,
+    ),
+    checkDuplicateIds(
+      cards, (c) => c.id,
+      "duplicate-card-ids", "error", "Duplicate Card IDs",
+      "Multiple cards share the same ID, which can cause data corruption.",
+      (id, cnt) => `Card ID ${id}: ${cnt} occurrences`,
+    ),
+    checkDuplicateIds(
+      notes, (n) => n.guid,
+      "duplicate-guids", "warning", "Duplicate Note GUIDs",
+      "Multiple notes share the same GUID. This can cause sync conflicts.",
+      (guid, cnt) => `GUID "${guid}": ${cnt} occurrences`,
+      20,
+    ),
+  ].filter((issue): issue is IntegrityIssue => issue !== null);
 }
 
 /**
@@ -354,19 +350,15 @@ function fixMissingDecks(db: Database): number {
     "SELECT id, nid, did, type, queue, due, ivl, odid FROM cards",
   );
 
-  let fixed = 0;
-  for (const card of cards) {
-    const effectiveDid = card.odid !== 0 ? card.odid : card.did;
-    if (!deckIds.has(effectiveDid)) {
-      if (card.odid !== 0) {
-        db.run(`UPDATE cards SET odid = 0, did = 1 WHERE id = ${card.id}`);
-      } else {
-        db.run(`UPDATE cards SET did = 1 WHERE id = ${card.id}`);
-      }
-      fixed++;
+  const cardsToFix = cards.filter((c) => !deckIds.has(c.odid !== 0 ? c.odid : c.did));
+  cardsToFix.forEach((card) => {
+    if (card.odid !== 0) {
+      db.run(`UPDATE cards SET odid = 0, did = 1 WHERE id = ${card.id}`);
+    } else {
+      db.run(`UPDATE cards SET did = 1 WHERE id = ${card.id}`);
     }
-  }
-  return fixed;
+  });
+  return cardsToFix.length;
 }
 
 /**
@@ -378,20 +370,13 @@ function fixInvalidScheduling(db: Database): number {
     "SELECT id, nid, did, type, queue, due, ivl, odid FROM cards",
   );
 
-  let fixed = 0;
-  for (const card of cards) {
-    const hasNegativeIvl = card.ivl < 0 && card.type === 2;
-    const hasInvalidType = card.type < 0 || card.type > 3;
-    const hasInvalidQueue = card.queue < -3 || card.queue > 4;
-
-    if (hasNegativeIvl || hasInvalidType || hasInvalidQueue) {
-      db.run(
-        `UPDATE cards SET type = 0, queue = 0, due = 0, ivl = 0, factor = 0, reps = 0, lapses = 0 WHERE id = ${card.id}`,
-      );
-      fixed++;
-    }
-  }
-  return fixed;
+  const cardsToFix = cards.filter(hasInvalidScheduling);
+  cardsToFix.forEach((card) => {
+    db.run(
+      `UPDATE cards SET type = 0, queue = 0, due = 0, ivl = 0, factor = 0, reps = 0, lapses = 0 WHERE id = ${card.id}`,
+    );
+  });
+  return cardsToFix.length;
 }
 
 /**

--- a/src/utils/mediaCache.ts
+++ b/src/utils/mediaCache.ts
@@ -27,14 +27,14 @@ async function loadMediaEntries<T>(
   transform: (blob: Blob) => T,
 ): Promise<Map<string, T>> {
   const mediaKeys = filterMediaKeys(await cache.keys());
-  const entries = new Map<string, T>();
-  for (const req of mediaKeys) {
-    const resp = await cache.match(req);
-    if (resp) {
-      entries.set(mediaKeyToFilename(req), transform(await resp.blob()));
-    }
-  }
-  return entries;
+  const results = await Promise.all(
+    mediaKeys.map(async (req) => {
+      const resp = await cache.match(req);
+      if (!resp) return null;
+      return [mediaKeyToFilename(req), transform(await resp.blob())] as const;
+    }),
+  );
+  return new Map(results.filter((r): r is NonNullable<typeof r> => r !== null));
 }
 
 /**
@@ -56,9 +56,7 @@ export function loadMediaObjectUrls(cache: Cache): Promise<Map<string, string>> 
  * Revoke all object URLs in a Map (for cleanup on deck switch / unmount).
  */
 export function revokeMediaObjectUrls(urls: Map<string, string>): void {
-  for (const url of urls.values()) {
-    URL.revokeObjectURL(url);
-  }
+  urls.forEach((url) => URL.revokeObjectURL(url));
 }
 
 /**

--- a/src/utils/tagTree.ts
+++ b/src/utils/tagTree.ts
@@ -11,41 +11,34 @@ export type TagTreeNode = {
  * Each node tracks how many notes have that exact tag or a descendant.
  */
 export function buildTagTree(tags: string[], tagNoteCounts: Map<string, number>): TagTreeNode[] {
-  const nodeMap = new Map<string, TagTreeNode>();
-
-  for (const tag of tags) {
+  const nodeEntries = tags.flatMap((tag) => {
     const parts = tag.split("::");
-    for (const [i] of parts.entries()) {
+    return parts.map((_, i) => {
       const fullPath = parts.slice(0, i + 1).join("::");
-      if (nodeMap.has(fullPath)) continue;
-      nodeMap.set(fullPath, {
-        name: parts[i]!,
-        fullPath,
-        noteCount: 0,
-        children: [],
-        expanded: false,
-      });
-    }
-  }
+      return [fullPath, parts[i]!] as const;
+    });
+  });
+
+  const nodeMap = new Map<string, TagTreeNode>(
+    nodeEntries.map(([fullPath, name]) => [
+      fullPath,
+      { name, fullPath, noteCount: 0, children: [], expanded: false },
+    ]),
+  );
 
   // Wire up parent-child relationships
-  for (const node of nodeMap.values()) {
+  nodeMap.forEach((node) => {
     const lastSep = node.fullPath.lastIndexOf("::");
-    if (lastSep === -1) continue;
-    const parentPath = node.fullPath.slice(0, lastSep);
-    const parent = nodeMap.get(parentPath);
-    if (parent) {
-      parent.children.push(node);
-    }
-  }
+    if (lastSep === -1) return;
+    const parent = nodeMap.get(node.fullPath.slice(0, lastSep));
+    if (parent) parent.children.push(node);
+  });
 
   // Compute note counts (exact matches only - parent click will filter with prefix)
-  for (const [tag, count] of tagNoteCounts) {
+  tagNoteCounts.forEach((count, tag) => {
     const node = nodeMap.get(tag);
-    if (node) {
-      node.noteCount = count;
-    }
-  }
+    if (node) node.noteCount = count;
+  });
 
   // Return only root nodes (no "::" in fullPath), sorted alphabetically
   return Array.from(nodeMap.values())


### PR DESCRIPTION
## Summary

- Replace `for...of` loops with `.push()` accumulation → `.map()`, `.filter()`, `.flatMap()`
- Replace `Map.set()` grouping patterns → `Object.groupBy()`, `new Map(entries.map(...))`
- Replace mutable object building → `Object.fromEntries()`, spread operators
- Net reduction of ~258 lines across 15 files

Key files: `syncMerge.ts`, `integrityCheck.ts`, `duplicates.ts`, `stores.ts`, `computeStats.ts`, `queue.ts`, `deckInfo.ts`, `tagTree.ts`, `syncWrite.ts`, `normalSync.ts`, `undoRedoExecutor.ts`, `mediaCache.ts`, `anki21b/index.ts`

Inherently imperative patterns (DB side-effects, Fisher-Yates shuffle, CSV parser, union-find) were intentionally kept.