### PR TITLE
widen page layout and fix Create Deck title consistency

### DIFF
--- a/src/components/DeckCreator.vue
+++ b/src/components/DeckCreator.vue
@@ -34,29 +34,24 @@ function exportDeck() {
 </script>
 
 <template>
-  <Page>
-    <template #title>
-      <div>
-        <h2>Create Deck</h2>
-        <div class="mode-toggle">
-          <button
-            :class="['mode-btn', { 'mode-btn--active': mode === 'manual' }]"
-            @click="mode = 'manual'"
-          >
-            Manual
-          </button>
-          <button
-            :class="['mode-btn', { 'mode-btn--active': mode === 'csv' }]"
-            @click="mode = 'csv'"
-          >
-            CSV Import
-          </button>
-          <button :class="['mode-btn', { 'mode-btn--active': mode === 'ai' }]" @click="mode = 'ai'">
-            AI Generate
-          </button>
-        </div>
-      </div>
-    </template>
+  <Page title="Create Deck">
+    <div class="mode-toggle">
+      <button
+        :class="['mode-btn', { 'mode-btn--active': mode === 'manual' }]"
+        @click="mode = 'manual'"
+      >
+        Manual
+      </button>
+      <button
+        :class="['mode-btn', { 'mode-btn--active': mode === 'csv' }]"
+        @click="mode = 'csv'"
+      >
+        CSV Import
+      </button>
+      <button :class="['mode-btn', { 'mode-btn--active': mode === 'ai' }]" @click="mode = 'ai'">
+        AI Generate
+      </button>
+    </div>
 
     <template v-if="mode === 'manual'">
       <p class="description">

--- a/src/components/stats/StatsOverview.vue
+++ b/src/components/stats/StatsOverview.vue
@@ -64,7 +64,7 @@ function formatTime(ms: number): string {
 <style scoped>
 .overview-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: var(--spacing-3);
 }
 

--- a/src/design-system/tokens/spacing.css
+++ b/src/design-system/tokens/spacing.css
@@ -23,5 +23,5 @@
   --spacing-24: 6rem; /* 96px */
 
   /* Layout */
-  --page-max-width: 640px;
+  --page-max-width: 960px;
 }


### PR DESCRIPTION
## Summary
- Increase `--page-max-width` from 640px to 960px for all pages
- Update stats overview grid to fixed 3-column layout
- Fix Create Deck title to use Page component's `title` prop for consistent styling