### PR TITLE
refactor: consolidate duplicated utilities, fix N+1 query, standardize imports

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,12 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import FlashCard from "./components/FlashCard.vue";
 import CardButtons from "./components/CardButtons.vue";
 import type { Answer } from "./scheduler/types";
-import { getRenderedCardString, hasTypeAnswerField, extractExpectedAnswer, replaceMediaFiles } from "./utils/render";
+import {
+  getRenderedCardString,
+  hasTypeAnswerField,
+  extractExpectedAnswer,
+  replaceMediaFiles,
+} from "./utils/render";
 import { isImageOcclusionCard, renderImageOcclusion } from "./utils/imageOcclusion";
 import { renderDiffHtml } from "./utils/typeansDiff";
 import { computeDeckInfo } from "./utils/deckInfo";
@@ -47,7 +52,9 @@ import { defineAsyncComponent } from "vue";
 const StatsPanel = defineAsyncComponent(() => import("./components/StatsPanel.vue"));
 const NoteTypeManager = defineAsyncComponent(() => import("./components/NoteTypeManager.vue"));
 const BackupPanel = defineAsyncComponent(() => import("./components/BackupPanel.vue"));
-const DatabaseCheckPanel = defineAsyncComponent(() => import("./components/DatabaseCheckPanel.vue"));
+const DatabaseCheckPanel = defineAsyncComponent(
+  () => import("./components/DatabaseCheckPanel.vue"),
+);
 import CongratsScreen from "./components/CongratsScreen.vue";
 import SchedulerSettings from "./components/SchedulerSettings.vue";
 import FlagSettings from "./components/FlagSettings.vue";
@@ -55,13 +62,19 @@ import CommandPalette from "./components/CommandPalette.vue";
 import { useCommands } from "./composables/useCommands";
 import { getAutoplayAudioSources, playAudio } from "./utils/sound";
 import { Info } from "lucide-vue-next";
-import Modal from "./design-system/components/primitives/Modal.vue";
-import Tooltip from "./design-system/components/primitives/Tooltip.vue";
+import { Modal, Tooltip } from "./design-system";
 import { markDataChanged, startAutoSync } from "./lib/autoSync";
 import { startAutoBackup } from "./backup/autoBackup";
 import NoteEditModal from "./components/NoteEditModal.vue";
 import ImageOcclusionNoteEditor from "./components/ImageOcclusionNoteEditor.vue";
-import { updateNote, isSyncedCollection, addNote, getOrCreateIONotetype, addMediaToCache, getActiveDeckId } from "./stores";
+import {
+  updateNote,
+  isSyncedCollection,
+  addNote,
+  getOrCreateIONotetype,
+  addMediaToCache,
+  getActiveDeckId,
+} from "./stores";
 
 const activeSide = ref<"front" | "back">("front");
 const reviewStartTime = ref<number>(Date.now());
@@ -219,10 +232,7 @@ const backHtmlWithDiff = computed(() => {
   const diffHtml = renderDiffHtml(typedAnswer.value, expected);
 
   // Replace the typeans span with the diff HTML
-  return card.backSideHtml.replace(
-    /<span id="typeans"[^>]*>[\s\S]*?<\/span>/,
-    diffHtml,
-  );
+  return card.backSideHtml.replace(/<span id="typeans"[^>]*>[\s\S]*?<\/span>/, diffHtml);
 });
 
 // Reset typed answer when the card changes
@@ -288,7 +298,11 @@ async function handleNoteSave(payload: { fields: Record<string, string | null>; 
   editModalOpen.value = false;
 }
 
-async function handleIONoteCreate(payload: { fields: Record<string, string | null>; tags: string[]; imageFile?: File }) {
+async function handleIONoteCreate(payload: {
+  fields: Record<string, string | null>;
+  tags: string[];
+  imageFile?: File;
+}) {
   try {
     // Cache image file if provided
     if (payload.imageFile) {
@@ -372,10 +386,7 @@ async function handleUndoRedoKeydown(e: KeyboardEvent) {
     e.preventDefault();
     const desc = await executeUndo();
     if (desc) showUndoToast(`Undo: ${desc}`);
-  } else if (
-    (e.key.toLowerCase() === "z" && e.shiftKey) ||
-    e.key.toLowerCase() === "y"
-  ) {
+  } else if ((e.key.toLowerCase() === "z" && e.shiftKey) || e.key.toLowerCase() === "y") {
     e.preventDefault();
     const desc = await executeRedo();
     if (desc) showUndoToast(`Redo: ${desc}`);
@@ -523,13 +534,29 @@ onUnmounted(clearAutoAdvanceTimer);
       <template v-if="renderedCard">
         <div v-if="activeFilteredDeckSig" class="filtered-deck-header">
           <span class="filtered-deck-name">
-            <svg class="filtered-deck-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg
+              class="filtered-deck-icon"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
               <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
             </svg>
             {{ activeFilteredDeckSig.name }}
             <span v-if="!activeFilteredDeckSig.reschedule" class="cram-badge">Cram</span>
           </span>
-          <button class="filtered-deck-close" @click="emptyFilteredDeck(activeFilteredDeckSig.id); reviewModeSig = 'deck-list'">
+          <button
+            class="filtered-deck-close"
+            @click="
+              emptyFilteredDeck(activeFilteredDeckSig.id);
+              reviewModeSig = 'deck-list';
+            "
+          >
             &times;
           </button>
         </div>
@@ -545,7 +572,9 @@ onUnmounted(clearAutoAdvanceTimer);
             class="deck-info-btn io-add-btn"
             title="Add Image Occlusion Note"
             @click="ioCreateModalOpen = true"
-          >+IO</button>
+          >
+            +IO
+          </button>
         </div>
         <FlashCard
           :active-side="activeSide"
@@ -934,11 +963,15 @@ main {
 }
 
 .toast-enter-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .toast-leave-active {
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
 }
 
 .toast-enter-from {

--- a/src/__tests__/sync-coverage-gaps.test.ts
+++ b/src/__tests__/sync-coverage-gaps.test.ts
@@ -26,8 +26,7 @@
  */
 import "fake-indexeddb/auto";
 import { describe, test, expect, beforeEach } from "vitest";
-import initSqlJs, { type SqlJsStatic, type Database } from "sql.js";
-import { join } from "node:path";
+import { type SqlJsStatic } from "sql.js";
 import {
   applyRemoteChunk,
   applyRemoteGraves,
@@ -51,238 +50,16 @@ import {
   readDeckStepCounts,
 } from "../lib/syncWrite";
 import { reviewDB } from "../scheduler/db";
+import { getSqlJs, scalar, createAnki2Collection, createAnki21bDb } from "./testDbUtils";
 
 // ── SQL.js setup ──────────────────────────────────────────────────
 
 let SQL: SqlJsStatic;
 
 beforeEach(async () => {
-  if (!SQL) {
-    const wasmPath = join(process.cwd(), "node_modules", "sql.js", "dist", "sql-wasm.wasm");
-    SQL = await initSqlJs({ locateFile: () => wasmPath });
-  }
+  SQL = await getSqlJs();
   await reviewDB.clearAll();
 });
-
-/** Read a scalar value from the database. */
-function scalar(db: Database, sql: string): unknown {
-  const r = db.exec(sql);
-  return r[0]?.values[0]?.[0] ?? null;
-}
-
-/** Create a minimal anki2 collection with proper schema. */
-function createAnki2Collection(
-  opts: {
-    dconf?: Record<string, unknown>;
-    decks?: Record<string, unknown>;
-    models?: Record<string, unknown>;
-    tags?: Record<string, number>;
-    conf?: Record<string, unknown>;
-    cardOverrides?: Record<string, unknown>;
-    extraCards?: Array<Record<string, unknown>>;
-    extraNotes?: Array<Record<string, unknown>>;
-  } = {},
-): Database {
-  const db = new SQL.Database();
-  const nowMs = Date.now();
-  const nowSec = Math.floor(nowMs / 1000);
-  const crt = nowSec - 86400 * 30;
-
-  const defaultDconf = {
-    "1": {
-      id: 1, mod: nowSec, name: "Default", usn: 0,
-      new: { delays: [1, 10], order: 1, perDay: 20 },
-      lapse: { delays: [10], minInt: 1, mult: 0, leechFails: 8 },
-      rev: { perDay: 200, ease4: 1.3, hardFactor: 1.2, ivlFct: 1.0, maxIvl: 36500, fuzz: true },
-    },
-  };
-
-  const defaultDecks = {
-    "1": { id: 1, mod: nowSec, name: "Default", usn: 0, conf: "1" },
-  };
-
-  const defaultModels = {
-    "1234567890": {
-      id: 1234567890, mod: nowSec, name: "Basic", usn: 0,
-      flds: [{ name: "Front", ord: 0 }, { name: "Back", ord: 1 }],
-      tmpls: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
-    },
-  };
-
-  db.run(`CREATE TABLE col (
-    id integer primary key, crt integer NOT NULL, mod integer NOT NULL,
-    scm integer NOT NULL, ver integer NOT NULL, dty integer NOT NULL,
-    usn integer NOT NULL, ls integer NOT NULL, conf text NOT NULL,
-    models text NOT NULL, decks text NOT NULL, dconf text NOT NULL, tags text NOT NULL
-  )`);
-  db.run(
-    `INSERT INTO col VALUES (1, ?, ?, ?, 11, 0, 0, 0, ?, ?, ?, ?, ?)`,
-    [
-      crt, nowMs, nowSec,
-      JSON.stringify(opts.conf ?? {}),
-      JSON.stringify(opts.models ?? defaultModels),
-      JSON.stringify(opts.decks ?? defaultDecks),
-      JSON.stringify(opts.dconf ?? defaultDconf),
-      JSON.stringify(opts.tags ?? {}),
-    ],
-  );
-
-  db.run(`CREATE TABLE notes (
-    id integer primary key, guid text NOT NULL, mid integer NOT NULL,
-    mod integer NOT NULL, usn integer NOT NULL, tags text NOT NULL,
-    flds text NOT NULL, sfld integer NOT NULL, csum integer NOT NULL,
-    flags integer NOT NULL, data text NOT NULL
-  )`);
-  db.run(`CREATE TABLE cards (
-    id integer primary key, nid integer NOT NULL, did integer NOT NULL,
-    ord integer NOT NULL, mod integer NOT NULL, usn integer NOT NULL,
-    type integer NOT NULL, queue integer NOT NULL, due integer NOT NULL,
-    ivl integer NOT NULL, factor integer NOT NULL, reps integer NOT NULL,
-    lapses integer NOT NULL, left integer NOT NULL, odue integer NOT NULL,
-    odid integer NOT NULL, flags integer NOT NULL, data text NOT NULL
-  )`);
-  db.run(`CREATE TABLE revlog (
-    id integer primary key, cid integer NOT NULL, usn integer NOT NULL,
-    ease integer NOT NULL, ivl integer NOT NULL, lastIvl integer NOT NULL,
-    factor integer NOT NULL, time integer NOT NULL, type integer NOT NULL
-  )`);
-  db.run(`CREATE TABLE graves (
-    usn integer NOT NULL, oid integer NOT NULL, type integer NOT NULL
-  )`);
-
-  // Insert default note
-  db.run(`INSERT INTO notes VALUES (100, 'abc123', 1234567890, ?, 0, '', 'front\x1fback', 'front', 0, 0, '')`, [nowSec]);
-
-  // Insert extra notes
-  for (const note of opts.extraNotes ?? []) {
-    const n = {
-      id: 101, guid: "def456", mid: 1234567890, mod: nowSec, usn: 0,
-      tags: "", flds: "q\x1fa", sfld: "q", csum: 0, flags: 0, data: "",
-      ...note,
-    };
-    db.run(
-      "INSERT INTO notes VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-      [n.id, n.guid, n.mid, n.mod, n.usn, n.tags, n.flds, n.sfld, n.csum, n.flags, n.data],
-    );
-  }
-
-  const cardDefaults = {
-    id: 200, nid: 100, did: 1, ord: 0, mod: nowSec, usn: 0,
-    type: 0, queue: 0, due: 0, ivl: 0, factor: 0, reps: 0,
-    lapses: 0, left: 0, odue: 0, odid: 0, flags: 0, data: "",
-    ...opts.cardOverrides,
-  };
-
-  db.run(
-    "INSERT INTO cards VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-    [
-      cardDefaults.id, cardDefaults.nid, cardDefaults.did, cardDefaults.ord,
-      cardDefaults.mod, cardDefaults.usn, cardDefaults.type, cardDefaults.queue,
-      cardDefaults.due, cardDefaults.ivl, cardDefaults.factor, cardDefaults.reps,
-      cardDefaults.lapses, cardDefaults.left, cardDefaults.odue, cardDefaults.odid,
-      cardDefaults.flags, cardDefaults.data,
-    ],
-  );
-
-  // Insert extra cards
-  for (const card of opts.extraCards ?? []) {
-    const c = {
-      id: 201, nid: 100, did: 1, ord: 0, mod: nowSec, usn: 0,
-      type: 0, queue: 0, due: 0, ivl: 0, factor: 0, reps: 0,
-      lapses: 0, left: 0, odue: 0, odid: 0, flags: 0, data: "",
-      ...card,
-    };
-    db.run(
-      "INSERT INTO cards VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-      [c.id, c.nid, c.did, c.ord, c.mod, c.usn, c.type, c.queue,
-       c.due, c.ivl, c.factor, c.reps, c.lapses, c.left, c.odue, c.odid, c.flags, c.data],
-    );
-  }
-
-  return db;
-}
-
-/** Create a minimal anki21b collection with separate tables. */
-function createAnki21bDb(
-  opts: {
-    notetypes?: Array<{ id: number; name: string; mtime_secs: number; usn: number; config: string }>;
-    decks?: Array<{ id: number; name: string; mtime: number; usn: number; common: string }>;
-    deckConfigs?: Array<{ id: number; name: string; mtime: number; usn: number; config: string }>;
-    tags?: Array<{ tag: string; usn: number }>;
-    conf?: Record<string, unknown>;
-  } = {},
-): Database {
-  const db = new SQL.Database();
-  const nowMs = Date.now();
-  const nowSec = Math.floor(nowMs / 1000);
-  const crt = nowSec - 86400 * 30;
-
-  db.run(`CREATE TABLE col (
-    id integer primary key, crt integer NOT NULL, mod integer NOT NULL,
-    scm integer NOT NULL, ver integer NOT NULL, dty integer NOT NULL,
-    usn integer NOT NULL, ls integer NOT NULL, conf text NOT NULL,
-    models text NOT NULL, decks text NOT NULL, dconf text NOT NULL, tags text NOT NULL
-  )`);
-  db.run(
-    `INSERT INTO col VALUES (1, ?, ?, ?, 11, 0, 0, 0, ?, '{}', '{}', '{}', '{}')`,
-    [crt, nowMs, nowSec, JSON.stringify(opts.conf ?? {})],
-  );
-
-  db.run(`CREATE TABLE notetypes (
-    id integer primary key, name text NOT NULL, mtime_secs integer NOT NULL,
-    usn integer NOT NULL, config text NOT NULL
-  )`);
-  db.run(`CREATE TABLE decks (
-    id integer primary key, name text NOT NULL, mtime integer NOT NULL,
-    usn integer NOT NULL, common text NOT NULL
-  )`);
-  db.run(`CREATE TABLE deck_config (
-    id integer primary key, name text NOT NULL, mtime integer NOT NULL,
-    usn integer NOT NULL, config text NOT NULL
-  )`);
-  db.run(`CREATE TABLE tags (tag text primary key, usn integer NOT NULL)`);
-
-  db.run(`CREATE TABLE notes (
-    id integer primary key, guid text NOT NULL, mid integer NOT NULL,
-    mod integer NOT NULL, usn integer NOT NULL, tags text NOT NULL,
-    flds text NOT NULL, sfld integer NOT NULL, csum integer NOT NULL,
-    flags integer NOT NULL, data text NOT NULL
-  )`);
-  db.run(`CREATE TABLE cards (
-    id integer primary key, nid integer NOT NULL, did integer NOT NULL,
-    ord integer NOT NULL, mod integer NOT NULL, usn integer NOT NULL,
-    type integer NOT NULL, queue integer NOT NULL, due integer NOT NULL,
-    ivl integer NOT NULL, factor integer NOT NULL, reps integer NOT NULL,
-    lapses integer NOT NULL, left integer NOT NULL, odue integer NOT NULL,
-    odid integer NOT NULL, flags integer NOT NULL, data text NOT NULL
-  )`);
-  db.run(`CREATE TABLE revlog (
-    id integer primary key, cid integer NOT NULL, usn integer NOT NULL,
-    ease integer NOT NULL, ivl integer NOT NULL, lastIvl integer NOT NULL,
-    factor integer NOT NULL, time integer NOT NULL, type integer NOT NULL
-  )`);
-  db.run(`CREATE TABLE graves (
-    usn integer NOT NULL, oid integer NOT NULL, type integer NOT NULL
-  )`);
-
-  // Insert default deck
-  db.run("INSERT INTO decks VALUES (1, 'Default', 0, 0, '{}')");
-
-  for (const d of opts.decks ?? []) {
-    db.run("INSERT OR REPLACE INTO decks VALUES (?,?,?,?,?)", [d.id, d.name, d.mtime, d.usn, d.common]);
-  }
-  for (const nt of opts.notetypes ?? []) {
-    db.run("INSERT INTO notetypes VALUES (?,?,?,?,?)", [nt.id, nt.name, nt.mtime_secs, nt.usn, nt.config]);
-  }
-  for (const dc of opts.deckConfigs ?? []) {
-    db.run("INSERT INTO deck_config VALUES (?,?,?,?,?)", [dc.id, dc.name, dc.mtime, dc.usn, dc.config]);
-  }
-  for (const t of opts.tags ?? []) {
-    db.run("INSERT INTO tags VALUES (?,?)", [t.tag, t.usn]);
-  }
-
-  return db;
-}
 
 // ── Tests ──────────────────────────────────────────────────────────
 
@@ -316,8 +93,8 @@ describe("sync coverage gaps", () => {
       const parsed = JSON.parse(data);
 
       expect(parsed.s).toBe(12.3457); // 4 decimal places
-      expect(parsed.d).toBe(5.679);   // 3 decimal places
-      expect(parsed.dr).toBe(0.91);   // 2 decimal places
+      expect(parsed.d).toBe(5.679); // 3 decimal places
+      expect(parsed.dr).toBe(0.91); // 2 decimal places
       expect(parsed.decay).toBe(0.123); // 3 decimal places
       expect(parsed.lrt).toBe(1700000000); // seconds, not ms
     });
@@ -329,9 +106,12 @@ describe("sync coverage gaps", () => {
         algorithm: "sm2" as const,
         cardState: {
           phase: "review" as const,
-          step: 0, ease: 2.5, interval: 10,
+          step: 0,
+          ease: 2.5,
+          interval: 10,
           due: Date.now() + 86400000 * 10,
-          lapses: 0, reps: 5,
+          lapses: 0,
+          reps: 5,
         },
         createdAt: Date.now() - 86400000,
         lastReviewed: Date.now(),
@@ -347,8 +127,12 @@ describe("sync coverage gaps", () => {
         algorithm: "fsrs" as const,
         cardState: {
           phase: "review" as const,
-          step: 0, ease: 2.5, interval: 10,
-          due: Date.now(), lapses: 0, reps: 3,
+          step: 0,
+          ease: 2.5,
+          interval: 10,
+          due: Date.now(),
+          lapses: 0,
+          reps: 3,
           stability: 5.0,
           difficulty: 3.0,
           // no desiredRetention, no decay
@@ -368,7 +152,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("mergeIndexedDBToSqlite writes FSRS card data to SQLite", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
         cardId: "200",
@@ -376,9 +160,12 @@ describe("sync coverage gaps", () => {
         algorithm: "fsrs",
         cardState: {
           phase: "review",
-          step: 0, ease: 2.5, interval: 10,
+          step: 0,
+          ease: 2.5,
+          interval: 10,
           due: Date.now() + 86400000 * 10,
-          lapses: 0, reps: 5,
+          lapses: 0,
+          reps: 5,
           stability: 12.345,
           difficulty: 5.678,
         },
@@ -398,7 +185,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("FSRS factor encoding uses difficulty-to-ease mapping", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
         cardId: "200",
@@ -406,9 +193,12 @@ describe("sync coverage gaps", () => {
         algorithm: "fsrs",
         cardState: {
           phase: "review",
-          step: 0, ease: 2.5, interval: 10,
+          step: 0,
+          ease: 2.5,
+          interval: 10,
           due: Date.now() + 86400000 * 10,
-          lapses: 0, reps: 5,
+          lapses: 0,
+          reps: 5,
           stability: 10.0,
           difficulty: 5.5,
         },
@@ -468,19 +258,44 @@ describe("sync coverage gaps", () => {
 
   describe("multi-chunk sequences", () => {
     test("buildLocalChunks yields multiple chunks for >250 items", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       // Insert 300 cards with usn=-1 (pending)
       const nowSec = Math.floor(Date.now() / 1000);
       for (let i = 1; i <= 300; i++) {
-        db.run(
-          "INSERT INTO notes VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-          [1000 + i, `guid_${i}`, 1234567890, nowSec, -1, "", `front_${i}\x1fback_${i}`, `front_${i}`, 0, 0, ""],
-        );
-        db.run(
-          "INSERT INTO cards VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-          [2000 + i, 1000 + i, 1, 0, nowSec, -1, 0, 0, i, 0, 0, 0, 0, 0, 0, 0, 0, ""],
-        );
+        db.run("INSERT INTO notes VALUES (?,?,?,?,?,?,?,?,?,?,?)", [
+          1000 + i,
+          `guid_${i}`,
+          1234567890,
+          nowSec,
+          -1,
+          "",
+          `front_${i}\x1fback_${i}`,
+          `front_${i}`,
+          0,
+          0,
+          "",
+        ]);
+        db.run("INSERT INTO cards VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", [
+          2000 + i,
+          1000 + i,
+          1,
+          0,
+          nowSec,
+          -1,
+          0,
+          0,
+          i,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          "",
+        ]);
       }
 
       const chunks = [...buildLocalChunks(db)];
@@ -502,7 +317,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("buildLocalChunks yields single done chunk for empty collection", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       // All cards/notes have usn=0 (not pending), so no chunks to send
 
       const chunks = [...buildLocalChunks(db)];
@@ -516,7 +331,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("buildLocalChunks interleaves revlog, notes, cards in order", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         cardOverrides: { usn: -1 },
       });
       // Also mark the default note as pending
@@ -539,14 +354,11 @@ describe("sync coverage gaps", () => {
 
   describe("anki21b table operations", () => {
     test("applyRemoteUnchunkedChanges merges decks into anki21b decks table", () => {
-      const db = createAnki21bDb();
+      const db = createAnki21bDb(SQL);
 
       const changes: UnchunkedChanges = {
         models: [],
-        decks: [
-          [{ id: 2, name: "Science", mtime: 100, usn: 5 }],
-          [],
-        ],
+        decks: [[{ id: 2, name: "Science", mtime: 100, usn: 5 }], []],
         tags: [],
       };
 
@@ -561,16 +373,13 @@ describe("sync coverage gaps", () => {
     });
 
     test("applyRemoteUnchunkedChanges skips older deck in anki21b", () => {
-      const db = createAnki21bDb({
+      const db = createAnki21bDb(SQL, {
         decks: [{ id: 2, name: "LocalDeck", mtime: 200, usn: 0, common: "{}" }],
       });
 
       const changes: UnchunkedChanges = {
         models: [],
-        decks: [
-          [{ id: 2, name: "OlderRemote", mtime: 100, usn: 5 }],
-          [],
-        ],
+        decks: [[{ id: 2, name: "OlderRemote", mtime: 100, usn: 5 }], []],
         tags: [],
       };
 
@@ -584,14 +393,11 @@ describe("sync coverage gaps", () => {
     });
 
     test("applyRemoteUnchunkedChanges merges deck_config in anki21b", () => {
-      const db = createAnki21bDb();
+      const db = createAnki21bDb(SQL);
 
       const changes: UnchunkedChanges = {
         models: [],
-        decks: [
-          [],
-          [{ id: 1, name: "Custom", mtime: 100, usn: 5 }],
-        ],
+        decks: [[], [{ id: 1, name: "Custom", mtime: 100, usn: 5 }]],
         tags: [],
       };
 
@@ -604,16 +410,13 @@ describe("sync coverage gaps", () => {
     });
 
     test("applyRemoteUnchunkedChanges skips older deck_config in anki21b", () => {
-      const db = createAnki21bDb({
+      const db = createAnki21bDb(SQL, {
         deckConfigs: [{ id: 1, name: "LocalConfig", mtime: 200, usn: 0, config: "{}" }],
       });
 
       const changes: UnchunkedChanges = {
         models: [],
-        decks: [
-          [],
-          [{ id: 1, name: "OlderConfig", mtime: 100, usn: 5 }],
-        ],
+        decks: [[], [{ id: 1, name: "OlderConfig", mtime: 100, usn: 5 }]],
         tags: [],
       };
 
@@ -626,7 +429,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("applyRemoteUnchunkedChanges inserts new notetype in anki21b", () => {
-      const db = createAnki21bDb();
+      const db = createAnki21bDb(SQL);
 
       const changes: UnchunkedChanges = {
         models: [
@@ -653,16 +456,18 @@ describe("sync coverage gaps", () => {
     });
 
     test("buildLocalUnchunkedChanges returns pending anki21b items", () => {
-      const db = createAnki21bDb({
+      const db = createAnki21bDb(SQL, {
         notetypes: [
-          { id: 1001, name: "Basic", mtime_secs: 100, usn: -1, config: JSON.stringify({ id: 1001, name: "Basic", flds: [], tmpls: [] }) },
+          {
+            id: 1001,
+            name: "Basic",
+            mtime_secs: 100,
+            usn: -1,
+            config: JSON.stringify({ id: 1001, name: "Basic", flds: [], tmpls: [] }),
+          },
         ],
-        decks: [
-          { id: 2, name: "PendingDeck", mtime: 100, usn: -1, common: "{}" },
-        ],
-        deckConfigs: [
-          { id: 2, name: "PendingConfig", mtime: 100, usn: -1, config: "{}" },
-        ],
+        decks: [{ id: 2, name: "PendingDeck", mtime: 100, usn: -1, common: "{}" }],
+        deckConfigs: [{ id: 2, name: "PendingConfig", mtime: 100, usn: -1, config: "{}" }],
         tags: [
           { tag: "pending-tag", usn: -1 },
           { tag: "synced-tag", usn: 5 },
@@ -683,7 +488,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("buildLocalUnchunkedChanges includes conf and crt when localIsNewer (anki21b)", () => {
-      const db = createAnki21bDb({ conf: { myKey: "myValue" } });
+      const db = createAnki21bDb(SQL, { conf: { myKey: "myValue" } });
 
       const changes = buildLocalUnchunkedChanges(db, true, true);
 
@@ -699,7 +504,7 @@ describe("sync coverage gaps", () => {
 
   describe("deck hierarchy operations", () => {
     test("merges parent::child deck names correctly (anki2)", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         decks: {
           "1": { id: 1, mod: 100, name: "Default", usn: 0, conf: "1" },
         },
@@ -729,7 +534,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("merges parent::child deck names in anki21b", () => {
-      const db = createAnki21bDb();
+      const db = createAnki21bDb(SQL);
 
       const changes: UnchunkedChanges = {
         models: [],
@@ -758,7 +563,7 @@ describe("sync coverage gaps", () => {
 
   describe("graves lifecycle and finalizeUsn", () => {
     test("finalizeUsn updates graves usn from -1 to server usn", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       db.run("INSERT INTO graves VALUES (-1, 100, 0)");
       db.run("INSERT INTO graves VALUES (-1, 200, 1)");
 
@@ -772,7 +577,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("finalizeUsn updates cards, notes, revlog usn", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         cardOverrides: { usn: -1 },
       });
       db.run("UPDATE notes SET usn=-1");
@@ -788,7 +593,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("finalizeUsn updates anki2 JSON columns (models, decks, dconf, tags)", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         models: {
           "1001": { id: 1001, mod: 100, name: "Basic", usn: -1, flds: [], tmpls: [] },
         },
@@ -820,7 +625,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("finalizeUsn updates anki21b separate tables", () => {
-      const db = createAnki21bDb({
+      const db = createAnki21bDb(SQL, {
         notetypes: [{ id: 1001, name: "Basic", mtime_secs: 100, usn: -1, config: "{}" }],
         decks: [{ id: 2, name: "Test", mtime: 100, usn: -1, common: "{}" }],
         deckConfigs: [{ id: 1, name: "Default", mtime: 100, usn: -1, config: "{}" }],
@@ -842,7 +647,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("finalizeUsn updates col.usn, col.mod, col.ls", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       const serverMod = 9999999;
 
       finalizeUsn(db, 42, serverMod, false);
@@ -859,7 +664,7 @@ describe("sync coverage gaps", () => {
 
   describe("sequential syncs simulation", () => {
     test("after finalizeUsn, new pending changes have usn=-1 again", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         cardOverrides: { usn: -1 },
       });
       db.run("UPDATE notes SET usn=-1");
@@ -893,10 +698,13 @@ describe("sync coverage gaps", () => {
 
   describe("deck config edge cases", () => {
     test("readDeckStepCounts handles zero learning steps", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         dconf: {
           "1": {
-            id: 1, mod: 0, name: "NoSteps", usn: 0,
+            id: 1,
+            mod: 0,
+            name: "NoSteps",
+            usn: 0,
             new: { delays: [], perDay: 20 },
             lapse: { delays: [], minInt: 1, mult: 0, leechFails: 8 },
             rev: { perDay: 200 },
@@ -914,10 +722,13 @@ describe("sync coverage gaps", () => {
     });
 
     test("readDeckStepCounts handles many learning steps", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         dconf: {
           "1": {
-            id: 1, mod: 0, name: "ManySteps", usn: 0,
+            id: 1,
+            mod: 0,
+            name: "ManySteps",
+            usn: 0,
             new: { delays: [1, 5, 10, 30, 60, 120, 240, 480, 1440], perDay: 20 },
             lapse: { delays: [5, 10, 30, 60], minInt: 1, mult: 0, leechFails: 8 },
             rev: { perDay: 200 },
@@ -934,10 +745,13 @@ describe("sync coverage gaps", () => {
     });
 
     test("readDeckStepCounts handles missing delays field", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         dconf: {
           "1": {
-            id: 1, mod: 0, name: "NoDelays", usn: 0,
+            id: 1,
+            mod: 0,
+            name: "NoDelays",
+            usn: 0,
             new: { perDay: 20 },
             lapse: { minInt: 1, mult: 0, leechFails: 8 },
             rev: { perDay: 200 },
@@ -955,16 +769,22 @@ describe("sync coverage gaps", () => {
     });
 
     test("readDeckStepCounts maps multiple decks to their configs", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         dconf: {
           "1": {
-            id: 1, mod: 0, name: "Default", usn: 0,
+            id: 1,
+            mod: 0,
+            name: "Default",
+            usn: 0,
             new: { delays: [1, 10] },
             lapse: { delays: [10] },
             rev: { perDay: 200 },
           },
           "2": {
-            id: 2, mod: 0, name: "Hard", usn: 0,
+            id: 2,
+            mod: 0,
+            name: "Hard",
+            usn: 0,
             new: { delays: [1, 5, 10, 30, 60] },
             lapse: { delays: [5, 15, 30] },
             rev: { perDay: 300 },
@@ -986,13 +806,14 @@ describe("sync coverage gaps", () => {
     });
 
     test("readDeckStepCounts handles anki21b format", () => {
-      const db = createAnki21bDb({
-        decks: [
-          { id: 2, name: "MyDeck", mtime: 0, usn: 0, common: JSON.stringify({ conf: 1 }) },
-        ],
+      const db = createAnki21bDb(SQL, {
+        decks: [{ id: 2, name: "MyDeck", mtime: 0, usn: 0, common: JSON.stringify({ conf: 1 }) }],
         deckConfigs: [
           {
-            id: 1, name: "Default", mtime: 0, usn: 0,
+            id: 1,
+            name: "Default",
+            mtime: 0,
+            usn: 0,
             config: JSON.stringify({
               new: { delays: [1, 10, 30] },
               lapse: { delays: [5, 10] },
@@ -1013,11 +834,17 @@ describe("sync coverage gaps", () => {
 
   describe("model field reordering within same count", () => {
     test("accepts field name changes when count is unchanged (anki2)", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         models: {
           "1001": {
-            id: 1001, mod: 100, name: "Basic", usn: 0,
-            flds: [{ name: "Front", ord: 0 }, { name: "Back", ord: 1 }],
+            id: 1001,
+            mod: 100,
+            name: "Basic",
+            usn: 0,
+            flds: [
+              { name: "Front", ord: 0 },
+              { name: "Back", ord: 1 },
+            ],
             tmpls: [{ name: "Card 1", ord: 0 }],
           },
         },
@@ -1026,8 +853,14 @@ describe("sync coverage gaps", () => {
       const changes: UnchunkedChanges = {
         models: [
           {
-            id: 1001, mod: 200, name: "Basic", usn: 5,
-            flds: [{ name: "Question", ord: 0 }, { name: "Answer", ord: 1 }], // renamed but same count
+            id: 1001,
+            mod: 200,
+            name: "Basic",
+            usn: 5,
+            flds: [
+              { name: "Question", ord: 0 },
+              { name: "Answer", ord: 1 },
+            ], // renamed but same count
             tmpls: [{ name: "Card 1", ord: 0 }],
           },
         ],
@@ -1046,11 +879,17 @@ describe("sync coverage gaps", () => {
     });
 
     test("accepts template name changes when count is unchanged", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         models: {
           "1001": {
-            id: 1001, mod: 100, name: "Basic", usn: 0,
-            flds: [{ name: "Front", ord: 0 }, { name: "Back", ord: 1 }],
+            id: 1001,
+            mod: 100,
+            name: "Basic",
+            usn: 0,
+            flds: [
+              { name: "Front", ord: 0 },
+              { name: "Back", ord: 1 },
+            ],
             tmpls: [{ name: "Card 1", ord: 0 }],
           },
         },
@@ -1059,8 +898,14 @@ describe("sync coverage gaps", () => {
       const changes: UnchunkedChanges = {
         models: [
           {
-            id: 1001, mod: 200, name: "Basic", usn: 5,
-            flds: [{ name: "Front", ord: 0 }, { name: "Back", ord: 1 }],
+            id: 1001,
+            mod: 200,
+            name: "Basic",
+            usn: 5,
+            flds: [
+              { name: "Front", ord: 0 },
+              { name: "Back", ord: 1 },
+            ],
             tmpls: [{ name: "Forward Card", ord: 0 }], // renamed
           },
         ],
@@ -1198,7 +1043,7 @@ describe("sync coverage gaps", () => {
 
   describe("applyRemoteGraves", () => {
     test("deletes cards and their review logs from SQLite", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       db.run("INSERT INTO revlog VALUES (999, 200, 5, 3, 10, 5, 2500, 5000, 1)");
 
       await applyRemoteGraves(db, { cards: [200], notes: [], decks: [] });
@@ -1211,7 +1056,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("deletes notes and cascades to their cards", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await applyRemoteGraves(db, { cards: [], notes: [100], decks: [] });
 
@@ -1222,7 +1067,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("deletes decks from anki2 JSON", async () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         decks: {
           "1": { id: 1, mod: 100, name: "Default", usn: 0 },
           "2": { id: 2, mod: 100, name: "ToDelete", usn: 0 },
@@ -1239,10 +1084,8 @@ describe("sync coverage gaps", () => {
     });
 
     test("deletes decks from anki21b table", async () => {
-      const db = createAnki21bDb({
-        decks: [
-          { id: 2, name: "ToDelete", mtime: 100, usn: 0, common: "{}" },
-        ],
+      const db = createAnki21bDb(SQL, {
+        decks: [{ id: 2, name: "ToDelete", mtime: 100, usn: 0, common: "{}" }],
       });
 
       await applyRemoteGraves(db, { cards: [], notes: [], decks: [2] });
@@ -1255,7 +1098,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("handles empty graves gracefully", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       // Should not throw
       await applyRemoteGraves(db, { cards: [], notes: [], decks: [] });
@@ -1271,7 +1114,7 @@ describe("sync coverage gaps", () => {
 
   describe("creation timestamp (crt) merge", () => {
     test("updates crt when remote is newer (anki2)", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       const oldCrt = scalar(db, "SELECT crt FROM col") as number;
 
       const changes: UnchunkedChanges = {
@@ -1289,7 +1132,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("does not update crt when remote is older", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       const oldCrt = scalar(db, "SELECT crt FROM col") as number;
 
       const changes: UnchunkedChanges = {
@@ -1307,7 +1150,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("updates crt in anki21b format", () => {
-      const db = createAnki21bDb();
+      const db = createAnki21bDb(SQL);
       const oldCrt = scalar(db, "SELECT crt FROM col") as number;
 
       const changes: UnchunkedChanges = {
@@ -1329,7 +1172,7 @@ describe("sync coverage gaps", () => {
 
   describe("referential integrity during merge", () => {
     test("applyRemoteChunk inserts card even if referenced note doesn't exist", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       // Send a card that references a non-existent note
       const chunk: Chunk = {
@@ -1349,7 +1192,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("applyRemoteGraves for notes deletes all associated cards", async () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         extraCards: [
           { id: 201, nid: 100, did: 1, ord: 1 },
           { id: 202, nid: 100, did: 1, ord: 2 },
@@ -1372,13 +1215,20 @@ describe("sync coverage gaps", () => {
 
   describe("card state transitions via mergeIndexedDBToSqlite", () => {
     test("new → learning: type=1, queue=1", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
-        cardId: "200", deckId: "deck-1", algorithm: "sm2",
+        cardId: "200",
+        deckId: "deck-1",
+        algorithm: "sm2",
         cardState: {
-          phase: "learning", step: 0, ease: 2.5, interval: 0.007,
-          due: Date.now() + 600_000, lapses: 0, reps: 1,
+          phase: "learning",
+          step: 0,
+          ease: 2.5,
+          interval: 0.007,
+          due: Date.now() + 600_000,
+          lapses: 0,
+          reps: 1,
         },
         createdAt: Date.now() - 60000,
         lastReviewed: Date.now(),
@@ -1393,13 +1243,20 @@ describe("sync coverage gaps", () => {
     });
 
     test("learning → review: type=2, queue=2", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
-        cardId: "200", deckId: "deck-1", algorithm: "sm2",
+        cardId: "200",
+        deckId: "deck-1",
+        algorithm: "sm2",
         cardState: {
-          phase: "review", step: 0, ease: 2.5, interval: 1,
-          due: Date.now() + 86400000, lapses: 0, reps: 3,
+          phase: "review",
+          step: 0,
+          ease: 2.5,
+          interval: 1,
+          due: Date.now() + 86400000,
+          lapses: 0,
+          reps: 3,
         },
         createdAt: Date.now() - 86400000,
         lastReviewed: Date.now(),
@@ -1414,13 +1271,20 @@ describe("sync coverage gaps", () => {
     });
 
     test("review → relearning: type=3, queue=1 (intraday)", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
-        cardId: "200", deckId: "deck-1", algorithm: "sm2",
+        cardId: "200",
+        deckId: "deck-1",
+        algorithm: "sm2",
         cardState: {
-          phase: "relearning", step: 0, ease: 2.0, interval: 0.01,
-          due: Date.now() + 600_000, lapses: 1, reps: 5,
+          phase: "relearning",
+          step: 0,
+          ease: 2.0,
+          interval: 0.01,
+          due: Date.now() + 600_000,
+          lapses: 1,
+          reps: 5,
         },
         createdAt: Date.now() - 86400000 * 10,
         lastReviewed: Date.now(),
@@ -1435,13 +1299,20 @@ describe("sync coverage gaps", () => {
     });
 
     test("dayLearning: learning with interval >= 1 day gets queue=3", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
-        cardId: "200", deckId: "deck-1", algorithm: "sm2",
+        cardId: "200",
+        deckId: "deck-1",
+        algorithm: "sm2",
         cardState: {
-          phase: "learning", step: 1, ease: 2.5, interval: 1,
-          due: Date.now() + 86400000, lapses: 0, reps: 2,
+          phase: "learning",
+          step: 1,
+          ease: 2.5,
+          interval: 1,
+          due: Date.now() + 86400000,
+          lapses: 0,
+          reps: 2,
         },
         createdAt: Date.now() - 86400000,
         lastReviewed: Date.now(),
@@ -1460,13 +1331,13 @@ describe("sync coverage gaps", () => {
 
   describe("isAnki21bFormat detection", () => {
     test("returns false for anki2 format", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       expect(isAnki21bFormat(db)).toBe(false);
       db.close();
     });
 
     test("returns true for anki21b format", () => {
-      const db = createAnki21bDb();
+      const db = createAnki21bDb(SQL);
       expect(isAnki21bFormat(db)).toBe(true);
       db.close();
     });
@@ -1476,20 +1347,23 @@ describe("sync coverage gaps", () => {
 
   describe("getSanityCounts for anki21b", () => {
     test("counts from separate tables for anki21b", () => {
-      const db = createAnki21bDb({
+      const db = createAnki21bDb(SQL, {
         notetypes: [
           { id: 1001, name: "Basic", mtime_secs: 0, usn: 0, config: "{}" },
           { id: 1002, name: "Cloze", mtime_secs: 0, usn: 0, config: "{}" },
         ],
-        deckConfigs: [
-          { id: 1, name: "Default", mtime: 0, usn: 0, config: "{}" },
-        ],
+        deckConfigs: [{ id: 1, name: "Default", mtime: 0, usn: 0, config: "{}" }],
       });
 
       // Insert a card and note
       const nowSec = Math.floor(Date.now() / 1000);
-      db.run("INSERT INTO notes VALUES (100, 'abc', 1001, ?, 0, '', 'f\x1fb', 'f', 0, 0, '')", [nowSec]);
-      db.run("INSERT INTO cards VALUES (200, 100, 1, 0, ?, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '')", [nowSec]);
+      db.run("INSERT INTO notes VALUES (100, 'abc', 1001, ?, 0, '', 'f\x1fb', 'f', 0, 0, '')", [
+        nowSec,
+      ]);
+      db.run(
+        "INSERT INTO cards VALUES (200, 100, 1, 0, ?, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '')",
+        [nowSec],
+      );
 
       const counts = getSanityCounts(db, true);
       const [dueCounts, cards, notes, revlog, graves, models, decks, deckConfig] = counts;
@@ -1511,12 +1385,12 @@ describe("sync coverage gaps", () => {
 
   describe("buildLocalGraves filtering", () => {
     test("only includes usn=-1 graves, excludes already-synced ones", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       db.run("INSERT INTO graves VALUES (-1, 100, 0)"); // pending card
       db.run("INSERT INTO graves VALUES (-1, 200, 1)"); // pending note
       db.run("INSERT INTO graves VALUES (-1, 300, 2)"); // pending deck
-      db.run("INSERT INTO graves VALUES (5, 400, 0)");  // synced card
+      db.run("INSERT INTO graves VALUES (5, 400, 0)"); // synced card
       db.run("INSERT INTO graves VALUES (10, 500, 1)"); // synced note
 
       const graves = buildLocalGraves(db);
@@ -1528,7 +1402,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("returns empty arrays when no pending graves", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       db.run("INSERT INTO graves VALUES (5, 100, 0)"); // already synced
 
       const graves = buildLocalGraves(db);
@@ -1544,7 +1418,7 @@ describe("sync coverage gaps", () => {
 
   describe("buildLocalUnchunkedChanges for anki2", () => {
     test("only includes pending (usn=-1) items", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         models: {
           "1001": { id: 1001, mod: 100, name: "Pending", usn: -1, flds: [], tmpls: [] },
           "1002": { id: 1002, mod: 100, name: "Synced", usn: 5, flds: [], tmpls: [] },
@@ -1575,7 +1449,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("includes conf and crt when localIsNewer", () => {
-      const db = createAnki2Collection({ conf: { myKey: "test" } });
+      const db = createAnki2Collection(SQL, { conf: { myKey: "test" } });
 
       const changes = buildLocalUnchunkedChanges(db, false, true);
 
@@ -1592,20 +1466,16 @@ describe("sync coverage gaps", () => {
 
   describe("applyRemoteChunk comprehensive", () => {
     test("applies notes, cards, and revlog in a single chunk", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       const nowSec = Math.floor(Date.now() / 1000);
 
       const chunk: Chunk = {
         done: true,
-        revlog: [
-          [Date.now(), 300, 5, 3, 10, 5, 2500, 5000, 1],
-        ],
+        revlog: [[Date.now(), 300, 5, 3, 10, 5, 2500, 5000, 1]],
         notes: [
           [300, "newguid", 1234567890, nowSec, 5, "", "newfront\x1fnewback", "newfront", 0, 0, ""],
         ],
-        cards: [
-          [300, 300, 1, 0, nowSec, 5, 2, 2, 5, 10, 2500, 3, 0, 0, 0, 0, 0, ""],
-        ],
+        cards: [[300, 300, 1, 0, nowSec, 5, 2, 2, 5, 10, 2500, 3, 0, 0, 0, 0, 0, ""]],
       };
 
       await applyRemoteChunk(db, chunk);
@@ -1618,29 +1488,21 @@ describe("sync coverage gaps", () => {
     });
 
     test("applies multiple chunks sequentially", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
       const nowSec = Math.floor(Date.now() / 1000);
 
       const chunk1: Chunk = {
         done: false,
         revlog: [],
-        notes: [
-          [301, "g1", 1234567890, nowSec, 5, "", "a\x1fb", "a", 0, 0, ""],
-        ],
-        cards: [
-          [301, 301, 1, 0, nowSec, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ""],
-        ],
+        notes: [[301, "g1", 1234567890, nowSec, 5, "", "a\x1fb", "a", 0, 0, ""]],
+        cards: [[301, 301, 1, 0, nowSec, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ""]],
       };
 
       const chunk2: Chunk = {
         done: true,
         revlog: [],
-        notes: [
-          [302, "g2", 1234567890, nowSec, 5, "", "c\x1fd", "c", 0, 0, ""],
-        ],
-        cards: [
-          [302, 302, 1, 0, nowSec, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ""],
-        ],
+        notes: [[302, "g2", 1234567890, nowSec, 5, "", "c\x1fd", "c", 0, 0, ""]],
+        cards: [[302, 302, 1, 0, nowSec, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ""]],
       };
 
       await applyRemoteChunk(db, chunk1);
@@ -1658,13 +1520,20 @@ describe("sync coverage gaps", () => {
 
   describe("flags preservation", () => {
     test("mergeIndexedDBToSqlite writes card flags to SQLite", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
-        cardId: "200", deckId: "deck-1", algorithm: "sm2",
+        cardId: "200",
+        deckId: "deck-1",
+        algorithm: "sm2",
         cardState: {
-          phase: "review", step: 0, ease: 2.5, interval: 10,
-          due: Date.now() + 86400000 * 10, lapses: 0, reps: 3,
+          phase: "review",
+          step: 0,
+          ease: 2.5,
+          interval: 10,
+          due: Date.now() + 86400000 * 10,
+          lapses: 0,
+          reps: 3,
         },
         createdAt: Date.now() - 86400000,
         lastReviewed: Date.now(),
@@ -1679,13 +1548,20 @@ describe("sync coverage gaps", () => {
     });
 
     test("defaults flags to 0 when not set", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
-        cardId: "200", deckId: "deck-1", algorithm: "sm2",
+        cardId: "200",
+        deckId: "deck-1",
+        algorithm: "sm2",
         cardState: {
-          phase: "review", step: 0, ease: 2.5, interval: 10,
-          due: Date.now() + 86400000 * 10, lapses: 0, reps: 3,
+          phase: "review",
+          step: 0,
+          ease: 2.5,
+          interval: 10,
+          due: Date.now() + 86400000 * 10,
+          lapses: 0,
+          reps: 3,
         },
         createdAt: Date.now() - 86400000,
         lastReviewed: Date.now(),
@@ -1704,7 +1580,7 @@ describe("sync coverage gaps", () => {
 
   describe("deck and dconf merge conflict resolution (anki2)", () => {
     test("remote deck wins when mod >= local mod", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         decks: {
           "1": { id: 1, mod: 100, name: "OldLocal", usn: 0 },
         },
@@ -1712,10 +1588,7 @@ describe("sync coverage gaps", () => {
 
       const changes: UnchunkedChanges = {
         models: [],
-        decks: [
-          [{ id: 1, mod: 200, name: "NewRemote", usn: 5 }],
-          [],
-        ],
+        decks: [[{ id: 1, mod: 200, name: "NewRemote", usn: 5 }], []],
         tags: [],
       };
 
@@ -1728,7 +1601,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("local deck wins when remote mod < local mod", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         decks: {
           "1": { id: 1, mod: 200, name: "NewerLocal", usn: 0 },
         },
@@ -1736,10 +1609,7 @@ describe("sync coverage gaps", () => {
 
       const changes: UnchunkedChanges = {
         models: [],
-        decks: [
-          [{ id: 1, mod: 100, name: "OlderRemote", usn: 5 }],
-          [],
-        ],
+        decks: [[{ id: 1, mod: 100, name: "OlderRemote", usn: 5 }], []],
         tags: [],
       };
 
@@ -1752,7 +1622,7 @@ describe("sync coverage gaps", () => {
     });
 
     test("remote dconf wins when mod >= local mod", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         dconf: {
           "1": { id: 1, mod: 100, name: "LocalConfig", usn: 0 },
         },
@@ -1760,10 +1630,7 @@ describe("sync coverage gaps", () => {
 
       const changes: UnchunkedChanges = {
         models: [],
-        decks: [
-          [],
-          [{ id: 1, mod: 200, name: "RemoteConfig", usn: 5 }],
-        ],
+        decks: [[], [{ id: 1, mod: 200, name: "RemoteConfig", usn: 5 }]],
         tags: [],
       };
 

--- a/src/__tests__/sync-gap-fixes.test.ts
+++ b/src/__tests__/sync-gap-fixes.test.ts
@@ -11,162 +11,22 @@
  */
 import "fake-indexeddb/auto";
 import { describe, test, expect, beforeEach } from "vitest";
-import initSqlJs, { type SqlJsStatic, type Database } from "sql.js";
 import { join } from "node:path";
-import {
-  mergeIndexedDBToSqlite,
-  readDeckStepCounts,
-} from "../lib/syncWrite";
+import { type SqlJsStatic } from "sql.js";
+import { mergeIndexedDBToSqlite, readDeckStepCounts } from "../lib/syncWrite";
 import { getSanityCounts, buildLocalGraves } from "../lib/syncMerge";
 import { fetchWithTimeout } from "../lib/ankiSync";
 import { reviewDB } from "../scheduler/db";
+import { getSqlJs, scalar, createAnki2Collection } from "./testDbUtils";
 
 // ── SQL.js setup ─────────────────────────────────��────────────────
 
 let SQL: SqlJsStatic;
 
 beforeEach(async () => {
-  if (!SQL) {
-    const wasmPath = join(process.cwd(), "node_modules", "sql.js", "dist", "sql-wasm.wasm");
-    SQL = await initSqlJs({ locateFile: () => wasmPath });
-  }
+  SQL = await getSqlJs();
   await reviewDB.clearAll();
 });
-
-/** Create a minimal anki2 collection with proper schema. */
-function createAnki2Collection(
-  opts: {
-    dconf?: Record<string, unknown>;
-    decks?: Record<string, unknown>;
-    models?: Record<string, unknown>;
-    cardOverrides?: Record<string, unknown>;
-  } = {},
-): Database {
-  const db = new SQL.Database();
-  const nowMs = Date.now();
-  const nowSec = Math.floor(nowMs / 1000);
-  const crt = nowSec - 86400 * 30; // 30 days ago
-
-  const defaultDconf = {
-    "1": {
-      id: 1,
-      mod: nowSec,
-      name: "Default",
-      usn: 0,
-      new: { delays: [1, 10], order: 1, perDay: 20 },
-      lapse: { delays: [10], minInt: 1, mult: 0, leechFails: 8 },
-      rev: { perDay: 200, ease4: 1.3, hardFactor: 1.2, ivlFct: 1.0, maxIvl: 36500, fuzz: true },
-    },
-  };
-
-  const defaultDecks = {
-    "1": {
-      id: 1,
-      mod: nowSec,
-      name: "Default",
-      usn: 0,
-      conf: "1",
-    },
-  };
-
-  const defaultModels = {
-    "1234567890": {
-      id: 1234567890,
-      mod: nowSec,
-      name: "Basic",
-      usn: 0,
-      flds: [{ name: "Front", ord: 0 }, { name: "Back", ord: 1 }],
-      tmpls: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
-    },
-  };
-
-  db.run(`CREATE TABLE col (
-    id integer primary key, crt integer NOT NULL, mod integer NOT NULL,
-    scm integer NOT NULL, ver integer NOT NULL, dty integer NOT NULL,
-    usn integer NOT NULL, ls integer NOT NULL, conf text NOT NULL,
-    models text NOT NULL, decks text NOT NULL, dconf text NOT NULL, tags text NOT NULL
-  )`);
-  db.run(
-    `INSERT INTO col VALUES (1, ?, ?, ?, 11, 0, 0, 0, '{}', ?, ?, ?, '{}')`,
-    [
-      crt,
-      nowMs,
-      nowSec,
-      JSON.stringify(opts.models ?? defaultModels),
-      JSON.stringify(opts.decks ?? defaultDecks),
-      JSON.stringify(opts.dconf ?? defaultDconf),
-    ],
-  );
-
-  db.run(`CREATE TABLE notes (
-    id integer primary key, guid text NOT NULL, mid integer NOT NULL,
-    mod integer NOT NULL, usn integer NOT NULL, tags text NOT NULL,
-    flds text NOT NULL, sfld integer NOT NULL, csum integer NOT NULL,
-    flags integer NOT NULL, data text NOT NULL
-  )`);
-
-  db.run(`CREATE TABLE cards (
-    id integer primary key, nid integer NOT NULL, did integer NOT NULL,
-    ord integer NOT NULL, mod integer NOT NULL, usn integer NOT NULL,
-    type integer NOT NULL, queue integer NOT NULL, due integer NOT NULL,
-    ivl integer NOT NULL, factor integer NOT NULL, reps integer NOT NULL,
-    lapses integer NOT NULL, left integer NOT NULL, odue integer NOT NULL,
-    odid integer NOT NULL, flags integer NOT NULL, data text NOT NULL
-  )`);
-
-  db.run(`CREATE TABLE revlog (
-    id integer primary key, cid integer NOT NULL, usn integer NOT NULL,
-    ease integer NOT NULL, ivl integer NOT NULL, lastIvl integer NOT NULL,
-    factor integer NOT NULL, time integer NOT NULL, type integer NOT NULL
-  )`);
-
-  db.run(`CREATE TABLE graves (
-    usn integer NOT NULL, oid integer NOT NULL, type integer NOT NULL
-  )`);
-
-  // Insert a note and card
-  db.run(`INSERT INTO notes VALUES (100, 'abc123', 1234567890, ?, 0, '', 'front\x1fback', 'front', 0, 0, '')`, [nowSec]);
-
-  const cardDefaults = {
-    id: 200,
-    nid: 100,
-    did: 1,
-    ord: 0,
-    mod: nowSec,
-    usn: 0,
-    type: 0,
-    queue: 0,
-    due: 0,
-    ivl: 0,
-    factor: 0,
-    reps: 0,
-    lapses: 0,
-    left: 0,
-    odue: 0,
-    odid: 0,
-    flags: 0,
-    data: "",
-    ...opts.cardOverrides,
-  };
-
-  db.run(
-    `INSERT INTO cards VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [
-      cardDefaults.id, cardDefaults.nid, cardDefaults.did, cardDefaults.ord,
-      cardDefaults.mod, cardDefaults.usn, cardDefaults.type, cardDefaults.queue,
-      cardDefaults.due, cardDefaults.ivl, cardDefaults.factor, cardDefaults.reps,
-      cardDefaults.lapses, cardDefaults.left, cardDefaults.odue, cardDefaults.odid,
-      cardDefaults.flags, cardDefaults.data,
-    ],
-  );
-
-  return db;
-}
-
-function scalar(db: Database, sql: string): unknown {
-  const r = db.exec(sql);
-  return r[0]?.values[0]?.[0] ?? null;
-}
 
 // ── Tests ──────────────────────────────────────────��──────────────
 
@@ -195,7 +55,7 @@ describe("sync gap fixes", () => {
   describe("filtered deck odue/odid preservation", () => {
     test("preserves odue and odid when card is in a filtered deck", async () => {
       // Create a collection with a card in a filtered deck
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         cardOverrides: {
           id: 300,
           did: 99, // filtered deck
@@ -239,7 +99,7 @@ describe("sync gap fixes", () => {
     });
 
     test("keeps odue=0 and odid=0 for normal (non-filtered) deck cards", async () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         cardOverrides: {
           id: 400,
           did: 1,
@@ -282,7 +142,7 @@ describe("sync gap fixes", () => {
 
   describe("step encoding from deck config", () => {
     test("reads step counts from anki2 dconf", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         dconf: {
           "1": {
             id: 1,
@@ -307,7 +167,7 @@ describe("sync gap fixes", () => {
 
     test("uses deck config steps in encodeLeft during merge", async () => {
       // Create collection with 4 learning steps
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         dconf: {
           "1": {
             id: 1,
@@ -357,7 +217,7 @@ describe("sync gap fixes", () => {
     });
 
     test("falls back to defaults when deck config is missing", () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         dconf: {}, // empty — no configs
       });
 
@@ -373,7 +233,7 @@ describe("sync gap fixes", () => {
 
   describe("deck config application to scheduler", () => {
     test("applyDeckConfigsToScheduler writes deck config to IndexedDB", async () => {
-      const db = createAnki2Collection({
+      const db = createAnki2Collection(SQL, {
         dconf: {
           "1": {
             id: 1,
@@ -394,11 +254,20 @@ describe("sync gap fixes", () => {
 
       // Simulate what applyDeckConfigsToScheduler does
       const dconfRaw = db.exec("SELECT dconf FROM col");
-      const parsed = JSON.parse(dconfRaw[0]!.values[0]![0] as string) as Record<string, {
-        new?: { delays?: number[]; perDay?: number };
-        lapse?: { delays?: number[]; minInt?: number; mult?: number; leechFails?: number };
-        rev?: { perDay?: number; ease4?: number; hardFactor?: number; ivlFct?: number; maxIvl?: number };
-      }>;
+      const parsed = JSON.parse(dconfRaw[0]!.values[0]![0] as string) as Record<
+        string,
+        {
+          new?: { delays?: number[]; perDay?: number };
+          lapse?: { delays?: number[]; minInt?: number; mult?: number; leechFails?: number };
+          rev?: {
+            perDay?: number;
+            ease4?: number;
+            hardFactor?: number;
+            ivlFct?: number;
+            maxIvl?: number;
+          };
+        }
+      >;
 
       const cfg = parsed["1"]!;
       const existing = await reviewDB.getSettings(deckId);
@@ -444,9 +313,9 @@ describe("sync gap fixes", () => {
     test("fetchWithTimeout throws on timeout", async () => {
       // Create a server that never responds using a very short timeout
       // We use a non-routable IP to simulate a timeout
-      await expect(
-        fetchWithTimeout("http://192.0.2.1/never-responds", {}, 100),
-      ).rejects.toThrow(/timed out/);
+      await expect(fetchWithTimeout("http://192.0.2.1/never-responds", {}, 100)).rejects.toThrow(
+        /timed out/,
+      );
     });
 
     test("fetchWithTimeout succeeds for fast responses", async () => {
@@ -462,10 +331,7 @@ describe("sync gap fixes", () => {
 
     test("ankiSync.ts uses fetchWithTimeout for all requests", async () => {
       const { readFileSync } = await import("node:fs");
-      const source = readFileSync(
-        join(process.cwd(), "src", "lib", "ankiSync.ts"),
-        "utf-8",
-      );
+      const source = readFileSync(join(process.cwd(), "src", "lib", "ankiSync.ts"), "utf-8");
 
       // Verify no raw fetch() calls remain (only fetchWithTimeout)
       // Match fetch( but not fetchWithTimeout(
@@ -493,7 +359,7 @@ describe("sync gap fixes", () => {
     });
 
     test("insertGraves writes card, note, and deck graves to SQLite", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       // Mark deletions in IndexedDB
       await reviewDB.markCardDeleted("888", "deck-1");
@@ -562,7 +428,7 @@ describe("sync gap fixes", () => {
     });
 
     test("buildLocalGraves picks up all grave types from SQLite", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       // Manually insert graves of all types
       db.run("INSERT INTO graves VALUES (-1, 100, 0)"); // card
@@ -583,7 +449,7 @@ describe("sync gap fixes", () => {
 
   describe("sanity check completeness", () => {
     test("getSanityCounts returns all 8 fields including due counts and structural counts", () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       const counts = getSanityCounts(db, false);
 
@@ -617,7 +483,7 @@ describe("sync gap fixes", () => {
 
   describe("suspend/bury state sync", () => {
     test("suspended cards written with queue=-1 in SQLite", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
         cardId: "200",
@@ -646,7 +512,7 @@ describe("sync gap fixes", () => {
     });
 
     test("user-buried cards written with queue=-3 in SQLite", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
         cardId: "200",
@@ -675,7 +541,7 @@ describe("sync gap fixes", () => {
     });
 
     test("scheduler-buried cards written with queue=-2 in SQLite", async () => {
-      const db = createAnki2Collection();
+      const db = createAnki2Collection(SQL);
 
       await reviewDB.saveCard({
         cardId: "200",

--- a/src/__tests__/sync-integration.test.ts
+++ b/src/__tests__/sync-integration.test.ts
@@ -17,7 +17,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import initSqlJs, { type SqlJsStatic, type Database } from "sql.js";
+import { type SqlJsStatic, type Database } from "sql.js";
 import {
   login,
   downloadCollection,
@@ -26,6 +26,7 @@ import {
   normalizeUrl,
 } from "../lib/ankiSync";
 import { normalSync, FullSyncRequiredError, ClockSkewError } from "../lib/normalSync";
+import { getSqlJs, scalar } from "./testDbUtils";
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -166,11 +167,6 @@ function withDb<T>(SQL: SqlJsStatic, bytes: Uint8Array, fn: (db: Database) => T)
   }
 }
 
-function scalar(db: Database, sql: string): unknown {
-  const r = db.exec(sql);
-  return r[0]?.values[0]?.[0] ?? null;
-}
-
 function mutateCollection(
   SQL: SqlJsStatic,
   bytes: Uint8Array,
@@ -196,8 +192,7 @@ describe.skipIf(!serverBin)("sync integration", () => {
   let baseCollection: Uint8Array;
 
   beforeAll(async () => {
-    const wasmPath = join(process.cwd(), "node_modules", "sql.js", "dist", "sql-wasm.wasm");
-    SQL = await initSqlJs({ locateFile: () => wasmPath });
+    SQL = await getSqlJs();
 
     // Extract a real, valid collection from the test fixture
     const rawCollection = await extractCollectionFromApkg();
@@ -965,7 +960,13 @@ describe.skipIf(!serverBin)("sync integration", () => {
         const decksRaw = scalar(db, "SELECT decks FROM col") as string;
         const decks = JSON.parse(decksRaw);
         // Add a deck
-        decks["99"] = { id: 99, mod: Math.floor(nowMs / 1000), name: "ToDelete", usn: -1, conf: "1" };
+        decks["99"] = {
+          id: 99,
+          mod: Math.floor(nowMs / 1000),
+          name: "ToDelete",
+          usn: -1,
+          conf: "1",
+        };
         db.run("UPDATE col SET decks=?, mod=?", [JSON.stringify(decks), nowMs + 1]);
       });
 
@@ -1032,7 +1033,9 @@ describe.skipIf(!serverBin)("sync integration", () => {
         tags["multi-sync-test"] = -1;
 
         db.run("UPDATE col SET dconf=?, tags=?, mod=?", [
-          JSON.stringify(dconf), JSON.stringify(tags), nowMs + 1,
+          JSON.stringify(dconf),
+          JSON.stringify(tags),
+          nowMs + 1,
         ]);
       });
 
@@ -1061,9 +1064,7 @@ describe.skipIf(!serverBin)("sync integration", () => {
       const firstEdit = mutateCollection(SQL, serverCopy, (db) => {
         const nowMs = Date.now();
         const nowSec = Math.floor(nowMs / 1000);
-        db.run(
-          `UPDATE cards SET reps=1, mod=${nowSec}, usn=-1 WHERE id=${cardId}`,
-        );
+        db.run(`UPDATE cards SET reps=1, mod=${nowSec}, usn=-1 WHERE id=${cardId}`);
         db.run(`UPDATE col SET mod=${nowMs + 1}`);
       });
 
@@ -1077,9 +1078,7 @@ describe.skipIf(!serverBin)("sync integration", () => {
         const secondEdit = mutateCollection(SQL, result1.sqliteBytes, (db) => {
           const nowMs = Date.now();
           const nowSec = Math.floor(nowMs / 1000);
-          db.run(
-            `UPDATE cards SET reps=2, mod=${nowSec}, usn=-1 WHERE id=${cardId}`,
-          );
+          db.run(`UPDATE cards SET reps=2, mod=${nowSec}, usn=-1 WHERE id=${cardId}`);
           db.run(`UPDATE col SET mod=${nowMs + 1}`);
         });
 
@@ -1154,14 +1153,39 @@ describe.skipIf(!serverBin)("sync integration", () => {
         const newNoteId = nowMs; // use timestamp as ID
         const newCardId = nowMs + 1;
 
-        db.run(
-          "INSERT INTO notes VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-          [newNoteId, "newguid123", modelId, nowSec, -1, "", "new front\x1fnew back", "new front", 0, 0, ""],
-        );
-        db.run(
-          "INSERT INTO cards VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-          [newCardId, newNoteId, 1, 0, nowSec, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ""],
-        );
+        db.run("INSERT INTO notes VALUES (?,?,?,?,?,?,?,?,?,?,?)", [
+          newNoteId,
+          "newguid123",
+          modelId,
+          nowSec,
+          -1,
+          "",
+          "new front\x1fnew back",
+          "new front",
+          0,
+          0,
+          "",
+        ]);
+        db.run("INSERT INTO cards VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", [
+          newCardId,
+          newNoteId,
+          1,
+          0,
+          nowSec,
+          -1,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          "",
+        ]);
         db.run(`UPDATE col SET mod=${nowMs + 1}`);
       });
 

--- a/src/__tests__/sync-parity-fixes.test.ts
+++ b/src/__tests__/sync-parity-fixes.test.ts
@@ -12,8 +12,8 @@
  */
 import "fake-indexeddb/auto";
 import { describe, test, expect, beforeEach } from "vitest";
-import initSqlJs, { type SqlJsStatic, type Database } from "sql.js";
 import { join } from "node:path";
+import { type SqlJsStatic, type Database } from "sql.js";
 import {
   applyRemoteChunk,
   applyRemoteUnchunkedChanges,
@@ -23,25 +23,18 @@ import {
   type UnchunkedChanges,
 } from "../lib/syncMerge";
 import { reviewDB } from "../scheduler/db";
+import { getSqlJs, scalar } from "./testDbUtils";
 
 // ── SQL.js setup ──────────────────────────────────────────────────
 
 let SQL: SqlJsStatic;
 
 beforeEach(async () => {
-  if (!SQL) {
-    const wasmPath = join(process.cwd(), "node_modules", "sql.js", "dist", "sql-wasm.wasm");
-    SQL = await initSqlJs({ locateFile: () => wasmPath });
-  }
+  SQL = await getSqlJs();
   await reviewDB.clearAll();
 });
 
 /** Helper: read a scalar value from the database. */
-function scalar(db: Database, sql: string): unknown {
-  const r = db.exec(sql);
-  return r[0]?.values[0]?.[0] ?? null;
-}
-
 /** Create a minimal anki2 collection. */
 function createAnki2Db(
   opts: {

--- a/src/__tests__/testDbUtils.ts
+++ b/src/__tests__/testDbUtils.ts
@@ -1,0 +1,336 @@
+/**
+ * Shared test utilities for SQL.js database tests.
+ */
+import initSqlJs, { type SqlJsStatic, type Database } from "sql.js";
+import { join } from "node:path";
+
+let _SQL: SqlJsStatic | undefined;
+
+/** Lazily initialize and return the SQL.js static instance. */
+export async function getSqlJs(): Promise<SqlJsStatic> {
+  if (!_SQL) {
+    const wasmPath = join(process.cwd(), "node_modules", "sql.js", "dist", "sql-wasm.wasm");
+    _SQL = await initSqlJs({ locateFile: () => wasmPath });
+  }
+  return _SQL;
+}
+
+/** Read a scalar value from the database. */
+export function scalar(db: Database, sql: string): unknown {
+  const r = db.exec(sql);
+  return r[0]?.values[0]?.[0] ?? null;
+}
+
+// ── Anki2 schema & factory ──────────────────────────────────────────
+
+const ANKI2_SCHEMA = `
+CREATE TABLE col (
+  id integer primary key, crt integer NOT NULL, mod integer NOT NULL,
+  scm integer NOT NULL, ver integer NOT NULL, dty integer NOT NULL,
+  usn integer NOT NULL, ls integer NOT NULL, conf text NOT NULL,
+  models text NOT NULL, decks text NOT NULL, dconf text NOT NULL, tags text NOT NULL
+);
+CREATE TABLE notes (
+  id integer primary key, guid text NOT NULL, mid integer NOT NULL,
+  mod integer NOT NULL, usn integer NOT NULL, tags text NOT NULL,
+  flds text NOT NULL, sfld integer NOT NULL, csum integer NOT NULL,
+  flags integer NOT NULL, data text NOT NULL
+);
+CREATE TABLE cards (
+  id integer primary key, nid integer NOT NULL, did integer NOT NULL,
+  ord integer NOT NULL, mod integer NOT NULL, usn integer NOT NULL,
+  type integer NOT NULL, queue integer NOT NULL, due integer NOT NULL,
+  ivl integer NOT NULL, factor integer NOT NULL, reps integer NOT NULL,
+  lapses integer NOT NULL, left integer NOT NULL, odue integer NOT NULL,
+  odid integer NOT NULL, flags integer NOT NULL, data text NOT NULL
+);
+CREATE TABLE revlog (
+  id integer primary key, cid integer NOT NULL, usn integer NOT NULL,
+  ease integer NOT NULL, ivl integer NOT NULL, lastIvl integer NOT NULL,
+  factor integer NOT NULL, time integer NOT NULL, type integer NOT NULL
+);
+CREATE TABLE graves (
+  usn integer NOT NULL, oid integer NOT NULL, type integer NOT NULL
+);
+`;
+
+const INSERT_CARD_SQL = "INSERT INTO cards VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+
+function insertCard(db: Database, overrides: Record<string, unknown>, nowSec: number) {
+  const c = {
+    id: 201,
+    nid: 100,
+    did: 1,
+    ord: 0,
+    mod: nowSec,
+    usn: 0,
+    type: 0,
+    queue: 0,
+    due: 0,
+    ivl: 0,
+    factor: 0,
+    reps: 0,
+    lapses: 0,
+    left: 0,
+    odue: 0,
+    odid: 0,
+    flags: 0,
+    data: "",
+    ...overrides,
+  };
+  db.run(INSERT_CARD_SQL, [
+    c.id,
+    c.nid,
+    c.did,
+    c.ord,
+    c.mod,
+    c.usn,
+    c.type,
+    c.queue,
+    c.due,
+    c.ivl,
+    c.factor,
+    c.reps,
+    c.lapses,
+    c.left,
+    c.odue,
+    c.odid,
+    c.flags,
+    c.data,
+  ]);
+}
+
+/** Create a minimal anki2 collection with proper schema. */
+export function createAnki2Collection(
+  SQL: SqlJsStatic,
+  opts: {
+    dconf?: Record<string, unknown>;
+    decks?: Record<string, unknown>;
+    models?: Record<string, unknown>;
+    tags?: Record<string, number>;
+    conf?: Record<string, unknown>;
+    cardOverrides?: Record<string, unknown>;
+    extraCards?: Array<Record<string, unknown>>;
+    extraNotes?: Array<Record<string, unknown>>;
+  } = {},
+): Database {
+  const db = new SQL.Database();
+  const nowMs = Date.now();
+  const nowSec = Math.floor(nowMs / 1000);
+  const crt = nowSec - 86400 * 30;
+
+  const defaultDconf = {
+    "1": {
+      id: 1,
+      mod: nowSec,
+      name: "Default",
+      usn: 0,
+      new: { delays: [1, 10], order: 1, perDay: 20 },
+      lapse: { delays: [10], minInt: 1, mult: 0, leechFails: 8 },
+      rev: { perDay: 200, ease4: 1.3, hardFactor: 1.2, ivlFct: 1.0, maxIvl: 36500, fuzz: true },
+    },
+  };
+
+  const defaultDecks = {
+    "1": { id: 1, mod: nowSec, name: "Default", usn: 0, conf: "1" },
+  };
+
+  const defaultModels = {
+    "1234567890": {
+      id: 1234567890,
+      mod: nowSec,
+      name: "Basic",
+      usn: 0,
+      flds: [
+        { name: "Front", ord: 0 },
+        { name: "Back", ord: 1 },
+      ],
+      tmpls: [{ name: "Card 1", qfmt: "{{Front}}", afmt: "{{Back}}", ord: 0 }],
+    },
+  };
+
+  db.run(ANKI2_SCHEMA);
+  db.run(`INSERT INTO col VALUES (1, ?, ?, ?, 11, 0, 0, 0, ?, ?, ?, ?, ?)`, [
+    crt,
+    nowMs,
+    nowSec,
+    JSON.stringify(opts.conf ?? {}),
+    JSON.stringify(opts.models ?? defaultModels),
+    JSON.stringify(opts.decks ?? defaultDecks),
+    JSON.stringify(opts.dconf ?? defaultDconf),
+    JSON.stringify(opts.tags ?? {}),
+  ]);
+
+  // Insert default note
+  db.run(
+    `INSERT INTO notes VALUES (100, 'abc123', 1234567890, ?, 0, '', 'front\x1fback', 'front', 0, 0, '')`,
+    [nowSec],
+  );
+
+  // Insert extra notes
+  for (const note of opts.extraNotes ?? []) {
+    const n = {
+      id: 101,
+      guid: "def456",
+      mid: 1234567890,
+      mod: nowSec,
+      usn: 0,
+      tags: "",
+      flds: "q\x1fa",
+      sfld: "q",
+      csum: 0,
+      flags: 0,
+      data: "",
+      ...note,
+    };
+    db.run("INSERT INTO notes VALUES (?,?,?,?,?,?,?,?,?,?,?)", [
+      n.id,
+      n.guid,
+      n.mid,
+      n.mod,
+      n.usn,
+      n.tags,
+      n.flds,
+      n.sfld,
+      n.csum,
+      n.flags,
+      n.data,
+    ]);
+  }
+
+  const cardDefaults = {
+    id: 200,
+    nid: 100,
+    did: 1,
+    ord: 0,
+    mod: nowSec,
+    usn: 0,
+    type: 0,
+    queue: 0,
+    due: 0,
+    ivl: 0,
+    factor: 0,
+    reps: 0,
+    lapses: 0,
+    left: 0,
+    odue: 0,
+    odid: 0,
+    flags: 0,
+    data: "",
+    ...opts.cardOverrides,
+  };
+  db.run(INSERT_CARD_SQL, [
+    cardDefaults.id,
+    cardDefaults.nid,
+    cardDefaults.did,
+    cardDefaults.ord,
+    cardDefaults.mod,
+    cardDefaults.usn,
+    cardDefaults.type,
+    cardDefaults.queue,
+    cardDefaults.due,
+    cardDefaults.ivl,
+    cardDefaults.factor,
+    cardDefaults.reps,
+    cardDefaults.lapses,
+    cardDefaults.left,
+    cardDefaults.odue,
+    cardDefaults.odid,
+    cardDefaults.flags,
+    cardDefaults.data,
+  ]);
+
+  // Insert extra cards
+  for (const card of opts.extraCards ?? []) {
+    insertCard(db, card, nowSec);
+  }
+
+  return db;
+}
+
+// ── Anki21b schema & factory ────────────────────────────────────────
+
+const ANKI21B_EXTRA_SCHEMA = `
+CREATE TABLE notetypes (
+  id integer primary key, name text NOT NULL, mtime_secs integer NOT NULL,
+  usn integer NOT NULL, config text NOT NULL
+);
+CREATE TABLE decks (
+  id integer primary key, name text NOT NULL, mtime integer NOT NULL,
+  usn integer NOT NULL, common text NOT NULL
+);
+CREATE TABLE deck_config (
+  id integer primary key, name text NOT NULL, mtime integer NOT NULL,
+  usn integer NOT NULL, config text NOT NULL
+);
+CREATE TABLE tags (tag text primary key, usn integer NOT NULL);
+`;
+
+/** Create a minimal anki21b collection with separate tables. */
+export function createAnki21bDb(
+  SQL: SqlJsStatic,
+  opts: {
+    notetypes?: Array<{
+      id: number;
+      name: string;
+      mtime_secs: number;
+      usn: number;
+      config: string;
+    }>;
+    decks?: Array<{ id: number; name: string; mtime: number; usn: number; common: string }>;
+    deckConfigs?: Array<{ id: number; name: string; mtime: number; usn: number; config: string }>;
+    tags?: Array<{ tag: string; usn: number }>;
+    conf?: Record<string, unknown>;
+  } = {},
+): Database {
+  const db = new SQL.Database();
+  const nowMs = Date.now();
+  const nowSec = Math.floor(nowMs / 1000);
+  const crt = nowSec - 86400 * 30;
+
+  db.run(ANKI2_SCHEMA);
+  db.run(`INSERT INTO col VALUES (1, ?, ?, ?, 11, 0, 0, 0, ?, '{}', '{}', '{}', '{}')`, [
+    crt,
+    nowMs,
+    nowSec,
+    JSON.stringify(opts.conf ?? {}),
+  ]);
+
+  db.run(ANKI21B_EXTRA_SCHEMA);
+
+  // Insert default deck
+  db.run("INSERT INTO decks VALUES (1, 'Default', 0, 0, '{}')");
+
+  for (const d of opts.decks ?? []) {
+    db.run("INSERT OR REPLACE INTO decks VALUES (?,?,?,?,?)", [
+      d.id,
+      d.name,
+      d.mtime,
+      d.usn,
+      d.common,
+    ]);
+  }
+  for (const nt of opts.notetypes ?? []) {
+    db.run("INSERT INTO notetypes VALUES (?,?,?,?,?)", [
+      nt.id,
+      nt.name,
+      nt.mtime_secs,
+      nt.usn,
+      nt.config,
+    ]);
+  }
+  for (const dc of opts.deckConfigs ?? []) {
+    db.run("INSERT INTO deck_config VALUES (?,?,?,?,?)", [
+      dc.id,
+      dc.name,
+      dc.mtime,
+      dc.usn,
+      dc.config,
+    ]);
+  }
+  for (const t of opts.tags ?? []) {
+    db.run("INSERT INTO tags VALUES (?,?)", [t.tag, t.usn]);
+  }
+
+  return db;
+}

--- a/src/ankiExporter/index.ts
+++ b/src/ankiExporter/index.ts
@@ -7,7 +7,6 @@ function generateId(): number {
   return Date.now() + Math.floor(Math.random() * 1000);
 }
 
-
 function guidFromId(_id: number): string {
   // Generate a random base91-like GUID (random source, not derived from ID)
   const chars =

--- a/src/ankiParser/index.ts
+++ b/src/ankiParser/index.ts
@@ -22,12 +22,30 @@ export async function getAnkiDataFromBlob(file: Blob): Promise<AnkiData> {
   if (ankiDb.type === "21b") {
     const { cards, deckName, decks, notesTypes, collectionCreationTime, deckConfigs } =
       getDataFromAnki21b(db);
-    return { cards, files, deckName, decks, notesTypes, collectionCreationTime, deckConfigs, colConf: null };
+    return {
+      cards,
+      files,
+      deckName,
+      decks,
+      notesTypes,
+      collectionCreationTime,
+      deckConfigs,
+      colConf: null,
+    };
   }
 
   const { cards, deckName, decks, notesTypes, collectionCreationTime, deckConfigs, colConf } =
     getDataFromAnki2(db);
-  return { cards, files, deckName, decks, notesTypes, collectionCreationTime, deckConfigs, colConf };
+  return {
+    cards,
+    files,
+    deckName,
+    decks,
+    notesTypes,
+    collectionCreationTime,
+    deckConfigs,
+    colConf,
+  };
 }
 
 /**
@@ -48,12 +66,30 @@ export async function getAnkiDataFromSqlite(
     if (tableNames.has("notetypes")) {
       const { cards, deckName, decks, notesTypes, collectionCreationTime, deckConfigs } =
         getDataFromAnki21b(db);
-      return { cards, files, deckName, decks, notesTypes, collectionCreationTime, deckConfigs, colConf: null };
+      return {
+        cards,
+        files,
+        deckName,
+        decks,
+        notesTypes,
+        collectionCreationTime,
+        deckConfigs,
+        colConf: null,
+      };
     }
 
     const { cards, deckName, decks, notesTypes, collectionCreationTime, deckConfigs, colConf } =
       getDataFromAnki2(db);
-    return { cards, files, deckName, decks, notesTypes, collectionCreationTime, deckConfigs, colConf };
+    return {
+      cards,
+      files,
+      deckName,
+      decks,
+      notesTypes,
+      collectionCreationTime,
+      deckConfigs,
+      colConf,
+    };
   } finally {
     db.close();
   }

--- a/src/backup/backupService.ts
+++ b/src/backup/backupService.ts
@@ -24,7 +24,9 @@ export function getBackupSettings(): BackupSettings {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);
     if (raw) return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
-  } catch { /* use defaults */ }
+  } catch {
+    /* use defaults */
+  }
   return { ...DEFAULT_SETTINGS };
 }
 

--- a/src/backup/colpkg.ts
+++ b/src/backup/colpkg.ts
@@ -22,10 +22,7 @@ export async function createColpkg(): Promise<Blob> {
   const zipWriter = new ZipWriter(new BlobWriter("application/zip"));
 
   // Add compressed SQLite database
-  await zipWriter.add(
-    "collection.anki21b",
-    new BlobReader(new Blob([compressed as BlobPart])),
-  );
+  await zipWriter.add("collection.anki21b", new BlobReader(new Blob([compressed as BlobPart])));
 
   // Add media files with numeric names and build the mapping
   const mediaMapping: Record<string, string> = {};
@@ -38,10 +35,7 @@ export async function createColpkg(): Promise<Blob> {
   }
 
   // Add media mapping JSON
-  await zipWriter.add(
-    "media",
-    new BlobReader(new Blob([JSON.stringify(mediaMapping)])),
-  );
+  await zipWriter.add("media", new BlobReader(new Blob([JSON.stringify(mediaMapping)])));
 
   return await zipWriter.close();
 }
@@ -89,9 +83,7 @@ export async function restoreColpkg(file: Blob): Promise<void> {
     }
 
     // Build filename → Blob map from numbered entries
-    const reverseMap = new Map(
-      Object.entries(mediaMapping).map(([num, name]) => [num, name]),
-    );
+    const reverseMap = new Map(Object.entries(mediaMapping).map(([num, name]) => [num, name]));
     mediaBlobs = new Map<string, Blob>();
 
     for (const [numKey, filename] of reverseMap) {

--- a/src/components/BackupPanel.vue
+++ b/src/components/BackupPanel.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted } from "vue";
 import { formatFileSize } from "../utils/format";
 import { Download, Upload, Archive, Trash2, RotateCcw } from "lucide-vue-next";
-import Modal from "../design-system/components/primitives/Modal.vue";
+import { Modal } from "../design-system";
 import {
   exportToFile,
   importFromFile,
@@ -161,7 +161,6 @@ function formatDate(ts: number): string {
   return new Date(ts).toLocaleString();
 }
 
-
 const intervalOptions = [
   { label: "1 hour", value: 60 * 60 * 1000 },
   { label: "6 hours", value: 6 * 60 * 60 * 1000 },
@@ -175,8 +174,8 @@ const intervalOptions = [
   <div class="backup-panel">
     <h2 class="backup-title">Collection Backup</h2>
     <p class="backup-description">
-      Export and restore your collection as <code>.colpkg</code> files. Backups include
-      the full database and all media files.
+      Export and restore your collection as <code>.colpkg</code> files. Backups include the full
+      database and all media files.
     </p>
 
     <!-- Export / Import Actions -->
@@ -187,7 +186,11 @@ const intervalOptions = [
           <Download :size="14" />
           Export Collection
         </button>
-        <button class="backup-btn backup-btn--secondary" :disabled="isBusy" @click="handleImportClick">
+        <button
+          class="backup-btn backup-btn--secondary"
+          :disabled="isBusy"
+          @click="handleImportClick"
+        >
           <Upload :size="14" />
           Import Collection
         </button>
@@ -198,15 +201,17 @@ const intervalOptions = [
     <div class="backup-section">
       <div class="backup-section-header">
         <h3 class="backup-section-title">Stored Backups</h3>
-        <button class="backup-btn backup-btn--primary" :disabled="isBusy" @click="handleCreateBackup">
+        <button
+          class="backup-btn backup-btn--primary"
+          :disabled="isBusy"
+          @click="handleCreateBackup"
+        >
           <Archive :size="14" />
           Create Backup
         </button>
       </div>
 
-      <div v-if="backups.length === 0" class="backup-empty">
-        No backups stored yet.
-      </div>
+      <div v-if="backups.length === 0" class="backup-empty">No backups stored yet.</div>
 
       <div v-else class="backup-list">
         <div v-for="backup in backups" :key="backup.id" class="backup-item">
@@ -251,20 +256,12 @@ const intervalOptions = [
       <summary>Auto-Backup Settings</summary>
       <div class="backup-settings-content">
         <label class="backup-toggle">
-          <input
-            type="checkbox"
-            v-model="settings.autoBackupEnabled"
-            @change="updateSettings"
-          />
+          <input type="checkbox" v-model="settings.autoBackupEnabled" @change="updateSettings" />
           Enable periodic auto-backup
         </label>
 
         <label class="backup-toggle">
-          <input
-            type="checkbox"
-            v-model="settings.backupBeforeSync"
-            @change="updateSettings"
-          />
+          <input type="checkbox" v-model="settings.backupBeforeSync" @change="updateSettings" />
           Backup before sync
         </label>
 
@@ -311,13 +308,11 @@ const intervalOptions = [
       @close="showRestoreConfirm = false"
     >
       <p class="backup-confirm-text">
-        This will <strong>replace your current collection</strong> with the backup.
-        Any unsaved changes will be lost.
+        This will <strong>replace your current collection</strong> with the backup. Any unsaved
+        changes will be lost.
       </p>
       <div class="backup-confirm-actions">
-        <button class="backup-btn backup-btn--danger" @click="confirmRestore">
-          Restore
-        </button>
+        <button class="backup-btn backup-btn--danger" @click="confirmRestore">Restore</button>
         <button class="backup-btn backup-btn--secondary" @click="showRestoreConfirm = false">
           Cancel
         </button>
@@ -332,13 +327,11 @@ const intervalOptions = [
       @close="showImportConfirm = false"
     >
       <p class="backup-confirm-text">
-        This will <strong>replace your current collection</strong> with the imported file.
-        Any unsaved changes will be lost.
+        This will <strong>replace your current collection</strong> with the imported file. Any
+        unsaved changes will be lost.
       </p>
       <div class="backup-confirm-actions">
-        <button class="backup-btn backup-btn--danger" @click="confirmImport">
-          Import
-        </button>
+        <button class="backup-btn backup-btn--danger" @click="confirmImport">Import</button>
         <button class="backup-btn backup-btn--secondary" @click="showImportConfirm = false">
           Cancel
         </button>

--- a/src/components/CardBrowser.vue
+++ b/src/components/CardBrowser.vue
@@ -18,8 +18,7 @@ import { isImageOcclusionCard, renderImageOcclusion } from "../utils/imageOcclus
 import { sanitizeHtmlForPreview } from "../utils/sanitize";
 import { stripHtml } from "../utils/stripHtml";
 import { playAudio } from "../utils/sound";
-import Button from "../design-system/components/primitives/Button.vue";
-import Modal from "../design-system/components/primitives/Modal.vue";
+import { Button, Modal } from "../design-system";
 import NoteEditModal from "./NoteEditModal.vue";
 import TagTree from "./TagTree.vue";
 import { buildTagTree, tagMatchesOrIsChild } from "../utils/tagTree";
@@ -131,7 +130,6 @@ watch(viewMode, () => {
   selectedRowKeys.value = new Set();
   lastClickedKey.value = null;
 });
-
 
 /** Single-pass extraction of tags, tag note counts, decks, and note types from cards */
 const cardMetadata = computed(() => {
@@ -270,7 +268,8 @@ async function applyReposition() {
   );
 
   if (count === 0) {
-    repositionResultMsg.value = "No new cards found in selection. Only new (unseen) cards can be repositioned.";
+    repositionResultMsg.value =
+      "No new cards found in selection. Only new (unseen) cards can be repositioned.";
   } else {
     repositionResultMsg.value = `Repositioned ${count} new card${count === 1 ? "" : "s"}.`;
     setTimeout(() => {
@@ -797,9 +796,7 @@ const filteredRows = computed(() => {
   // Apply tag sidebar filter
   const tagFilter = activeTagFilter.value;
   if (tagFilter) {
-    result = result.filter((row) =>
-      row.tags.some((t) => tagMatchesOrIsChild(t, tagFilter)),
-    );
+    result = result.filter((row) => row.tags.some((t) => tagMatchesOrIsChild(t, tagFilter)));
   }
 
   if (expr) {
@@ -874,7 +871,11 @@ function getCellValue(row: Row, col: string): string {
 
 // ── Virtual scrolling ──
 
-const { scrollContainerRef, onScroll: onTableScroll, virtualSlice } = useVirtualScroll({
+const {
+  scrollContainerRef,
+  onScroll: onTableScroll,
+  virtualSlice,
+} = useVirtualScroll({
   items: filteredRows,
 });
 
@@ -1089,7 +1090,12 @@ async function bulkUnsuspend() {
 
   // Map card type to the appropriate queue to restore to
   const TYPE_TO_QUEUE: Record<number, number> = { 0: 0, 1: 1, 2: 2, 3: 1 };
-  const TYPE_TO_QUEUE_NAME: Record<number, string> = { 0: "new", 1: "learning", 2: "review", 3: "dayLearning" };
+  const TYPE_TO_QUEUE_NAME: Record<number, string> = {
+    0: "new",
+    1: "learning",
+    2: "review",
+    3: "dayLearning",
+  };
 
   bulkOperationInProgress.value = true;
   try {

--- a/src/components/CommandPalette.vue
+++ b/src/components/CommandPalette.vue
@@ -152,7 +152,7 @@ function matchesHotkey(e: KeyboardEvent, hotkey: string): boolean {
   // Allow shift for keys that naturally require it (e.g. *, @, ?, !, etc.)
   // Only enforce strict shift check for letter/number keys
   const isShiftedSymbol = key.length === 1 && !/[a-z0-9]/.test(key);
-  const shiftOk = needsShift ? e.shiftKey : (!e.shiftKey || isShiftedSymbol);
+  const shiftOk = needsShift ? e.shiftKey : !e.shiftKey || isShiftedSymbol;
 
   return (
     (needsCtrl ? e.ctrlKey : !e.ctrlKey || needsMeta) &&

--- a/src/components/CongratsScreen.vue
+++ b/src/components/CongratsScreen.vue
@@ -100,21 +100,13 @@ function handleRebuild() {
 
       <div class="congrats-actions">
         <template v-if="isFilteredDeck">
-          <Button variant="secondary" @click="handleRebuild">
-            Rebuild Deck
-          </Button>
-          <Button variant="secondary" @click="handleEmptyDeck">
-            Empty Deck
-          </Button>
+          <Button variant="secondary" @click="handleRebuild"> Rebuild Deck </Button>
+          <Button variant="secondary" @click="handleEmptyDeck"> Empty Deck </Button>
         </template>
         <template v-else>
-          <Button variant="secondary" @click="customStudyOpen = true">
-            Custom Study
-          </Button>
+          <Button variant="secondary" @click="customStudyOpen = true"> Custom Study </Button>
         </template>
-        <Button variant="secondary" @click="reviewModeSig = 'deck-list'">
-          Back to Decks
-        </Button>
+        <Button variant="secondary" @click="reviewModeSig = 'deck-list'"> Back to Decks </Button>
       </div>
     </div>
 

--- a/src/components/CustomStudyModal.vue
+++ b/src/components/CustomStudyModal.vue
@@ -9,11 +9,14 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: "close"): void;
-  (e: "create-filtered", payload: {
-    name: string;
-    query: string;
-    reschedule: boolean;
-  }): void;
+  (
+    e: "create-filtered",
+    payload: {
+      name: string;
+      query: string;
+      reschedule: boolean;
+    },
+  ): void;
 }>();
 
 const currentDeckName = computed(() => {
@@ -45,7 +48,7 @@ const presets = computed<Preset[]>(() => {
     {
       label: "Review forgotten cards",
       description: "Study cards you answered Again on recently",
-      getQuery: () => df ? `rated:7:1 ${df}` : "rated:7:1",
+      getQuery: () => (df ? `rated:7:1 ${df}` : "rated:7:1"),
       reschedule: true,
     },
     {
@@ -60,13 +63,13 @@ const presets = computed<Preset[]>(() => {
     {
       label: "Preview new cards",
       description: "Study new cards without affecting scheduling",
-      getQuery: () => df ? `is:new ${df}` : "is:new",
+      getQuery: () => (df ? `is:new ${df}` : "is:new"),
       reschedule: false,
     },
     {
       label: "Study by state: due",
       description: "Review all cards that are currently due",
-      getQuery: () => df ? `is:due ${df}` : "is:due",
+      getQuery: () => (df ? `is:due ${df}` : "is:due"),
       reschedule: true,
     },
     {

--- a/src/components/DatabaseCheckPanel.vue
+++ b/src/components/DatabaseCheckPanel.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
-import {
-  ankiDataSig,
-  activeViewSig,
-  getActiveSqliteBytes,
-} from "../stores";
+import { ankiDataSig, activeViewSig, getActiveSqliteBytes } from "../stores";
 import { createDatabase } from "../utils/sql";
 import {
   checkDatabaseIntegrity,
@@ -13,8 +9,7 @@ import {
   type IssueSeverity,
 } from "../utils/integrityCheck";
 import { withDbMutation } from "../stores";
-import Button from "../design-system/components/primitives/Button.vue";
-import Modal from "../design-system/components/primitives/Modal.vue";
+import { Button, Modal } from "../design-system";
 
 const issues = ref<IntegrityIssue[]>([]);
 const hasChecked = ref(false);
@@ -155,13 +150,23 @@ watch(ankiDataSig, () => {
       <div class="db-check__header">
         <div class="db-check__title-row">
           <button class="db-check__back-btn" @click="goBack" title="Back to Browse">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
           </button>
           <h1 class="db-check__title">Database Check</h1>
         </div>
-        <p class="db-check__subtitle">
-          Verify collection integrity and repair common issues.
-        </p>
+        <p class="db-check__subtitle">Verify collection integrity and repair common issues.</p>
       </div>
 
       <!-- Action bar -->
@@ -173,12 +178,13 @@ watch(ankiDataSig, () => {
           :disabled="!ankiDataSig || !getActiveSqliteBytes()"
           @click="runCheck"
         >
-          {{ hasChecked ? 'Re-run Check' : 'Check Database' }}
+          {{ hasChecked ? "Re-run Check" : "Check Database" }}
         </Button>
 
         <div v-if="fixResult" class="db-check__fix-toast">
-          Fixed {{ fixResult.count }} item{{ fixResult.count !== 1 ? 's' : '' }}
-          ({{ fixResult.type }})
+          Fixed {{ fixResult.count }} item{{ fixResult.count !== 1 ? "s" : "" }} ({{
+            fixResult.type
+          }})
         </div>
       </div>
 
@@ -186,35 +192,50 @@ watch(ankiDataSig, () => {
       <div v-if="hasChecked" class="db-check__results">
         <!-- Summary -->
         <div v-if="issues.length === 0" class="db-check__pass">
-          <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="40"
+            height="40"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+            <path d="m9 11 3 3L22 4" />
+          </svg>
           <p>No issues found. Your collection looks healthy!</p>
         </div>
 
         <template v-else>
           <div class="db-check__summary">
-            <span v-if="errorCount() > 0" class="db-check__summary-badge db-check__summary-badge--error">
-              {{ errorCount() }} error{{ errorCount() !== 1 ? 's' : '' }}
+            <span
+              v-if="errorCount() > 0"
+              class="db-check__summary-badge db-check__summary-badge--error"
+            >
+              {{ errorCount() }} error{{ errorCount() !== 1 ? "s" : "" }}
             </span>
-            <span v-if="warningCount() > 0" class="db-check__summary-badge db-check__summary-badge--warning">
-              {{ warningCount() }} warning{{ warningCount() !== 1 ? 's' : '' }}
+            <span
+              v-if="warningCount() > 0"
+              class="db-check__summary-badge db-check__summary-badge--warning"
+            >
+              {{ warningCount() }} warning{{ warningCount() !== 1 ? "s" : "" }}
             </span>
             <span class="db-check__summary-total">
-              {{ issues.length }} issue{{ issues.length !== 1 ? 's' : '' }} found
+              {{ issues.length }} issue{{ issues.length !== 1 ? "s" : "" }} found
             </span>
           </div>
 
           <!-- Issue groups -->
-          <div
-            v-for="issue in issues"
-            :key="issue.type"
-            class="db-check__issue"
-          >
-            <button
-              class="db-check__issue-header"
-              @click="toggleIssue(issue.type)"
-            >
+          <div v-for="issue in issues" :key="issue.type" class="db-check__issue">
+            <button class="db-check__issue-header" @click="toggleIssue(issue.type)">
               <svg
-                :class="['db-check__chevron', { 'db-check__chevron--open': expandedIssues.has(issue.type) }]"
+                :class="[
+                  'db-check__chevron',
+                  { 'db-check__chevron--open': expandedIssues.has(issue.type) },
+                ]"
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
                 height="16"
@@ -225,7 +246,7 @@ watch(ankiDataSig, () => {
                 stroke-linecap="round"
                 stroke-linejoin="round"
               >
-                <path d="m9 18 6-6-6-6"/>
+                <path d="m9 18 6-6-6-6" />
               </svg>
 
               <span
@@ -237,7 +258,7 @@ watch(ankiDataSig, () => {
               <span class="db-check__issue-title">{{ issue.title }}</span>
 
               <span class="db-check__issue-count">
-                {{ issue.count }} item{{ issue.count !== 1 ? 's' : '' }}
+                {{ issue.count }} item{{ issue.count !== 1 ? "s" : "" }}
               </span>
 
               <span class="db-check__severity-tag" :data-severity="issue.severity">
@@ -245,10 +266,7 @@ watch(ankiDataSig, () => {
               </span>
             </button>
 
-            <div
-              v-if="expandedIssues.has(issue.type)"
-              class="db-check__issue-body"
-            >
+            <div v-if="expandedIssues.has(issue.type)" class="db-check__issue-body">
               <p class="db-check__issue-desc">{{ issue.description }}</p>
 
               <ul class="db-check__details">
@@ -261,11 +279,7 @@ watch(ankiDataSig, () => {
               </ul>
 
               <div v-if="issue.fixable" class="db-check__issue-fix">
-                <Button
-                  variant="primary"
-                  size="sm"
-                  @click.stop="handleFix(issue)"
-                >
+                <Button variant="primary" size="sm" @click.stop="handleFix(issue)">
                   Fix {{ issue.title }}
                 </Button>
               </div>
@@ -290,8 +304,9 @@ watch(ankiDataSig, () => {
       <div v-if="confirmFix" class="db-check__confirm">
         <p>{{ confirmFix.description }}</p>
         <p>
-          This will automatically fix <strong>{{ confirmFix.count }}</strong>
-          item{{ confirmFix.count !== 1 ? 's' : '' }}. This cannot be undone.
+          This will automatically fix <strong>{{ confirmFix.count }}</strong> item{{
+            confirmFix.count !== 1 ? "s" : ""
+          }}. This cannot be undone.
         </p>
       </div>
       <template #footer>

--- a/src/components/FileLibrary.vue
+++ b/src/components/FileLibrary.vue
@@ -149,24 +149,41 @@ function handleDeleteFiltered(id: string, event: Event) {
         >
           <div class="file-info">
             <span class="file-name">
-              <svg class="filtered-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg
+                class="filtered-icon"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
                 <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
               </svg>
               {{ fd.name }}
             </span>
-            <span class="file-meta">{{ fd.matchCount }} card{{ fd.matchCount === 1 ? "" : "s" }} · {{ fd.reschedule ? "Normal" : "Cram" }}</span>
+            <span class="file-meta"
+              >{{ fd.matchCount }} card{{ fd.matchCount === 1 ? "" : "s" }} ·
+              {{ fd.reschedule ? "Normal" : "Cram" }}</span
+            >
           </div>
           <div class="filtered-actions">
             <button
               class="filtered-action-btn"
               title="Rebuild"
               @click.stop="rebuildFilteredDeck(fd.id)"
-            >&#8635;</button>
+            >
+              &#8635;
+            </button>
             <button
               class="delete-btn"
               title="Delete"
               @click.stop="handleDeleteFiltered(fd.id, $event)"
-            >&times;</button>
+            >
+              &times;
+            </button>
           </div>
         </div>
       </div>
@@ -178,10 +195,7 @@ function handleDeleteFiltered(id: string, event: Event) {
       </Button>
     </div>
 
-    <FilteredDeckModal
-      :is-open="filteredDeckModalOpen"
-      @close="filteredDeckModalOpen = false"
-    />
+    <FilteredDeckModal :is-open="filteredDeckModalOpen" @close="filteredDeckModalOpen = false" />
 
     <section
       v-if="(syncActiveSig || isSampleCollectionActive) && deckInfoSig"

--- a/src/components/FilteredDeckModal.vue
+++ b/src/components/FilteredDeckModal.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import { Button, Modal } from "../design-system";
-import {
-  ankiDataSig,
-  countFilteredDeckCards,
-  createFilteredDeck,
-} from "../stores";
+import { ankiDataSig, countFilteredDeckCards, createFilteredDeck } from "../stores";
 import type { FilteredDeckSortOrder } from "../scheduler/types";
 
 const props = defineProps<{
@@ -97,7 +93,7 @@ const SORT_OPTIONS: { value: FilteredDeckSortOrder; label: string }[] = [
           v-model="query"
           type="text"
           class="field-input"
-          placeholder='e.g. is:due deck:Biology'
+          placeholder="e.g. is:due deck:Biology"
           @keydown.enter.prevent="handleCreate"
         />
         <span class="field-hint">
@@ -126,7 +122,9 @@ const SORT_OPTIONS: { value: FilteredDeckSortOrder; label: string }[] = [
         <span>Reschedule cards based on my answers</span>
       </label>
       <span class="field-hint" style="margin-top: -8px">
-        {{ reschedule ? "Cards will be rescheduled normally." : "Cram mode: scheduling won't change." }}
+        {{
+          reschedule ? "Cards will be rescheduled normally." : "Cram mode: scheduling won't change."
+        }}
       </span>
 
       <div class="preview-bar">

--- a/src/components/FindDuplicates.vue
+++ b/src/components/FindDuplicates.vue
@@ -11,8 +11,7 @@ import {
   type DuplicateSearchOptions,
   type NoteInfo,
 } from "../utils/duplicates";
-import Button from "../design-system/components/primitives/Button.vue";
-import Modal from "../design-system/components/primitives/Modal.vue";
+import { Button, Modal } from "../design-system";
 import { deleteNotesByGuid } from "../stores";
 
 // Search options
@@ -111,7 +110,6 @@ function runSearch() {
   });
 }
 
-
 /** Get a preview of note fields (excluding the comparison field) */
 function getNotePreview(note: NoteInfo, skipFieldIndex: number): string {
   const entries: string[] = [];
@@ -180,7 +178,19 @@ watch(ankiDataSig, () => {
       <div class="find-duplicates__header">
         <div class="find-duplicates__title-row">
           <button class="find-duplicates__back-btn" @click="goBack" title="Back to Browse">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
           </button>
           <h1 class="find-duplicates__title">Find Duplicates</h1>
         </div>
@@ -193,28 +203,16 @@ watch(ankiDataSig, () => {
       <div class="find-duplicates__options">
         <div class="find-duplicates__option">
           <label class="find-duplicates__label" for="dup-field">Compare field</label>
-          <select
-            id="dup-field"
-            v-model="fieldIndex"
-            class="find-duplicates__select"
-          >
-            <option
-              v-for="(name, idx) in fieldNames"
-              :key="idx"
-              :value="idx"
-            >
-              {{ name }}{{ idx === 0 ? ' (sort field)' : '' }}
+          <select id="dup-field" v-model="fieldIndex" class="find-duplicates__select">
+            <option v-for="(name, idx) in fieldNames" :key="idx" :value="idx">
+              {{ name }}{{ idx === 0 ? " (sort field)" : "" }}
             </option>
           </select>
         </div>
 
         <div class="find-duplicates__option">
           <label class="find-duplicates__label" for="dup-scope">Scope</label>
-          <select
-            id="dup-scope"
-            v-model="scope"
-            class="find-duplicates__select"
-          >
+          <select id="dup-scope" v-model="scope" class="find-duplicates__select">
             <option value="all">Across all decks</option>
             <option value="deck">Within each deck</option>
           </select>
@@ -262,22 +260,20 @@ watch(ankiDataSig, () => {
         <template v-else>
           <div class="find-duplicates__results-header">
             <span class="find-duplicates__results-count">
-              {{ duplicateGroups.length }} duplicate group{{ duplicateGroups.length !== 1 ? 's' : '' }}
+              {{ duplicateGroups.length }} duplicate group{{
+                duplicateGroups.length !== 1 ? "s" : ""
+              }}
               ({{ totalDuplicateNotes }} notes total)
             </span>
           </div>
 
-          <div
-            v-for="group in duplicateGroups"
-            :key="group.key"
-            class="find-duplicates__group"
-          >
-            <button
-              class="find-duplicates__group-header"
-              @click="toggleGroup(group.key)"
-            >
+          <div v-for="group in duplicateGroups" :key="group.key" class="find-duplicates__group">
+            <button class="find-duplicates__group-header" @click="toggleGroup(group.key)">
               <svg
-                :class="['find-duplicates__chevron', { 'find-duplicates__chevron--open': expandedGroups.has(group.key) }]"
+                :class="[
+                  'find-duplicates__chevron',
+                  { 'find-duplicates__chevron--open': expandedGroups.has(group.key) },
+                ]"
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
                 height="16"
@@ -288,34 +284,24 @@ watch(ankiDataSig, () => {
                 stroke-linecap="round"
                 stroke-linejoin="round"
               >
-                <path d="m9 18 6-6-6-6"/>
+                <path d="m9 18 6-6-6-6" />
               </svg>
               <span class="find-duplicates__group-title">
                 {{ truncate(group.displayKey, 100) }}
               </span>
-              <span class="find-duplicates__group-badge">
-                {{ group.notes.length }} notes
-              </span>
-              <span
-                v-if="group.similarity < 1"
-                class="find-duplicates__group-similarity"
-              >
+              <span class="find-duplicates__group-badge"> {{ group.notes.length }} notes </span>
+              <span v-if="group.similarity < 1" class="find-duplicates__group-similarity">
                 ~{{ Math.round(group.similarity * 100) }}% similar
               </span>
             </button>
 
-            <div
-              v-if="expandedGroups.has(group.key)"
-              class="find-duplicates__group-body"
-            >
-              <div
-                v-for="note in group.notes"
-                :key="note.guid"
-                class="find-duplicates__note"
-              >
+            <div v-if="expandedGroups.has(group.key)" class="find-duplicates__group-body">
+              <div v-for="note in group.notes" :key="note.guid" class="find-duplicates__note">
                 <div class="find-duplicates__note-content">
                   <div class="find-duplicates__note-field">
-                    {{ truncate(stripHtml(note.values[note.fieldNames[fieldIndex] ?? ''] ?? ''), 150) }}
+                    {{
+                      truncate(stripHtml(note.values[note.fieldNames[fieldIndex] ?? ""] ?? ""), 150)
+                    }}
                   </div>
                   <div class="find-duplicates__note-preview">
                     {{ getNotePreview(note, fieldIndex) }}
@@ -323,7 +309,7 @@ watch(ankiDataSig, () => {
                   <div class="find-duplicates__note-meta">
                     <span class="find-duplicates__note-deck">{{ note.deckName }}</span>
                     <span v-if="note.tags.length > 0" class="find-duplicates__note-tags">
-                      {{ note.tags.join(', ') }}
+                      {{ note.tags.join(", ") }}
                     </span>
                   </div>
                 </div>
@@ -368,17 +354,15 @@ watch(ankiDataSig, () => {
         <p v-if="confirmAction.type === 'merge'">
           Keep the selected note and delete
           <strong>{{ confirmAction.deleteGuids?.length }}</strong>
-          duplicate{{ (confirmAction.deleteGuids?.length ?? 0) !== 1 ? 's' : '' }}?
-          This cannot be undone.
+          duplicate{{ (confirmAction.deleteGuids?.length ?? 0) !== 1 ? "s" : "" }}? This cannot be
+          undone.
         </p>
-        <p v-else>
-          Delete this note? This cannot be undone.
-        </p>
+        <p v-else>Delete this note? This cannot be undone.</p>
       </div>
       <template #footer>
         <Button variant="secondary" size="sm" @click="confirmAction = null">Cancel</Button>
         <Button variant="danger" size="sm" @click="confirmDeletion">
-          {{ confirmAction?.type === 'merge' ? 'Delete Duplicates' : 'Delete' }}
+          {{ confirmAction?.type === "merge" ? "Delete Duplicates" : "Delete" }}
         </Button>
       </template>
     </Modal>

--- a/src/components/FindReplaceModal.vue
+++ b/src/components/FindReplaceModal.vue
@@ -3,8 +3,7 @@ import { ref, computed, watch } from "vue";
 import { ankiDataSig, bulkUpdateNoteFields } from "../stores";
 import { stripHtml } from "../utils/stripHtml";
 import { escapeHtml, truncate } from "../utils/format";
-import Modal from "../design-system/components/primitives/Modal.vue";
-import Button from "../design-system/components/primitives/Button.vue";
+import { Button, Modal } from "../design-system";
 
 type Scope = "all" | "selected" | "deck";
 

--- a/src/components/ImageOcclusionEditor.vue
+++ b/src/components/ImageOcclusionEditor.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted, onUnmounted, watch } from "vue";
 import { useImageOcclusionEditor, type IoTool } from "../composables/useImageOcclusionEditor";
 import type { OcclusionShape, OcclusionMode } from "../utils/imageOcclusion";
-import Button from "../design-system/components/primitives/Button.vue";
+import { Button } from "../design-system";
 
 const props = defineProps<{
   imageUrl: string;
@@ -108,7 +108,8 @@ let dragState: {
   origW: number;
   origH: number;
 } | null = null;
-let resizeHandle: { shapeId: string; dir: HandleDir; anchorX: number; anchorY: number } | null = null;
+let resizeHandle: { shapeId: string; dir: HandleDir; anchorX: number; anchorY: number } | null =
+  null;
 const MIN_DRAG_THRESHOLD = 5;
 let hasDragged = false;
 
@@ -182,7 +183,10 @@ function onPointerMove(e: PointerEvent) {
     const shape = editor.shapes.value.find((s) => s.id === shapeId);
     if (!shape) return;
 
-    let newX = shape.x, newY = shape.y, newW = shape.width, newH = shape.height;
+    let newX = shape.x,
+      newY = shape.y,
+      newW = shape.width,
+      newH = shape.height;
 
     if (dir.includes("w") || dir.includes("e")) {
       const minX = dir.includes("w") ? pt.x : anchorX;
@@ -197,8 +201,14 @@ function onPointerMove(e: PointerEvent) {
       newH = Math.abs(maxY - minY);
     }
     // Edge-only handles: preserve the other axis
-    if (dir === "n" || dir === "s") { newX = shape.x; newW = shape.width; }
-    if (dir === "e" || dir === "w") { newY = shape.y; newH = shape.height; }
+    if (dir === "n" || dir === "s") {
+      newX = shape.x;
+      newW = shape.width;
+    }
+    if (dir === "e" || dir === "w") {
+      newY = shape.y;
+      newH = shape.height;
+    }
 
     // Enforce minimum size
     if (newW < 10) newW = 10;
@@ -208,7 +218,8 @@ function onPointerMove(e: PointerEvent) {
   } else if (dragState) {
     const dx = pt.x - dragState.startX;
     const dy = pt.y - dragState.startY;
-    if (!hasDragged && Math.abs(dx) < MIN_DRAG_THRESHOLD && Math.abs(dy) < MIN_DRAG_THRESHOLD) return;
+    if (!hasDragged && Math.abs(dx) < MIN_DRAG_THRESHOLD && Math.abs(dy) < MIN_DRAG_THRESHOLD)
+      return;
     hasDragged = true;
     editor.resizeShape(dragState.shapeId, {
       x: dragState.origX + dx,
@@ -252,8 +263,14 @@ function getHandles(shape: OcclusionShape): HandleDef[] {
 }
 
 const handleCursors: Record<HandleDir, string> = {
-  nw: "nwse-resize", n: "ns-resize", ne: "nesw-resize", e: "ew-resize",
-  se: "nwse-resize", s: "ns-resize", sw: "nesw-resize", w: "ew-resize",
+  nw: "nwse-resize",
+  n: "ns-resize",
+  ne: "nesw-resize",
+  e: "ew-resize",
+  se: "nwse-resize",
+  s: "ns-resize",
+  sw: "nesw-resize",
+  w: "ew-resize",
 };
 </script>
 
@@ -319,7 +336,10 @@ const handleCursors: Record<HandleDir, string> = {
             fill-opacity="0.6"
             stroke="#2d2d2d"
             stroke-width="1"
-            :class="{ 'io-shape': true, 'io-shape-selected': shape.id === editor.selectedShapeId.value }"
+            :class="{
+              'io-shape': true,
+              'io-shape-selected': shape.id === editor.selectedShapeId.value,
+            }"
             style="cursor: pointer"
           />
           <ellipse
@@ -333,7 +353,10 @@ const handleCursors: Record<HandleDir, string> = {
             fill-opacity="0.6"
             stroke="#2d2d2d"
             stroke-width="1"
-            :class="{ 'io-shape': true, 'io-shape-selected': shape.id === editor.selectedShapeId.value }"
+            :class="{
+              'io-shape': true,
+              'io-shape-selected': shape.id === editor.selectedShapeId.value,
+            }"
             style="cursor: pointer"
           />
           <!-- Ordinal label -->

--- a/src/components/ImageOcclusionNoteEditor.vue
+++ b/src/components/ImageOcclusionNoteEditor.vue
@@ -2,7 +2,7 @@
 import { ref, watch, computed } from "vue";
 import ImageOcclusionEditor from "./ImageOcclusionEditor.vue";
 import TiptapEditor from "./TiptapEditor.vue";
-import Button from "../design-system/components/primitives/Button.vue";
+import { Button } from "../design-system";
 import type { AnkiDB2Data } from "../ankiParser/anki2";
 import {
   IO_FIELD_NAMES,
@@ -158,7 +158,12 @@ function handleTagKeydown(e: KeyboardEvent) {
 }
 
 function handleSave() {
-  const occSvg = serializeShapesToSvg(shapes.value, imageNaturalWidth.value, imageNaturalHeight.value, occlusionMode.value);
+  const occSvg = serializeShapesToSvg(
+    shapes.value,
+    imageNaturalWidth.value,
+    imageNaturalHeight.value,
+    occlusionMode.value,
+  );
   const imgTag = imageFilename.value ? `<img src="${imageFilename.value}">` : "";
 
   const fields: Record<string, string | null> = {
@@ -182,12 +187,7 @@ function handleSave() {
     <div v-if="!hasImage" class="io-image-picker" @drop="handleDrop" @dragover="handleDragOver">
       <div class="io-picker-content">
         <p class="io-picker-text">Drop an image here or click to select</p>
-        <input
-          type="file"
-          accept="image/*"
-          class="io-picker-input"
-          @change="handleImagePick"
-        />
+        <input type="file" accept="image/*" class="io-picker-input" @change="handleImagePick" />
         <Button variant="secondary" @click="($refs.fileInput as HTMLInputElement)?.click()">
           Choose Image
         </Button>
@@ -207,17 +207,11 @@ function handleSave() {
     <div class="io-text-fields">
       <div class="field-group">
         <label class="field-label">Header</label>
-        <TiptapEditor
-          v-model="headerText"
-          :media-files="mediaFiles"
-        />
+        <TiptapEditor v-model="headerText" :media-files="mediaFiles" />
       </div>
       <div class="field-group">
         <label class="field-label">Back Extra</label>
-        <TiptapEditor
-          v-model="backExtraText"
-          :media-files="mediaFiles"
-        />
+        <TiptapEditor v-model="backExtraText" :media-files="mediaFiles" />
       </div>
     </div>
 

--- a/src/components/NoteEditModal.vue
+++ b/src/components/NoteEditModal.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
-import Modal from "../design-system/components/primitives/Modal.vue";
-import Button from "../design-system/components/primitives/Button.vue";
+import { Button, Modal } from "../design-system";
 import TiptapEditor from "./TiptapEditor.vue";
 import ImageOcclusionNoteEditor from "./ImageOcclusionNoteEditor.vue";
 import type { AnkiDB2Data } from "../ankiParser/anki2";
@@ -77,7 +76,12 @@ function handleSave() {
 </script>
 
 <template>
-  <Modal :is-open="isOpen" :title="isIONote ? 'Edit Image Occlusion' : 'Edit Note'" :size="isIONote ? 'xl' : 'lg'" @close="emit('close')">
+  <Modal
+    :is-open="isOpen"
+    :title="isIONote ? 'Edit Image Occlusion' : 'Edit Note'"
+    :size="isIONote ? 'xl' : 'lg'"
+    @close="emit('close')"
+  >
     <!-- Image Occlusion editor -->
     <ImageOcclusionNoteEditor
       v-if="isIONote"

--- a/src/components/NoteTypeManager.vue
+++ b/src/components/NoteTypeManager.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import { Copy, Plus, Trash2 } from "lucide-vue-next";
-import Modal from "~/design-system/components/primitives/Modal.vue";
-import Button from "~/design-system/components/primitives/Button.vue";
+import { Button, Modal } from "~/design-system";
 import FieldEditor, { type FieldEntry } from "./notetype/FieldEditor.vue";
 import TemplateEditor, { type TemplateEntry } from "./notetype/TemplateEditor.vue";
 import CssEditor from "./notetype/CssEditor.vue";
@@ -75,8 +74,8 @@ const filteredNotetypes = computed(() => {
   return notetypes.value.filter((nt) => nt.name.toLowerCase().includes(q));
 });
 
-const selectedNotetype = computed(() =>
-  notetypes.value.find((nt) => nt.id === selectedNtid.value) ?? null,
+const selectedNotetype = computed(
+  () => notetypes.value.find((nt) => nt.id === selectedNtid.value) ?? null,
 );
 
 const allNotetypeInfos = computed<NotetypeInfo[]>(() =>
@@ -288,11 +287,9 @@ async function handleConvert(targetNtid: string, fieldMapping: Record<string, st
   const db = await createDatabase(bytes);
   let noteIds: number[];
   try {
-    noteIds = executeQueryAll<{ id: number }>(
-      db,
-      "SELECT id FROM notes WHERE mid=?",
-      [Number(ntid)] as unknown as Record<string, string>,
-    ).map((r) => r.id);
+    noteIds = executeQueryAll<{ id: number }>(db, "SELECT id FROM notes WHERE mid=?", [
+      Number(ntid),
+    ] as unknown as Record<string, string>).map((r) => r.id);
   } finally {
     db.close();
   }
@@ -323,11 +320,7 @@ function commitRename() {
     <div class="manager-layout">
       <!-- Left sidebar -->
       <div class="sidebar">
-        <input
-          v-model="searchQuery"
-          class="search-input"
-          placeholder="Search note types..."
-        />
+        <input v-model="searchQuery" class="search-input" placeholder="Search note types..." />
 
         <div class="notetype-list">
           <button
@@ -339,9 +332,7 @@ function commitRename() {
             <span class="notetype-name">{{ nt.name }}</span>
             <span class="notetype-count">{{ nt.noteCount }} notes</span>
           </button>
-          <div v-if="filteredNotetypes.length === 0" class="empty-list">
-            No note types found
-          </div>
+          <div v-if="filteredNotetypes.length === 0" class="empty-list">No note types found</div>
         </div>
 
         <div class="sidebar-actions">
@@ -375,7 +366,12 @@ function commitRename() {
                 {{ selectedNotetype.name }}
               </h3>
             </template>
-            <span :class="['kind-badge', `kind-badge--${selectedNotetype.kind === 1 ? 'cloze' : 'normal'}`]">
+            <span
+              :class="[
+                'kind-badge',
+                `kind-badge--${selectedNotetype.kind === 1 ? 'cloze' : 'normal'}`,
+              ]"
+            >
               {{ selectedNotetype.kind === 1 ? "Cloze" : "Normal" }}
             </span>
           </div>
@@ -441,7 +437,11 @@ function commitRename() {
             size="sm"
             variant="danger"
             :disabled="selectedNotetype.noteCount > 0"
-            :title="selectedNotetype.noteCount > 0 ? `Cannot delete: ${selectedNotetype.noteCount} note(s) use this type` : 'Delete note type'"
+            :title="
+              selectedNotetype.noteCount > 0
+                ? `Cannot delete: ${selectedNotetype.noteCount} note(s) use this type`
+                : 'Delete note type'
+            "
             @click="handleDelete"
           >
             <template #iconLeft><Trash2 :size="14" /></template>
@@ -459,12 +459,7 @@ function commitRename() {
     </div>
 
     <!-- New notetype dialog -->
-    <Modal
-      :is-open="showNewDialog"
-      title="New Note Type"
-      size="sm"
-      @close="showNewDialog = false"
-    >
+    <Modal :is-open="showNewDialog" title="New Note Type" size="sm" @close="showNewDialog = false">
       <div class="new-form">
         <div class="form-group">
           <label class="form-label">Name</label>

--- a/src/components/SandboxedCard.vue
+++ b/src/components/SandboxedCard.vue
@@ -171,7 +171,7 @@ function setupIframe() {
   }
 
   // Wire up type-answer input fields
-  const typeans = doc.querySelector<HTMLInputElement>('input.typeans-input');
+  const typeans = doc.querySelector<HTMLInputElement>("input.typeans-input");
   if (typeans) {
     // Focus the input automatically
     setTimeout(() => typeans.focus(), 50);

--- a/src/components/StatsPanel.vue
+++ b/src/components/StatsPanel.vue
@@ -103,10 +103,7 @@ async function loadStats() {
   addedCardsData.value = computeAddedCards(normalized, startMs, endMs);
 
   // Aggregate totals
-  totalReviews.value = filteredDailyStats.reduce(
-    (sum, s) => sum + s.newCount + s.reviewCount,
-    0,
-  );
+  totalReviews.value = filteredDailyStats.reduce((sum, s) => sum + s.newCount + s.reviewCount, 0);
   totalTimeMs.value = filteredDailyStats.reduce((sum, s) => sum + s.totalTimeMs, 0);
   streak.value = computeStudyStreak(dailyStats);
 

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -3,7 +3,7 @@ import { type AppView, activeViewSig, reviewModeSig } from "../stores";
 import { canUndo, canRedo, undoDescription, redoDescription } from "../undoRedo";
 import { executeUndo, executeRedo } from "../undoRedoExecutor";
 import { Undo2, Redo2 } from "lucide-vue-next";
-import Tooltip from "../design-system/components/primitives/Tooltip.vue";
+import { Tooltip } from "../design-system";
 
 const emit = defineEmits<{
   undoToast: [message: string];
@@ -43,7 +43,15 @@ async function handleRedo() {
       <button
         v-for="tab in tabs"
         :key="tab.id"
-        :class="['tab', { 'tab--active': activeViewSig === tab.id || (tab.id === 'browse' && (activeViewSig === 'duplicates' || activeViewSig === 'check-db')) }]"
+        :class="[
+          'tab',
+          {
+            'tab--active':
+              activeViewSig === tab.id ||
+              (tab.id === 'browse' &&
+                (activeViewSig === 'duplicates' || activeViewSig === 'check-db')),
+          },
+        ]"
         @click="handleTabClick(tab.id)"
       >
         {{ tab.label }}
@@ -51,20 +59,14 @@ async function handleRedo() {
     </div>
     <div class="status-bar-actions">
       <Tooltip :text="undoDescription ? `Undo: ${undoDescription} (Ctrl+Z)` : 'Nothing to undo'">
-        <button
-          class="undo-redo-btn"
-          :disabled="!canUndo"
-          @click="handleUndo"
-        >
+        <button class="undo-redo-btn" :disabled="!canUndo" @click="handleUndo">
           <Undo2 :size="16" />
         </button>
       </Tooltip>
-      <Tooltip :text="redoDescription ? `Redo: ${redoDescription} (Ctrl+Shift+Z)` : 'Nothing to redo'">
-        <button
-          class="undo-redo-btn"
-          :disabled="!canRedo"
-          @click="handleRedo"
-        >
+      <Tooltip
+        :text="redoDescription ? `Redo: ${redoDescription} (Ctrl+Shift+Z)` : 'Nothing to redo'"
+      >
+        <button class="undo-redo-btn" :disabled="!canRedo" @click="handleRedo">
           <Redo2 :size="16" />
         </button>
       </Tooltip>

--- a/src/components/SyncProgressBar.vue
+++ b/src/components/SyncProgressBar.vue
@@ -33,7 +33,9 @@ const detail = computed(() => props.progress?.detail ?? "");
         :style="{ width: `${percentage}%` }"
       />
     </div>
-    <div class="sync-progress__percentage">{{ progress.fraction !== undefined ? `${percentage}%` : '' }}</div>
+    <div class="sync-progress__percentage">
+      {{ progress.fraction !== undefined ? `${percentage}%` : "" }}
+    </div>
   </div>
 </template>
 

--- a/src/components/notetype/ConvertNotetypeModal.vue
+++ b/src/components/notetype/ConvertNotetypeModal.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
-import Modal from "~/design-system/components/primitives/Modal.vue";
-import Button from "~/design-system/components/primitives/Button.vue";
+import { Button, Modal } from "~/design-system";
 
 export interface NotetypeInfo {
   id: string;
@@ -24,9 +23,7 @@ const emit = defineEmits<{
 const targetNtid = ref("");
 const fieldMapping = ref<Record<string, string>>({});
 
-const targetNotetype = computed(() =>
-  props.allNotetypes.find((nt) => nt.id === targetNtid.value),
-);
+const targetNotetype = computed(() => props.allNotetypes.find((nt) => nt.id === targetNtid.value));
 
 const availableTargets = computed(() =>
   props.allNotetypes.filter((nt) => nt.id !== props.sourceNotetype.id),
@@ -42,9 +39,7 @@ watch(targetNtid, () => {
   // Auto-map fields with matching names
   const map: Record<string, string> = {};
   for (const tf of target.fields) {
-    const match = props.sourceNotetype.fields.find(
-      (sf) => sf.toLowerCase() === tf.toLowerCase(),
-    );
+    const match = props.sourceNotetype.fields.find((sf) => sf.toLowerCase() === tf.toLowerCase());
     if (match) map[tf] = match;
   }
   fieldMapping.value = map;
@@ -97,11 +92,7 @@ function handleConvert() {
               @change="fieldMapping[targetField] = ($event.target as HTMLSelectElement).value"
             >
               <option value="">(empty)</option>
-              <option
-                v-for="sf in sourceNotetype.fields"
-                :key="sf"
-                :value="sf"
-              >
+              <option v-for="sf in sourceNotetype.fields" :key="sf" :value="sf">
                 {{ sf }}
               </option>
             </select>

--- a/src/components/notetype/FieldEditor.vue
+++ b/src/components/notetype/FieldEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { GripVertical, Plus, Trash2, ChevronDown, ChevronRight } from "lucide-vue-next";
-import Button from "~/design-system/components/primitives/Button.vue";
+import { Button } from "~/design-system";
 import type { Anki21bFieldConfig } from "~/ankiParser/anki21b/proto";
 
 export interface FieldEntry {
@@ -117,11 +117,7 @@ function handleDragEnd() {
           </template>
 
           <div class="field-actions">
-            <button
-              class="icon-btn"
-              title="Toggle options"
-              @click="toggleExpand(field.ord)"
-            >
+            <button class="icon-btn" title="Toggle options" @click="toggleExpand(field.ord)">
               <ChevronDown v-if="expandedField === field.ord" :size="14" />
               <ChevronRight v-else :size="14" />
             </button>
@@ -165,7 +161,11 @@ function handleDragEnd() {
             <input
               type="checkbox"
               :checked="field.config.excludeFromSearch"
-              @change="emit('updateFieldConfig', field.ord, { excludeFromSearch: !field.config.excludeFromSearch })"
+              @change="
+                emit('updateFieldConfig', field.ord, {
+                  excludeFromSearch: !field.config.excludeFromSearch,
+                })
+              "
             />
             <span>Exclude from search</span>
           </label>
@@ -177,7 +177,11 @@ function handleDragEnd() {
                 class="desc-input"
                 :value="field.config.description"
                 placeholder="Field description..."
-                @change="emit('updateFieldConfig', field.ord, { description: ($event.target as HTMLInputElement).value })"
+                @change="
+                  emit('updateFieldConfig', field.ord, {
+                    description: ($event.target as HTMLInputElement).value,
+                  })
+                "
               />
             </label>
           </div>
@@ -188,7 +192,11 @@ function handleDragEnd() {
                 type="text"
                 class="desc-input"
                 :value="field.config.fontName"
-                @change="emit('updateFieldConfig', field.ord, { fontName: ($event.target as HTMLInputElement).value })"
+                @change="
+                  emit('updateFieldConfig', field.ord, {
+                    fontName: ($event.target as HTMLInputElement).value,
+                  })
+                "
               />
             </label>
             <label>
@@ -199,7 +207,11 @@ function handleDragEnd() {
                 :value="field.config.fontSize"
                 min="8"
                 max="72"
-                @change="emit('updateFieldConfig', field.ord, { fontSize: Number(($event.target as HTMLInputElement).value) })"
+                @change="
+                  emit('updateFieldConfig', field.ord, {
+                    fontSize: Number(($event.target as HTMLInputElement).value),
+                  })
+                "
               />
             </label>
           </div>

--- a/src/components/notetype/TemplateEditor.vue
+++ b/src/components/notetype/TemplateEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import { Plus, Trash2 } from "lucide-vue-next";
-import Button from "~/design-system/components/primitives/Button.vue";
+import { Button } from "~/design-system";
 
 export interface TemplateEntry {
   ord: number;
@@ -25,8 +25,8 @@ const emit = defineEmits<{
 const selectedOrd = ref(0);
 const editSide = ref<"front" | "back">("front");
 
-const selectedTemplate = computed(() =>
-  props.templates.find((t) => t.ord === selectedOrd.value) ?? props.templates[0],
+const selectedTemplate = computed(
+  () => props.templates.find((t) => t.ord === selectedOrd.value) ?? props.templates[0],
 );
 
 // Reset selection if current template is removed
@@ -154,13 +154,28 @@ function handleAddTemplate() {
         <summary>Template syntax help</summary>
         <!-- v-pre prevents Vue from parsing mustache-like Anki template syntax -->
         <div v-pre class="help-content">
-          <p><code>{{FieldName}}</code> — Insert field value</p>
-          <p><code>{{#FieldName}}...{{/FieldName}}</code> — Conditional (show if field is non-empty)</p>
-          <p><code>{{^FieldName}}...{{/FieldName}}</code> — Inverted conditional (show if field is empty)</p>
-          <p><code>{{FrontSide}}</code> — Insert front template content (back template only)</p>
-          <p><code>{{type:FieldName}}</code> — Type-in-the-answer input</p>
-          <p><code>{{cloze:FieldName}}</code> — Cloze deletion</p>
-          <p><code>{{hint:FieldName}}</code> — Hint (click to reveal)</p>
+          <p>
+            <code>{{ FieldName }}</code> — Insert field value
+          </p>
+          <p>
+            <code>{{#FieldName}}...{{/FieldName}}</code> — Conditional (show if field is non-empty)
+          </p>
+          <p>
+            <code>{{^FieldName}}...{{/FieldName}}</code> — Inverted conditional (show if field is
+            empty)
+          </p>
+          <p>
+            <code>{{ FrontSide }}</code> — Insert front template content (back template only)
+          </p>
+          <p>
+            <code>{{type:FieldName}}</code> — Type-in-the-answer input
+          </p>
+          <p>
+            <code>{{cloze:FieldName}}</code> — Cloze deletion
+          </p>
+          <p>
+            <code>{{hint:FieldName}}</code> — Hint (click to reveal)
+          </p>
         </div>
       </details>
     </div>

--- a/src/components/stats/CalendarHeatmap.vue
+++ b/src/components/stats/CalendarHeatmap.vue
@@ -94,11 +94,7 @@ function handleMouseLeave() {
   <div class="chart-card">
     <h3 class="chart-title">Review Activity</h3>
     <div class="heatmap-wrapper">
-      <svg
-        :width="LABEL_WIDTH + WEEKS * TOTAL"
-        :height="7 * TOTAL"
-        class="heatmap-svg"
-      >
+      <svg :width="LABEL_WIDTH + WEEKS * TOTAL" :height="7 * TOTAL" class="heatmap-svg">
         <!-- Day labels -->
         <text
           v-for="(label, i) in dayLabels"

--- a/src/components/stats/StatsOverview.vue
+++ b/src/components/stats/StatsOverview.vue
@@ -29,7 +29,11 @@ function formatTime(ms: number): string {
     </div>
     <div class="stat-card">
       <div class="stat-value">
-        {{ props.trueRetention.total > 0 ? (props.trueRetention.retention * 100).toFixed(1) + "%" : "—" }}
+        {{
+          props.trueRetention.total > 0
+            ? (props.trueRetention.retention * 100).toFixed(1) + "%"
+            : "—"
+        }}
       </div>
       <div class="stat-label">True Retention</div>
     </div>
@@ -44,7 +48,12 @@ function formatTime(ms: number): string {
     <div class="stat-card">
       <div class="stat-value">
         {{
-          (props.cardCounts.new + props.cardCounts.learning + props.cardCounts.young + props.cardCounts.mature).toLocaleString()
+          (
+            props.cardCounts.new +
+            props.cardCounts.learning +
+            props.cardCounts.young +
+            props.cardCounts.mature
+          ).toLocaleString()
         }}
       </div>
       <div class="stat-label">Total Cards</div>

--- a/src/composables/useCommands.ts
+++ b/src/composables/useCommands.ts
@@ -257,8 +257,10 @@ export function useCommands(options: UseCommandsOptions = {}) {
   });
 }
 
-
-function buildCardActionCommands(ankiData: AnkiData | null, options: UseCommandsOptions): Command[] {
+function buildCardActionCommands(
+  ankiData: AnkiData | null,
+  options: UseCommandsOptions,
+): Command[] {
   const reviewCard = currentReviewCardSig.value;
   if (!reviewCard || activeViewSig.value !== "review" || reviewModeSig.value !== "studying")
     return [];
@@ -419,7 +421,10 @@ function buildCardInfoMetadata(
   type MetadataEntry = { label: string; value: string | ReturnType<typeof h> };
   const conditionalEntries: (MetadataEntry | null)[] = [
     displayInfo.ease !== undefined
-      ? { label: "Ease Factor", value: String(Math.round((displayInfo.ease as number) * 100)) + "%" }
+      ? {
+          label: "Ease Factor",
+          value: String(Math.round((displayInfo.ease as number) * 100)) + "%",
+        }
       : null,
     displayInfo.interval !== undefined
       ? { label: "Interval", value: displayInfo.interval + " days" }

--- a/src/composables/useImageOcclusionEditor.ts
+++ b/src/composables/useImageOcclusionEditor.ts
@@ -20,8 +20,8 @@ export function useImageOcclusionEditor(initialShapes: OcclusionShape[] = []) {
   let drawStartY = 0;
   let drawingShapeId: string | null = null;
 
-  const selectedShape = computed(() =>
-    shapes.value.find((s) => s.id === selectedShapeId.value) ?? null,
+  const selectedShape = computed(
+    () => shapes.value.find((s) => s.id === selectedShapeId.value) ?? null,
   );
 
   const nextOrdinal = computed(() => {
@@ -90,18 +90,14 @@ export function useImageOcclusionEditor(initialShapes: OcclusionShape[] = []) {
   }
 
   function moveShape(id: string, dx: number, dy: number) {
-    shapes.value = shapes.value.map((s) =>
-      s.id === id ? { ...s, x: s.x + dx, y: s.y + dy } : s,
-    );
+    shapes.value = shapes.value.map((s) => (s.id === id ? { ...s, x: s.x + dx, y: s.y + dy } : s));
   }
 
   function resizeShape(
     id: string,
     bounds: { x: number; y: number; width: number; height: number },
   ) {
-    shapes.value = shapes.value.map((s) =>
-      s.id === id ? { ...s, ...bounds } : s,
-    );
+    shapes.value = shapes.value.map((s) => (s.id === id ? { ...s, ...bounds } : s));
   }
 
   function deleteShape(id: string) {

--- a/src/composables/useVirtualScroll.ts
+++ b/src/composables/useVirtualScroll.ts
@@ -6,7 +6,11 @@ interface VirtualScrollOptions<T> {
   overscan?: number;
 }
 
-export function useVirtualScroll<T>({ items, rowHeight = 30, overscan = 10 }: VirtualScrollOptions<T>) {
+export function useVirtualScroll<T>({
+  items,
+  rowHeight = 30,
+  overscan = 10,
+}: VirtualScrollOptions<T>) {
   const scrollContainerRef = ref<HTMLElement | null>(null);
   const scrollTop = ref(0);
   const containerHeight = ref(600);

--- a/src/deckLibrary.ts
+++ b/src/deckLibrary.ts
@@ -94,7 +94,6 @@ export function removeCachedFileEntry(cachedFiles: CachedFileEntry[], name: stri
   return cachedFiles.filter((file) => file.name !== name);
 }
 
-
 function formatAddedDate(timestamp: number): string {
   return new Date(timestamp).toLocaleDateString(undefined, {
     month: "short",

--- a/src/design-system/components/primitives/Modal.vue
+++ b/src/design-system/components/primitives/Modal.vue
@@ -65,7 +65,12 @@ function handleContentClick(e: MouseEvent) {
       <div v-if="title || showCloseButton" class="ds-modal__header">
         <h2 v-if="title" class="ds-modal__title">{{ title }}</h2>
         <div v-else />
-        <button v-if="showCloseButton" class="ds-modal__close" aria-label="Close" @click="emit('close')">
+        <button
+          v-if="showCloseButton"
+          class="ds-modal__close"
+          aria-label="Close"
+          @click="emit('close')"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
             <path
               d="M289.94 256l95-95A24 24 0 0 0 351 127l-95 95l-95-95a24 24 0 0 0-34 34l95 95l-95 95a24 24 0 1 0 34 34l95-95l95 95a24 24 0 0 0 34-34z"

--- a/src/lib/ankiSync.ts
+++ b/src/lib/ankiSync.ts
@@ -471,10 +471,14 @@ export async function uploadMedia(
     form.append("k", hkey);
     form.append("data", zipBlob, "media.zip");
 
-    const uploadResponse = await fetchWithTimeout(`${base}/msync/uploadChanges`, {
-      method: "POST",
-      body: form,
-    }, TRANSFER_TIMEOUT_MS);
+    const uploadResponse = await fetchWithTimeout(
+      `${base}/msync/uploadChanges`,
+      {
+        method: "POST",
+        body: form,
+      },
+      TRANSFER_TIMEOUT_MS,
+    );
 
     if (!uploadResponse.ok) {
       const body = await uploadResponse.text().catch(() => "(unreadable)");
@@ -535,10 +539,14 @@ export async function uploadCollection(
   form.append("data", new Blob([sqliteBytes as BlobPart]), "collection.anki2");
   form.append("c", "0");
 
-  const response = await fetchWithTimeout(`${base}/sync/upload`, {
-    method: "POST",
-    body: form,
-  }, TRANSFER_TIMEOUT_MS);
+  const response = await fetchWithTimeout(
+    `${base}/sync/upload`,
+    {
+      method: "POST",
+      body: form,
+    },
+    TRANSFER_TIMEOUT_MS,
+  );
 
   if (response.status === 401 || response.status === 403) {
     throw new Error("Authentication expired. Please log in again.");

--- a/src/lib/autoSync.ts
+++ b/src/lib/autoSync.ts
@@ -181,4 +181,3 @@ export function startAutoSync() {
     visibilityListenerAdded = true;
   }
 }
-

--- a/src/lib/normalSync.ts
+++ b/src/lib/normalSync.ts
@@ -466,10 +466,7 @@ async function applyDeckConfigsToScheduler(
   const { DEFAULT_SM2_PARAMS } = await import("../scheduler/types");
 
   // Detect format
-  const hasNotetypes = db.exec(
-    "SELECT name FROM sqlite_master WHERE type='table' AND name='notetypes'",
-  );
-  const isAnki21b = (hasNotetypes[0]?.values.length ?? 0) > 0;
+  const isAnki21b = isAnki21bFormat(db);
 
   // Collect all deck configs
   const rawDconfSchema = z
@@ -508,17 +505,27 @@ async function applyDeckConfigsToScheduler(
   const configs: Map<string, RawDconf> = isAnki21b
     ? new Map(
         (db.exec("SELECT id, config FROM deck_config")[0]?.values ?? [])
-          .map((row) => [String(row[0]), rawDconfSchema.safeParse(safeJsonParse(String(row[1] ?? "")))] as const)
+          .map(
+            (row) =>
+              [
+                String(row[0]),
+                rawDconfSchema.safeParse(safeJsonParse(String(row[1] ?? ""))),
+              ] as const,
+          )
           .filter((entry): entry is [string, { success: true; data: RawDconf }] => entry[1].success)
           .map(([id, parsed]) => [id, parsed.data]),
       )
     : (() => {
-        const outer = safeJsonParse(String(db.exec("SELECT dconf FROM col")[0]?.values[0]?.[0] ?? ""));
+        const outer = safeJsonParse(
+          String(db.exec("SELECT dconf FROM col")[0]?.values[0]?.[0] ?? ""),
+        );
         if (!outer || typeof outer !== "object") return new Map<string, RawDconf>();
         return new Map(
           Object.entries(outer)
             .map(([id, raw]) => [id, rawDconfSchema.safeParse(raw)] as const)
-            .filter((entry): entry is [string, { success: true; data: RawDconf }] => entry[1].success)
+            .filter(
+              (entry): entry is [string, { success: true; data: RawDconf }] => entry[1].success,
+            )
             .map(([id, parsed]) => [id, parsed.data]),
         );
       })();

--- a/src/lib/notetypeOps.ts
+++ b/src/lib/notetypeOps.ts
@@ -92,7 +92,9 @@ export function createNotetype(db: Database, options: CreateNotetypeOptions): st
   const configBlob = encodeNotesTypeConfig({
     kind: options.kind ?? 0,
     originalStockKind: options.originalStockKind ?? 0,
-    css: options.css ?? ".card {\n  font-family: arial;\n  font-size: 20px;\n  text-align: center;\n  color: black;\n  background-color: white;\n}\n",
+    css:
+      options.css ??
+      ".card {\n  font-family: arial;\n  font-size: 20px;\n  text-align: center;\n  color: black;\n  background-color: white;\n}\n",
   });
 
   db.run("INSERT INTO notetypes (id, name, mtime_secs, usn, config) VALUES (?, ?, ?, -1, ?)", [
@@ -323,11 +325,9 @@ export function addTemplate(
   );
 
   // Generate a card for each existing note of this notetype
-  const notes = executeQueryAll<{ id: number }>(
-    db,
-    "SELECT id FROM notes WHERE mid=?",
-    [ntidNum] as unknown as Record<string, string>,
-  );
+  const notes = executeQueryAll<{ id: number }>(db, "SELECT id FROM notes WHERE mid=?", [
+    ntidNum,
+  ] as unknown as Record<string, string>);
 
   for (const note of notes) {
     const cardId = generateId();
@@ -438,9 +438,7 @@ export function convertNotes(
   const targetTemplates = getTemplatesForNotetype(db, targetNtid);
 
   // Get source notetype's fields (from the first note)
-  const firstNote = db.exec("SELECT cast(mid as text) as mid FROM notes WHERE id=?", [
-    noteIds[0]!,
-  ]);
+  const firstNote = db.exec("SELECT cast(mid as text) as mid FROM notes WHERE id=?", [noteIds[0]!]);
   const sourceMid = String(firstNote[0]?.values[0]?.[0]);
   const sourceFields = getFieldsForNotetype(db, sourceMid);
   const sourceFieldNames = sourceFields.map((f) => f.name);

--- a/src/lib/syncMerge.ts
+++ b/src/lib/syncMerge.ts
@@ -74,9 +74,62 @@ type CardRow = [
 
 export const chunkSchema = z.object({
   done: z.boolean(),
-  revlog: z.array(z.tuple([z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number()])).default([]),
-  cards: z.array(z.tuple([z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.number(), z.string()])).default([]),
-  notes: z.array(z.tuple([z.number(), z.string(), z.number(), z.number(), z.number(), z.string(), z.string(), z.string(), z.coerce.number(), z.number(), z.string()])).default([]),
+  revlog: z
+    .array(
+      z.tuple([
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+      ]),
+    )
+    .default([]),
+  cards: z
+    .array(
+      z.tuple([
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.string(),
+      ]),
+    )
+    .default([]),
+  notes: z
+    .array(
+      z.tuple([
+        z.number(),
+        z.string(),
+        z.number(),
+        z.number(),
+        z.number(),
+        z.string(),
+        z.string(),
+        z.string(),
+        z.coerce.number(),
+        z.number(),
+        z.string(),
+      ]),
+    )
+    .default([]),
 });
 
 export type Chunk = z.infer<typeof chunkSchema>;
@@ -192,10 +245,7 @@ function mergeColJsonField<T extends { id: number; mod?: number }>(
  * compared to the local version. A mismatch means cards could become corrupt
  * and a full sync is required (matching desktop Anki's ResyncRequired behavior).
  */
-function validateNotetypeSchema(
-  localModel: SyncModel,
-  remoteModel: SyncModel,
-): void {
+function validateNotetypeSchema(localModel: SyncModel, remoteModel: SyncModel): void {
   const localFlds = Array.isArray(localModel.flds) ? localModel.flds.length : -1;
   const remoteFlds = Array.isArray(remoteModel.flds) ? remoteModel.flds.length : -1;
   const localTmpls = Array.isArray(localModel.tmpls) ? localModel.tmpls.length : -1;
@@ -374,7 +424,11 @@ export function applyRemoteUnchunkedChanges(
   }
 }
 
-function applyRemoteUnchunkedAnki2(db: Database, changes: UnchunkedChanges, localIsNewer: boolean): void {
+function applyRemoteUnchunkedAnki2(
+  db: Database,
+  changes: UnchunkedChanges,
+  localIsNewer: boolean,
+): void {
   // Models — merge with mod-time conflict resolution + schema validation
   if (changes.models.length > 0) {
     const local = getColJson<Record<string, SyncModel>>(db, "models", {});
@@ -419,7 +473,11 @@ function applyRemoteUnchunkedAnki2(db: Database, changes: UnchunkedChanges, loca
   }
 }
 
-function applyRemoteUnchunkedAnki21b(db: Database, changes: UnchunkedChanges, localIsNewer: boolean): void {
+function applyRemoteUnchunkedAnki21b(
+  db: Database,
+  changes: UnchunkedChanges,
+  localIsNewer: boolean,
+): void {
   // Models (notetypes) — stored in notetypes table, with schema validation
   for (const m of changes.models) {
     const mtimeSecs = "mtime_secs" in m ? Number(m.mtime_secs) : undefined;
@@ -639,28 +697,55 @@ export function* buildLocalChunks(db: Database): Generator<Chunk> {
     "SELECT id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data FROM cards WHERE usn=-1",
   );
   const pendingCards: CardRow[] = (cardsResult[0]?.values ?? []).map((row) => [
-    Number(row[0]), Number(row[1]), Number(row[2]), Number(row[3]),
-    Number(row[4]), Number(row[5]), Number(row[6]), Number(row[7]),
-    Number(row[8]), Number(row[9]), Number(row[10]), Number(row[11]),
-    Number(row[12]), Number(row[13]), Number(row[14]), Number(row[15]),
-    Number(row[16]), String(row[17] ?? ""),
+    Number(row[0]),
+    Number(row[1]),
+    Number(row[2]),
+    Number(row[3]),
+    Number(row[4]),
+    Number(row[5]),
+    Number(row[6]),
+    Number(row[7]),
+    Number(row[8]),
+    Number(row[9]),
+    Number(row[10]),
+    Number(row[11]),
+    Number(row[12]),
+    Number(row[13]),
+    Number(row[14]),
+    Number(row[15]),
+    Number(row[16]),
+    String(row[17] ?? ""),
   ]);
 
   const notesResult = db.exec(
     "SELECT id, guid, mid, mod, usn, tags, flds, sfld, csum, flags, data FROM notes WHERE usn=-1",
   );
   const pendingNotes: NoteRow[] = (notesResult[0]?.values ?? []).map((row) => [
-    Number(row[0]), String(row[1] ?? ""), Number(row[2]), Number(row[3]),
-    Number(row[4]), String(row[5] ?? ""), String(row[6] ?? ""), String(row[7] ?? ""),
-    Number(row[8]), Number(row[9]), String(row[10] ?? ""),
+    Number(row[0]),
+    String(row[1] ?? ""),
+    Number(row[2]),
+    Number(row[3]),
+    Number(row[4]),
+    String(row[5] ?? ""),
+    String(row[6] ?? ""),
+    String(row[7] ?? ""),
+    Number(row[8]),
+    Number(row[9]),
+    String(row[10] ?? ""),
   ]);
 
   const revlogResult = db.exec(
     "SELECT id, cid, usn, ease, ivl, lastIvl, factor, time, type FROM revlog WHERE usn=-1",
   );
   const pendingRevlog: RevlogRow[] = (revlogResult[0]?.values ?? []).map((row) => [
-    Number(row[0]), Number(row[1]), Number(row[2]), Number(row[3]),
-    Number(row[4]), Number(row[5]), Number(row[6]), Number(row[7]),
+    Number(row[0]),
+    Number(row[1]),
+    Number(row[2]),
+    Number(row[3]),
+    Number(row[4]),
+    Number(row[5]),
+    Number(row[6]),
+    Number(row[7]),
     Number(row[8]),
   ]);
 

--- a/src/lib/syncWrite.ts
+++ b/src/lib/syncWrite.ts
@@ -1,6 +1,7 @@
 import { createDatabase } from "~/utils/sql";
 import type { CardReviewState } from "../scheduler/types";
 import { MS_PER_DAY } from "../utils/constants";
+import { isAnki21bFormat } from "./syncMerge";
 
 /**
  * SM-2 card state shape (from anki-sm2-algorithm.ts).
@@ -160,11 +161,7 @@ interface DeckStepInfo {
 export function readDeckStepCounts(db: import("sql.js").Database): Map<number, DeckStepInfo> {
   const result = new Map<number, DeckStepInfo>();
 
-  // Detect format
-  const hasNotetypes = db.exec(
-    "SELECT name FROM sqlite_master WHERE type='table' AND name='notetypes'",
-  );
-  const isAnki21b = (hasNotetypes[0]?.values.length ?? 0) > 0;
+  const isAnki21b = isAnki21bFormat(db);
 
   if (isAnki21b) {
     const dcResult = db.exec("SELECT id, config FROM deck_config");
@@ -173,10 +170,13 @@ export function readDeckStepCounts(db: import("sql.js").Database): Map<number, D
         const id = row[0] as number;
         try {
           const cfg = JSON.parse(row[1] as string);
-          return [id, {
-            learnSteps: Array.isArray(cfg.new?.delays) ? cfg.new.delays.length : 2,
-            relearnSteps: Array.isArray(cfg.lapse?.delays) ? cfg.lapse.delays.length : 1,
-          }];
+          return [
+            id,
+            {
+              learnSteps: Array.isArray(cfg.new?.delays) ? cfg.new.delays.length : 2,
+              relearnSteps: Array.isArray(cfg.lapse?.delays) ? cfg.lapse.delays.length : 1,
+            },
+          ];
         } catch {
           return [id, { learnSteps: 2, relearnSteps: 1 }];
         }
@@ -191,7 +191,9 @@ export function readDeckStepCounts(db: import("sql.js").Database): Map<number, D
         const confId = common.conf ?? common.config_id ?? 1;
         const steps = configMap.get(confId);
         return steps ? [[deckId, steps] as const] : [];
-      } catch { return []; }
+      } catch {
+        return [];
+      }
     });
     deckEntries.forEach(([deckId, steps]) => result.set(deckId, steps));
   } else {
@@ -199,20 +201,29 @@ export function readDeckStepCounts(db: import("sql.js").Database): Map<number, D
     const colResult = db.exec("SELECT dconf, decks FROM col");
     if (colResult[0]?.values[0]) {
       try {
-        const dconf = JSON.parse(colResult[0].values[0][0] as string) as Record<string, {
-          new?: { delays?: number[] };
-          lapse?: { delays?: number[] };
-        }>;
-        const decks = JSON.parse(colResult[0].values[0][1] as string) as Record<string, {
-          id: number;
-          conf?: string | number;
-        }>;
+        const dconf = JSON.parse(colResult[0].values[0][0] as string) as Record<
+          string,
+          {
+            new?: { delays?: number[] };
+            lapse?: { delays?: number[] };
+          }
+        >;
+        const decks = JSON.parse(colResult[0].values[0][1] as string) as Record<
+          string,
+          {
+            id: number;
+            conf?: string | number;
+          }
+        >;
 
         const configMap = new Map<string, DeckStepInfo>(
-          Object.entries(dconf).map(([id, cfg]) => [id, {
-            learnSteps: Array.isArray(cfg.new?.delays) ? cfg.new.delays.length : 2,
-            relearnSteps: Array.isArray(cfg.lapse?.delays) ? cfg.lapse.delays.length : 1,
-          }]),
+          Object.entries(dconf).map(([id, cfg]) => [
+            id,
+            {
+              learnSteps: Array.isArray(cfg.new?.delays) ? cfg.new.delays.length : 2,
+              relearnSteps: Array.isArray(cfg.lapse?.delays) ? cfg.lapse.delays.length : 1,
+            },
+          ]),
         );
 
         Object.values(decks)
@@ -221,7 +232,9 @@ export function readDeckStepCounts(db: import("sql.js").Database): Map<number, D
             return steps ? [[deck.id, steps] as const] : [];
           })
           .forEach(([deckId, steps]) => result.set(deckId, steps));
-      } catch { /* use defaults */ }
+      } catch {
+        /* use defaults */
+      }
     }
   }
 
@@ -251,6 +264,19 @@ export async function mergeIndexedDBToSqlite(
   // Build a map of deckId → deck config step counts from SQLite
   const deckStepCounts = readDeckStepCounts(db);
 
+  // Pre-fetch odue/odid/did for all cards in one query to avoid N+1
+  const cardInfoMap = new Map<number, { odue: number; odid: number; did: number }>();
+  const allRows = db.exec("SELECT id, odue, odid, did FROM cards");
+  if (allRows[0]) {
+    for (const row of allRows[0].values) {
+      cardInfoMap.set(row[0] as number, {
+        odue: (row[1] as number) ?? 0,
+        odid: (row[2] as number) ?? 0,
+        did: (row[3] as number) ?? 0,
+      });
+    }
+  }
+
   // Update each reviewed card in the SQLite database
   const updateStmt = db.prepare(CARD_UPDATE_SQL);
 
@@ -268,19 +294,11 @@ export async function mergeIndexedDBToSqlite(
       card.queueOverride === QUEUE_USER_BURIED;
     if (!card.lastReviewed && !hasOverride && card.flags === undefined) continue;
 
-    // Read existing odue/odid from SQLite to preserve filtered deck state
-    let odue = 0;
-    let odid = 0;
-    const existingRow = db.exec(
-      "SELECT odue, odid, did FROM cards WHERE id=?",
-      [ankiCardId],
-    );
-    let cardDeckId: number | undefined;
-    if (existingRow[0]?.values[0]) {
-      odue = (existingRow[0].values[0][0] as number) ?? 0;
-      odid = (existingRow[0].values[0][1] as number) ?? 0;
-      cardDeckId = (existingRow[0].values[0][2] as number) ?? undefined;
-    }
+    // Look up existing odue/odid/did from pre-fetched map
+    const existing = cardInfoMap.get(ankiCardId);
+    const odue = existing?.odue ?? 0;
+    const odid = existing?.odid ?? 0;
+    const cardDeckId: number | undefined = existing?.did;
 
     const state = card.cardState as SM2CardState;
     const type = phaseToType(state.phase);
@@ -479,9 +497,7 @@ async function insertGraves(db: import("sql.js").Database, deckId: string): Prom
     ...deletedDecks.map((d) => [Number(d.deletedDeckId), 2] as [number, number]),
   ];
 
-  graves
-    .filter(([id]) => !isNaN(id))
-    .forEach(([id, type]) => insertStmt.run([-1, id, type]));
+  graves.filter(([id]) => !isNaN(id)).forEach(([id, type]) => insertStmt.run([-1, id, type]));
 
   insertStmt.free();
 }

--- a/src/scheduler/__tests__/anki-sm2-algorithm.prop.test.ts
+++ b/src/scheduler/__tests__/anki-sm2-algorithm.prop.test.ts
@@ -253,24 +253,20 @@ describe("SM2 Algorithm — property-based tests", () => {
   describe("leech detection", () => {
     it("leech triggers at exact threshold boundary", () => {
       fc.assert(
-        fc.property(
-          fc.integer({ min: 2, max: 20 }),
-          arbCardId,
-          (threshold, cardId) => {
-            const custom = new AnkiSM2Algorithm({ leechThreshold: threshold });
-            const card: AnkiSM2CardState = {
-              phase: "review",
-              step: 0,
-              ease: 2.5,
-              interval: 10,
-              due: Date.now(),
-              lapses: threshold - 1,
-              reps: 50,
-            };
-            const result = custom.reviewCard(card, "again", cardId);
-            expect((result.reviewLog as AnkiSM2ReviewLog).leeched).toBe(true);
-          },
-        ),
+        fc.property(fc.integer({ min: 2, max: 20 }), arbCardId, (threshold, cardId) => {
+          const custom = new AnkiSM2Algorithm({ leechThreshold: threshold });
+          const card: AnkiSM2CardState = {
+            phase: "review",
+            step: 0,
+            ease: 2.5,
+            interval: 10,
+            due: Date.now(),
+            lapses: threshold - 1,
+            reps: 50,
+          };
+          const result = custom.reviewCard(card, "again", cardId);
+          expect((result.reviewLog as AnkiSM2ReviewLog).leeched).toBe(true);
+        }),
         { numRuns: NUM_RUNS ?? 50 },
       );
     });

--- a/src/scheduler/__tests__/db.test.ts
+++ b/src/scheduler/__tests__/db.test.ts
@@ -252,8 +252,14 @@ describe("ReviewDB", () => {
 
     it("should preserve different sort orders", async () => {
       const sortOrders = [
-        "random", "orderAdded", "orderDue", "intervalAsc",
-        "intervalDesc", "easeAsc", "easeDesc", "lapsesDesc",
+        "random",
+        "orderAdded",
+        "orderDue",
+        "intervalAsc",
+        "intervalDesc",
+        "easeAsc",
+        "easeDesc",
+        "lapsesDesc",
       ] as const;
 
       for (const sortOrder of sortOrders) {

--- a/src/scheduler/db.ts
+++ b/src/scheduler/db.ts
@@ -197,9 +197,7 @@ class ReviewDB {
   /**
    * Batch-patch multiple cards in a single transaction.
    */
-  async patchCards(
-    patches: { cardId: string; patch: Partial<CardReviewState> }[],
-  ): Promise<void> {
+  async patchCards(patches: { cardId: string; patch: Partial<CardReviewState> }[]): Promise<void> {
     if (patches.length === 0) return;
     const db = await this.ensureInit();
     return new Promise((resolve, reject) => {

--- a/src/scheduler/queue.ts
+++ b/src/scheduler/queue.ts
@@ -122,7 +122,10 @@ export class ReviewQueue {
     const cards = await reviewDB.getCardsForDeck(this.deckId);
     const patches = cards
       .filter((c) => c.queueOverride === QUEUE_USER_BURIED)
-      .map((c) => ({ cardId: c.cardId, patch: { queueOverride: undefined } as Partial<import("./types").CardReviewState> }));
+      .map((c) => ({
+        cardId: c.cardId,
+        patch: { queueOverride: undefined } as Partial<import("./types").CardReviewState>,
+      }));
     await reviewDB.patchCards(patches);
   }
 
@@ -198,7 +201,9 @@ export class ReviewQueue {
     const dueDateCache = new Map<string, number>(
       activeCards.flatMap((card) => {
         try {
-          return [[card.cardId, this.algorithm.getDueDate(card.reviewState.cardState).getTime()] as const];
+          return [
+            [card.cardId, this.algorithm.getDueDate(card.reviewState.cardState).getTime()] as const,
+          ];
         } catch (error) {
           console.error("Error processing card in queue:", error, card);
           return [];

--- a/src/search/__tests__/engine.prop.test.ts
+++ b/src/search/__tests__/engine.prop.test.ts
@@ -12,11 +12,10 @@ import { NUM_RUNS } from "~/test/pbt";
 // ── Custom arbitraries ──
 
 const arbSearchableCard: fc.Arbitrary<SearchableCard> = fc.record({
-  fields: fc.dictionary(
-    fc.stringMatching(/^[A-Za-z]{1,8}$/),
-    fc.string({ maxLength: 50 }),
-    { minKeys: 1, maxKeys: 3 },
-  ),
+  fields: fc.dictionary(fc.stringMatching(/^[A-Za-z]{1,8}$/), fc.string({ maxLength: 50 }), {
+    minKeys: 1,
+    maxKeys: 3,
+  }),
   deck: fc.stringMatching(/^[A-Za-z]{1,15}$/),
   tags: fc.array(fc.stringMatching(/^[a-z]{1,10}$/), { maxLength: 3 }),
   templateName: fc.stringMatching(/^[A-Za-z ]{1,15}$/),
@@ -246,11 +245,7 @@ describe("Search Engine — property-based tests", () => {
         fc.property(arbSearchableCard, (card) => {
           const isDue = matchExpr(card, { type: "is", value: "due" }, collectionCreationTime);
           const isLearn = matchExpr(card, { type: "is", value: "learn" }, collectionCreationTime);
-          const isReview = matchExpr(
-            card,
-            { type: "is", value: "review" },
-            collectionCreationTime,
-          );
+          const isReview = matchExpr(card, { type: "is", value: "review" }, collectionCreationTime);
           expect(isDue).toBe(isLearn || isReview);
         }),
         { numRuns: NUM_RUNS ?? 200 },

--- a/src/search/__tests__/engine.test.ts
+++ b/src/search/__tests__/engine.test.ts
@@ -301,13 +301,17 @@ describe("matchExpr", () => {
     it("AND requires both conditions", () => {
       const card = makeCard({ queueName: "new", deck: "Biology" });
       expect(matchExpr(card, parseSearch("is:new deck:Biology")!, COLLECTION_CREATION)).toBe(true);
-      expect(matchExpr(card, parseSearch("is:new deck:Chemistry")!, COLLECTION_CREATION)).toBe(false);
+      expect(matchExpr(card, parseSearch("is:new deck:Chemistry")!, COLLECTION_CREATION)).toBe(
+        false,
+      );
     });
 
     it("OR requires either condition", () => {
       const card = makeCard({ queueName: "new" });
       expect(matchExpr(card, parseSearch("is:new OR is:review")!, COLLECTION_CREATION)).toBe(true);
-      expect(matchExpr(card, parseSearch("is:review OR is:suspended")!, COLLECTION_CREATION)).toBe(false);
+      expect(matchExpr(card, parseSearch("is:review OR is:suspended")!, COLLECTION_CREATION)).toBe(
+        false,
+      );
     });
   });
 });

--- a/src/search/engine.ts
+++ b/src/search/engine.ts
@@ -25,8 +25,16 @@ export type SearchExpr =
 export const IS_VALUES = ["new", "learn", "review", "due", "suspended", "buried"] as const;
 
 export const QUALIFIERS = [
-  "deck:", "tag:", "is:", "flag:", "card:", "note:",
-  "prop:", "added:", "edited:", "rated:",
+  "deck:",
+  "tag:",
+  "is:",
+  "flag:",
+  "card:",
+  "note:",
+  "prop:",
+  "added:",
+  "edited:",
+  "rated:",
 ] as const;
 
 // ── Searchable card interface ──
@@ -401,28 +409,26 @@ export function matchExpr(
 
 // ── Helper to convert AnkiData card to SearchableCard ──
 
-export function ankiCardToSearchable(
-  card: {
-    values: Record<string, string | null>;
-    tags: string[];
-    templates: { name: string }[];
-    deckName: string;
-    guid: string;
-    scheduling: {
-      queueName: string;
-      flags: number;
-      easeFactor: number | null;
-      ivl: number;
-      due: number;
-      dueType: string;
-      reps: number;
-      lapses: number;
-    } | null;
-    ankiCardId?: number;
-    noteMod?: number;
-    cardMod?: number;
-  },
-): SearchableCard {
+export function ankiCardToSearchable(card: {
+  values: Record<string, string | null>;
+  tags: string[];
+  templates: { name: string }[];
+  deckName: string;
+  guid: string;
+  scheduling: {
+    queueName: string;
+    flags: number;
+    easeFactor: number | null;
+    ivl: number;
+    due: number;
+    dueType: string;
+    reps: number;
+    lapses: number;
+  } | null;
+  ankiCardId?: number;
+  noteMod?: number;
+  cardMod?: number;
+}): SearchableCard {
   const fields: Record<string, string> = {};
   for (const [k, v] of Object.entries(card.values)) {
     fields[k] = stripHtml(v);

--- a/src/stats/computeStats.ts
+++ b/src/stats/computeStats.ts
@@ -92,9 +92,8 @@ export function computeAddedCards(
   startMs: number,
   endMs: number,
 ): DayCount[] {
-  const scaffoldDates = Array.from(
-    { length: Math.ceil((endMs - startMs) / MS_PER_DAY) },
-    (_, i) => formatDate(startMs + i * MS_PER_DAY),
+  const scaffoldDates = Array.from({ length: Math.ceil((endMs - startMs) / MS_PER_DAY) }, (_, i) =>
+    formatDate(startMs + i * MS_PER_DAY),
   );
 
   const cardsInRange = cards.filter((c) => c.createdAt >= startMs && c.createdAt < endMs);

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -49,7 +49,15 @@ function revokeOldMediaUrls() {
 }
 
 // View state
-export type AppView = "review" | "browse" | "create" | "sync" | "duplicates" | "stats" | "backup" | "check-db";
+export type AppView =
+  | "review"
+  | "browse"
+  | "create"
+  | "sync"
+  | "duplicates"
+  | "stats"
+  | "backup"
+  | "check-db";
 export const activeViewSig = ref<AppView>("review");
 export const reviewModeSig = ref<"deck-list" | "studying">("deck-list");
 
@@ -287,7 +295,9 @@ export async function loadSyncedCollection(bytes: Uint8Array, mediaBlobs?: Map<s
     const entries = [...mediaBlobs];
     entries.forEach(([filename]) => newMediaFilenames.add(filename));
     mediaFiles = new Map(entries.map(([filename, blob]) => [filename, URL.createObjectURL(blob)]));
-    await Promise.all(entries.map(([filename, blob]) => cache.put(mediaCachePath(filename), new Response(blob))));
+    await Promise.all(
+      entries.map(([filename, blob]) => cache.put(mediaCachePath(filename), new Response(blob))),
+    );
   }
 
   // Clear old media entries that weren't replaced by new ones
@@ -1048,9 +1058,10 @@ export function moveToNextReviewCard() {
   // Third priority: soonest learning card (even if not yet due)
   const soonest = dueCards
     .filter((c) => c.cardId !== currentId && queue?.isCardInLearning(c))
-    .toSorted((a, b) =>
-      (a.reviewState.cardState as { due: number }).due -
-      (b.reviewState.cardState as { due: number }).due,
+    .toSorted(
+      (a, b) =>
+        (a.reviewState.cardState as { due: number }).due -
+        (b.reviewState.cardState as { due: number }).due,
     )[0];
   if (soonest) {
     currentReviewCardSig.value = soonest;
@@ -1366,7 +1377,9 @@ export async function updateNote(
  * Open the DB from current deck input, run a mutation callback, then persist and re-parse.
  * This is the standard pattern for all notetype (and other schema) mutations.
  */
-export async function withDbMutation(mutate: (db: import("sql.js").Database) => void): Promise<void> {
+export async function withDbMutation(
+  mutate: (db: import("sql.js").Database) => void,
+): Promise<void> {
   const input = activeDeckInputSig.value;
   if (input?.kind !== "sqlite") return;
 
@@ -1385,7 +1398,10 @@ const BASE91_CHARS =
   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&()*+,-.:;<=>?@[]^_`{|}~";
 
 function generateGuid(): string {
-  return Array.from({ length: 10 }, () => BASE91_CHARS[Math.floor(Math.random() * BASE91_CHARS.length)]).join("");
+  return Array.from(
+    { length: 10 },
+    () => BASE91_CHARS[Math.floor(Math.random() * BASE91_CHARS.length)],
+  ).join("");
 }
 
 /**
@@ -1398,7 +1414,10 @@ export async function getOrCreateIONotetype(): Promise<string> {
 
   // Check existing notetypes for IO
   for (const nt of data.notesTypes) {
-    if ("originalStockKind" in nt && (nt as { originalStockKind?: number }).originalStockKind === 6) {
+    if (
+      "originalStockKind" in nt &&
+      (nt as { originalStockKind?: number }).originalStockKind === 6
+    ) {
       return String(nt.id);
     }
   }
@@ -1474,16 +1493,26 @@ export async function addNote(options: {
     );
 
     // Build flds string (field values joined by \x1f in field order)
-    const flds = fieldRows
-      .map((f) => options.fields[f.name] ?? "")
-      .join("\x1f");
+    const flds = fieldRows.map((f) => options.fields[f.name] ?? "").join("\x1f");
 
     const { sfld, csum } = computeSortField(options.fields[fieldRows[0]?.name ?? ""] ?? "");
 
     // Insert note
     db.run(
       "INSERT INTO notes (id, guid, mid, mod, usn, tags, flds, sfld, csum, flags, data) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-      [noteId, guid, options.notetypeId, mod, -1, formatTagsStr(options.tags), flds, sfld, csum, 0, ""],
+      [
+        noteId,
+        guid,
+        options.notetypeId,
+        mod,
+        -1,
+        formatTagsStr(options.tags),
+        flds,
+        sfld,
+        csum,
+        0,
+        "",
+      ],
     );
 
     // Insert cards (one per template, or numCards for cloze)
@@ -1590,9 +1619,19 @@ export async function importPresetJson(json: string): Promise<string | null> {
 
     // Pick only known keys to prevent injection of arbitrary properties
     const KNOWN_KEYS = [
-      "enabled", "algorithm", "dailyNewLimit", "dailyReviewLimit",
-      "showAheadOfSchedule", "learnAheadMins", "rolloverHour",
-      "sm2Params", "fsrsParams", "autoAdvance", "easyDays", "loadBalancer", "presetId",
+      "enabled",
+      "algorithm",
+      "dailyNewLimit",
+      "dailyReviewLimit",
+      "showAheadOfSchedule",
+      "learnAheadMins",
+      "rolloverHour",
+      "sm2Params",
+      "fsrsParams",
+      "autoAdvance",
+      "easyDays",
+      "loadBalancer",
+      "presetId",
     ];
     const sanitized: Record<string, unknown> = {};
     for (const key of KNOWN_KEYS) {
@@ -1649,8 +1688,9 @@ function gatherFilteredCards(config: FilteredDeckConfig): number[] {
   const expr = parseSearch(config.query);
   const matching = data.cards
     .map((card, index) => ({ index, card }))
-    .filter(({ card }) =>
-      !expr || matchExpr(ankiCardToSearchable(card), expr, data.collectionCreationTime),
+    .filter(
+      ({ card }) =>
+        !expr || matchExpr(ankiCardToSearchable(card), expr, data.collectionCreationTime),
     );
 
   // Sort
@@ -2072,15 +2112,17 @@ async function bulkPersistTags(guids: string[]): Promise<void> {
 
     const guidSet = new Set(guids);
     const cardsByGuid = new Map(
-      data.cards
-        .filter((card) => guidSet.has(card.guid))
-        .map((card) => [card.guid, card] as const),
+      data.cards.filter((card) => guidSet.has(card.guid)).map((card) => [card.guid, card] as const),
     );
 
     guids.forEach((guid) => {
       const card = cardsByGuid.get(guid);
       if (!card) return;
-      db.run("UPDATE notes SET tags=?, mod=?, usn=-1 WHERE guid=?", [formatTagsStr(card.tags), mod, guid]);
+      db.run("UPDATE notes SET tags=?, mod=?, usn=-1 WHERE guid=?", [
+        formatTagsStr(card.tags),
+        mod,
+        guid,
+      ]);
     });
 
     await persistSqliteBytes(db, input);

--- a/src/undoRedoExecutor.ts
+++ b/src/undoRedoExecutor.ts
@@ -1,22 +1,9 @@
 import { triggerRef } from "vue";
-import {
-  popUndo,
-  popRedo,
-  pushUndo,
-  pushRedo,
-  canUndo,
-  canRedo,
-  type UndoEntry,
-} from "./undoRedo";
+import { popUndo, popRedo, pushUndo, pushRedo, canUndo, canRedo, type UndoEntry } from "./undoRedo";
 import { reviewDB } from "./scheduler/db";
 import type { CardReviewState, StoredReviewLog } from "./scheduler/types";
 import { removeTags } from "./utils/tagTree";
-import {
-  ankiDataSig,
-  currentReviewCardSig,
-  initializeReviewQueue,
-  updateNote,
-} from "./stores";
+import { ankiDataSig, currentReviewCardSig, initializeReviewQueue, updateNote } from "./stores";
 import { markDataChanged } from "./lib/autoSync";
 import { QUEUE_USER_BURIED, QUEUE_SUSPENDED } from "./lib/syncWrite";
 

--- a/src/utils/__tests__/csvParser.prop.test.ts
+++ b/src/utils/__tests__/csvParser.prop.test.ts
@@ -11,10 +11,10 @@ describe("CSV Parser — property-based tests", () => {
     it("parse(serialize(data)) === data for safe cells", () => {
       fc.assert(
         fc.property(
-          fc.array(
-            fc.array(arbSafeCell, { minLength: 1, maxLength: 5 }),
-            { minLength: 1, maxLength: 10 },
-          ),
+          fc.array(fc.array(arbSafeCell, { minLength: 1, maxLength: 5 }), {
+            minLength: 1,
+            maxLength: 10,
+          }),
           fc.constantFrom(",", "\t", ";", "|"),
           (rows, delimiter) => {
             // Serialize: join fields with delimiter, rows with newlines
@@ -22,7 +22,10 @@ describe("CSV Parser — property-based tests", () => {
             const parsed = parseCsv(csv, delimiter);
 
             // Filter out empty rows (parseCsv trims empty lines)
-            const nonEmptyRows = rows.filter((row) => row.some((cell) => cell.trim().length > 0) || row.join(delimiter).trim().length > 0);
+            const nonEmptyRows = rows.filter(
+              (row) =>
+                row.some((cell) => cell.trim().length > 0) || row.join(delimiter).trim().length > 0,
+            );
 
             expect(parsed.length).toBe(nonEmptyRows.length);
             for (let i = 0; i < parsed.length; i++) {
@@ -171,10 +174,10 @@ describe("CSV Parser — property-based tests", () => {
     it("CRLF and LF produce the same result", () => {
       fc.assert(
         fc.property(
-          fc.array(
-            fc.array(arbSafeCell, { minLength: 1, maxLength: 3 }),
-            { minLength: 2, maxLength: 5 },
-          ),
+          fc.array(fc.array(arbSafeCell, { minLength: 1, maxLength: 3 }), {
+            minLength: 2,
+            maxLength: 5,
+          }),
           (rows) => {
             const lf = rows.map((r) => r.join(",")).join("\n");
             const crlf = rows.map((r) => r.join(",")).join("\r\n");

--- a/src/utils/__tests__/duplicates.prop.test.ts
+++ b/src/utils/__tests__/duplicates.prop.test.ts
@@ -39,16 +39,13 @@ describe("Duplicate detection — property-based tests", () => {
 
     it("returns 0 when one string has length < 2 and strings differ", () => {
       fc.assert(
-        fc.property(
-          fc.string({ minLength: 2, maxLength: 50 }),
-          (b) => {
-            // Single char 'x' vs longer string — should be 0 unless b === "x"
-            const a = "x";
-            if (a !== b) {
-              expect(stringSimilarity(a, b)).toBe(0);
-            }
-          },
-        ),
+        fc.property(fc.string({ minLength: 2, maxLength: 50 }), (b) => {
+          // Single char 'x' vs longer string — should be 0 unless b === "x"
+          const a = "x";
+          if (a !== b) {
+            expect(stringSimilarity(a, b)).toBe(0);
+          }
+        }),
         { numRuns: NUM_RUNS ?? 100 },
       );
     });

--- a/src/utils/__tests__/duplicates.test.ts
+++ b/src/utils/__tests__/duplicates.test.ts
@@ -49,9 +49,9 @@ describe("normalizeForComparison", () => {
   });
 
   it("handles complex HTML", () => {
-    expect(
-      normalizeForComparison('<div class="front"><p>What is a <b>cat</b>?</p></div>'),
-    ).toBe("what is a cat?");
+    expect(normalizeForComparison('<div class="front"><p>What is a <b>cat</b>?</p></div>')).toBe(
+      "what is a cat?",
+    );
   });
 
   it("handles nbsp entities", () => {

--- a/src/utils/__tests__/templateParser.prop.test.ts
+++ b/src/utils/__tests__/templateParser.prop.test.ts
@@ -229,19 +229,16 @@ describe("Template Parser — property-based tests", () => {
 
     it("multiple clozes produce the correct count", () => {
       fc.assert(
-        fc.property(
-          fc.integer({ min: 1, max: 5 }),
-          (count) => {
-            const parts: string[] = [];
-            for (let i = 1; i <= count; i++) {
-              parts.push(`{{c${i}::answer${i}}}`);
-            }
-            const text = parts.join(" ");
-            const nodes = parseClozeNodes(text);
-            const clozeNodes = nodes.filter(isClozeNode);
-            expect(clozeNodes.length).toBe(count);
-          },
-        ),
+        fc.property(fc.integer({ min: 1, max: 5 }), (count) => {
+          const parts: string[] = [];
+          for (let i = 1; i <= count; i++) {
+            parts.push(`{{c${i}::answer${i}}}`);
+          }
+          const text = parts.join(" ");
+          const nodes = parseClozeNodes(text);
+          const clozeNodes = nodes.filter(isClozeNode);
+          expect(clozeNodes.length).toBe(count);
+        }),
         { numRuns: NUM_RUNS ?? 50 },
       );
     });

--- a/src/utils/deckInfo.ts
+++ b/src/utils/deckInfo.ts
@@ -23,7 +23,9 @@ export function computeDeckInfo(ankiData: AnkiData) {
       const displayName = deck.name.includes("::") ? deck.name.split("::").pop()! : deck.name;
 
       // Compute new/learn/due counts from Anki scheduling data
-      const activeCards = cardsInDeck.filter((item) => !item.card.scheduling || item.card.scheduling.queue >= 0);
+      const activeCards = cardsInDeck.filter(
+        (item) => !item.card.scheduling || item.card.scheduling.queue >= 0,
+      );
       const grouped = groupBy(activeCards, (item) => {
         const q = item.card.scheduling?.queue;
         if (q === undefined || q === 0) return "new";

--- a/src/utils/duplicates.ts
+++ b/src/utils/duplicates.ts
@@ -14,7 +14,9 @@ export type NoteInfo = {
   fieldNames: string[];
 };
 
+import { decodeHtmlEntities } from "./format";
 import { groupBy } from "./groupBy";
+import { stripHtml } from "./stripHtml";
 
 export type DuplicateGroup = {
   /** The normalized key used to group these notes */
@@ -45,24 +47,7 @@ export type DuplicateSearchOptions = {
  */
 export function normalizeForComparison(html: string | null): string {
   if (!html) return "";
-  return (
-    html
-      // Remove sound tags
-      .replace(/\[sound:[^\]]+\]/g, "")
-      // Remove HTML tags
-      .replace(/<[^>]*>/g, "")
-      // Decode common HTML entities
-      .replace(/&nbsp;/gi, " ")
-      .replace(/&amp;/gi, "&")
-      .replace(/&lt;/gi, "<")
-      .replace(/&gt;/gi, ">")
-      .replace(/&quot;/gi, '"')
-      .replace(/&#39;/gi, "'")
-      // Collapse whitespace
-      .replace(/\s+/g, " ")
-      .trim()
-      .toLowerCase()
-  );
+  return decodeHtmlEntities(stripHtml(html)).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
 /**
@@ -130,6 +115,10 @@ export function buildNoteInfos(
     }));
 }
 
+function cleanDisplayKey(html: string | null): string {
+  return stripHtml(html);
+}
+
 /**
  * Find duplicate notes based on exact matching of the specified field.
  */
@@ -154,14 +143,10 @@ export function findExactDuplicates(
     .filter(([, entries]) => entries !== undefined && entries.length >= 2)
     .map(([key, entries]) => {
       const noteGroup = entries!.map((e) => e.note);
-      const displayKey = getFieldValue(noteGroup[0]!, fieldIndex) ?? key;
-      const cleanDisplayKey = displayKey
-        .replace(/<[^>]*>/g, "")
-        .replace(/\[sound:[^\]]+\]/g, "")
-        .trim();
+      const rawDisplayKey = getFieldValue(noteGroup[0]!, fieldIndex) ?? key;
       return {
         key,
-        displayKey: cleanDisplayKey || key,
+        displayKey: cleanDisplayKey(rawDisplayKey) || key,
         notes: noteGroup,
         similarity: 1.0,
       };
@@ -245,11 +230,7 @@ export function findFuzzyDuplicates(
           }
           const avgSim = count > 0 ? totalSim / count : 1.0;
           const clusterNotes = indices.map((i) => scopeNotes[i]!.note);
-          const displayKey =
-            getFieldValue(clusterNotes[0]!, fieldIndex)
-              ?.replace(/<[^>]*>/g, "")
-              .replace(/\[sound:[^\]]+\]/g, "")
-              .trim() ?? "";
+          const displayKey = cleanDisplayKey(getFieldValue(clusterNotes[0]!, fieldIndex));
           return {
             key: `fuzzy-${clusterNotes.map((n) => n.guid).join("-")}`,
             displayKey: displayKey || "(empty)",

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -19,3 +19,14 @@ export function escapeHtml(text: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
 }
+
+/** Decode common HTML entities back to their literal characters. */
+export function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+}

--- a/src/utils/imageOcclusion.ts
+++ b/src/utils/imageOcclusion.ts
@@ -63,14 +63,11 @@ export function getImageFilename(imageFieldHtml: string): string | null {
 
 // --- Shape parsing (for rendering) ---
 
-export function parseOcclusionShapes(
-  svgString: string,
-): { ordinal: number; svgElement: string }[] {
+export function parseOcclusionShapes(svgString: string): { ordinal: number; svgElement: string }[] {
   if (!svgString.trim()) return [];
 
   const shapes: { ordinal: number; svgElement: string }[] = [];
-  const shapeRegex =
-    /<(rect|ellipse|circle|polygon|path)\b([^>]*?)\/?>(?:<\/\1>)?/gi;
+  const shapeRegex = /<(rect|ellipse|circle|polygon|path)\b([^>]*?)\/?>(?:<\/\1>)?/gi;
 
   let match;
   while ((match = shapeRegex.exec(svgString)) !== null) {
@@ -100,8 +97,7 @@ export function parseOcclusionShapesForEditor(svgString: string): OcclusionShape
   if (!svgString.trim()) return [];
 
   const shapes: OcclusionShape[] = [];
-  const shapeRegex =
-    /<(rect|ellipse|circle|polygon|path)\b([^>]*?)\/?>(?:<\/\1>)?/gi;
+  const shapeRegex = /<(rect|ellipse|circle|polygon|path)\b([^>]*?)\/?>(?:<\/\1>)?/gi;
 
   let match;
   while ((match = shapeRegex.exec(svgString)) !== null) {

--- a/src/utils/integrityCheck.ts
+++ b/src/utils/integrityCheck.ts
@@ -25,7 +25,16 @@ export type IntegrityIssue = {
 };
 
 type NoteRow = { id: number; mid: number; flds: string; guid: string };
-type CardRow = { id: number; nid: number; did: number; type: number; queue: number; due: number; ivl: number; odid: number };
+type CardRow = {
+  id: number;
+  nid: number;
+  did: number;
+  type: number;
+  queue: number;
+  due: number;
+  ivl: number;
+  odid: number;
+};
 
 function tableExists(db: Database, name: string): boolean {
   const rows = executeQueryAll<{ name: string }>(
@@ -42,7 +51,10 @@ function isAnki21b(db: Database): boolean {
   return tableExists(db, "notetypes");
 }
 
-function countByKey<T, K extends string | number>(items: T[], keyFn: (item: T) => K): Map<K, number> {
+function countByKey<T, K extends string | number>(
+  items: T[],
+  keyFn: (item: T) => K,
+): Map<K, number> {
   const map = new Map<K, number>();
   items.forEach((item) => {
     const key = keyFn(item);
@@ -53,7 +65,9 @@ function countByKey<T, K extends string | number>(items: T[], keyFn: (item: T) =
 
 function sumValues(map: Map<unknown, number>): number {
   let total = 0;
-  map.forEach((v) => { total += v; });
+  map.forEach((v) => {
+    total += v;
+  });
   return total;
 }
 
@@ -192,7 +206,10 @@ function checkMissingDecks(cards: CardRow[], deckIds: Set<number>): IntegrityIss
   };
 }
 
-function checkFieldCountMismatches(notes: NoteRow[], notetypeFieldCounts: Map<number, number>): IntegrityIssue | null {
+function checkFieldCountMismatches(
+  notes: NoteRow[],
+  notetypeFieldCounts: Map<number, number>,
+): IntegrityIssue | null {
   const fieldMismatches = notes
     .filter((note) => notetypeFieldCounts.has(note.mid))
     .map((note) => ({
@@ -208,20 +225,28 @@ function checkFieldCountMismatches(notes: NoteRow[], notetypeFieldCounts: Map<nu
     title: "Field Count Mismatches",
     description: "Notes whose field count doesn't match their note type definition.",
     count: fieldMismatches.length,
-    details: fieldMismatches.slice(0, 20).map(
-      (m) => `Note ${m.noteId}: expected ${m.expected} fields, has ${m.actual}`,
-    ),
+    details: fieldMismatches
+      .slice(0, 20)
+      .map((m) => `Note ${m.noteId}: expected ${m.expected} fields, has ${m.actual}`),
     fixable: false,
   };
 }
 
 function hasInvalidScheduling(card: CardRow): boolean {
-  return (card.ivl < 0 && card.type === 2) || card.type < 0 || card.type > 3 || card.queue < -3 || card.queue > 4;
+  return (
+    (card.ivl < 0 && card.type === 2) ||
+    card.type < 0 ||
+    card.type > 3 ||
+    card.queue < -3 ||
+    card.queue > 4
+  );
 }
 
 function describeSchedulingIssue(card: CardRow): string[] {
   return [
-    ...(card.ivl < 0 && card.type === 2 ? [`Card ${card.id}: negative interval on review card`] : []),
+    ...(card.ivl < 0 && card.type === 2
+      ? [`Card ${card.id}: negative interval on review card`]
+      : []),
     ...(card.type < 0 || card.type > 3 ? [`Card ${card.id}: invalid type ${card.type}`] : []),
     ...(card.queue < -3 || card.queue > 4 ? [`Card ${card.id}: invalid queue ${card.queue}`] : []),
   ];
@@ -235,7 +260,8 @@ function checkInvalidScheduling(cards: CardRow[]): IntegrityIssue | null {
     type: "invalid-scheduling",
     severity: "warning",
     title: "Invalid Scheduling Data",
-    description: "Cards with impossible scheduling values (negative intervals, invalid types/queues).",
+    description:
+      "Cards with impossible scheduling values (negative intervals, invalid types/queues).",
     count: details.length,
     details: details.slice(0, 20),
     fixable: true,
@@ -291,20 +317,29 @@ export function checkDatabaseIntegrity(db: Database): IntegrityIssue[] {
     checkFieldCountMismatches(notes, notetypeFieldCounts),
     checkInvalidScheduling(cards),
     checkDuplicateIds(
-      notes, (n) => n.id,
-      "duplicate-note-ids", "error", "Duplicate Note IDs",
+      notes,
+      (n) => n.id,
+      "duplicate-note-ids",
+      "error",
+      "Duplicate Note IDs",
       "Multiple notes share the same ID, which can cause data corruption.",
       (id, cnt) => `Note ID ${id}: ${cnt} occurrences`,
     ),
     checkDuplicateIds(
-      cards, (c) => c.id,
-      "duplicate-card-ids", "error", "Duplicate Card IDs",
+      cards,
+      (c) => c.id,
+      "duplicate-card-ids",
+      "error",
+      "Duplicate Card IDs",
       "Multiple cards share the same ID, which can cause data corruption.",
       (id, cnt) => `Card ID ${id}: ${cnt} occurrences`,
     ),
     checkDuplicateIds(
-      notes, (n) => n.guid,
-      "duplicate-guids", "warning", "Duplicate Note GUIDs",
+      notes,
+      (n) => n.guid,
+      "duplicate-guids",
+      "warning",
+      "Duplicate Note GUIDs",
       "Multiple notes share the same GUID. This can cause sync conflicts.",
       (guid, cnt) => `GUID "${guid}": ${cnt} occurrences`,
       20,

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -1,4 +1,5 @@
 import katex from "katex";
+import { decodeHtmlEntities } from "./format";
 import { isClozeNode, parseClozeNodes, renderTemplateString } from "./templateParser";
 import { stripHtmlForComparison } from "./typeansDiff";
 
@@ -165,7 +166,9 @@ function stripAvTags(html: string): string {
  * Strip type: input fields from FrontSide HTML when injecting into answer side.
  */
 function stripTypeInputs(html: string): string {
-  return html.replace(/<input[^>]*id="typeans"[^>]*>/g, "").replace(/<input[^>]*class="typeans-input"[^>]*>/g, "");
+  return html
+    .replace(/<input[^>]*id="typeans"[^>]*>/g, "")
+    .replace(/<input[^>]*class="typeans-input"[^>]*>/g, "");
 }
 
 /**
@@ -504,22 +507,8 @@ function replaceLatex(renderedString: string, macros: Record<string, string> = {
     ...(hasMacros ? { macros } : {}),
   });
 
-  const cleanAndUnescapeLatex = (latex: string) => {
-    // Strip HTML tags that Anki may have inserted
-    let cleanLatex = latex.replace(/<[^>]+>/g, "");
-
-    // Unescape HTML entities
-    cleanLatex = cleanLatex
-      .replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<")
-      .replace(/&gt;/g, ">")
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&nbsp;/g, " ");
-
-    // Trim whitespace
-    return cleanLatex.trim();
-  };
+  const cleanAndUnescapeLatex = (latex: string) =>
+    decodeHtmlEntities(latex.replace(/<[^>]+>/g, "")).trim();
 
   const replaceMathBlock = (displayMode: boolean) => (_match: string, latex: string) => {
     try {
@@ -690,5 +679,9 @@ export function hasTypeAnswerField(html: string): boolean {
 export function extractExpectedAnswer(backHtml: string): string | null {
   const match = backHtml.match(/id="typeans"\s+data-expected="([^"]*)"/);
   if (!match) return null;
-  return match[1]!.replace(/&quot;/g, '"').replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+  return match[1]!
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
 }

--- a/src/utils/tagTree.ts
+++ b/src/utils/tagTree.ts
@@ -55,4 +55,3 @@ export function tagMatchesOrIsChild(t: string, tag: string): boolean {
 export function removeTags(tags: string[], tag: string): string[] {
   return tags.filter((t) => !tagMatchesOrIsChild(t, tag));
 }
-

--- a/src/utils/typeansDiff.ts
+++ b/src/utils/typeansDiff.ts
@@ -6,7 +6,7 @@
  * - Grey (#888) with strikethrough for missing characters
  */
 
-import { escapeHtml } from "./format";
+import { decodeHtmlEntities, escapeHtml } from "./format";
 
 type DiffEntry =
   | { type: "correct"; value: string }
@@ -203,15 +203,7 @@ export function renderDiffHtml(typed: string, expected: string): string {
  * Used to get the plain-text expected answer from a field value.
  */
 export function stripHtmlForComparison(html: string): string {
-  // Remove HTML tags
-  let text = html.replace(/<br\s*\/?>/gi, "\n").replace(/<[^>]*>/g, "");
-  // Decode common HTML entities
-  text = text
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, " ");
-  return text.trim();
+  // Remove HTML tags (convert <br> to newline first)
+  const text = html.replace(/<br\s*\/?>/gi, "\n").replace(/<[^>]*>/g, "");
+  return decodeHtmlEntities(text).trim();
 }

--- a/src/utils/zipUtils.ts
+++ b/src/utils/zipUtils.ts
@@ -3,6 +3,8 @@ import type { Entry } from "@zip-js/zip-js";
 /**
  * Type guard to check if a zip Entry has getData (i.e. is a file, not a directory).
  */
-export function isFileEntry(entry: Entry): entry is Entry & { getData: NonNullable<Entry["getData"]> } {
+export function isFileEntry(
+  entry: Entry,
+): entry is Entry & { getData: NonNullable<Entry["getData"]> } {
   return !entry.directory && typeof entry.getData === "function";
 }


### PR DESCRIPTION
## Summary

- Extract shared `decodeHtmlEntities()` into `format.ts`, replacing 3 copy-pasted entity decode blocks across `render.ts`, `typeansDiff.ts`, `duplicates.ts`
- Fix N+1 query in `mergeIndexedDBToSqlite()` — pre-fetch all card odue/odid/did in one query instead of per-card SELECT
- Replace inline `isAnki21bFormat` detection in `normalSync.ts` and `syncWrite.ts` with existing exported function
- Extract shared test utilities (`scalar`, `getSqlJs`, `createAnki2Collection`, `createAnki21bDb`) into `testDbUtils.ts`, eliminating ~400 lines of duplication across 4 test files
- Standardize all 22 verbose design-system component imports to use barrel re-exports